### PR TITLE
Fixing #539

### DIFF
--- a/booking-app/components/src/client/routes/booking/bookingProvider.tsx
+++ b/booking-app/components/src/client/routes/booking/bookingProvider.tsx
@@ -34,6 +34,7 @@ export interface BookingContextType {
   setSelectedRooms: (x: RoomSetting[]) => void;
   setSubmitting: (x: SubmitStatus) => void;
   submitting: SubmitStatus;
+  fetchingStatus: "loading" | "loaded" | "error" | null;
 }
 
 export const BookingContext = createContext<BookingContextType>({
@@ -56,6 +57,7 @@ export const BookingContext = createContext<BookingContextType>({
   setSelectedRooms: (x: RoomSetting[]) => {},
   setSubmitting: (x: SubmitStatus) => {},
   submitting: "none",
+  fetchingStatus: null,
 });
 
 export function BookingProvider({ children }) {
@@ -71,7 +73,7 @@ export function BookingProvider({ children }) {
   const [role, setRole] = useState<Role>();
   const [selectedRooms, setSelectedRooms] = useState<RoomSetting[]>([]);
   const [submitting, setSubmitting] = useState<SubmitStatus>("error");
-  const { existingCalendarEvents, reloadExistingCalendarEvents } =
+  const { existingCalendarEvents, reloadExistingCalendarEvents, fetchingStatus } =
     fetchCalendarEvents(roomSettings);
 
   const isBanned = useMemo<boolean>(() => {
@@ -127,6 +129,7 @@ export function BookingProvider({ children }) {
         setSelectedRooms,
         setSubmitting,
         submitting,
+        fetchingStatus,
       }}
     >
       {children}

--- a/booking-app/components/src/client/routes/booking/components/CalendarVerticalResource.tsx
+++ b/booking-app/components/src/client/routes/booking/components/CalendarVerticalResource.tsx
@@ -90,6 +90,7 @@ export default function CalendarVerticalResource({
     bookingCalendarInfo,
     existingCalendarEvents,
     setBookingCalendarInfo,
+    fetchingStatus,
   } = useContext(BookingContext);
   const ref = useRef(null);
 
@@ -177,6 +178,10 @@ export default function CalendarVerticalResource({
     return el.overlap;
   };
 
+  useEffect(() => {
+    console.log(fetchingStatus);
+  },[fetchingStatus]);
+
   // clicking on created event should delete it
   // only if not in MODIFICATION mode
   const handleEventClick = (info: EventClickArg) => {
@@ -217,7 +222,7 @@ export default function CalendarVerticalResource({
     );
   }, [existingCalendarEvents, formContext]);
 
-  if (existingCalendarEvents.length === 0) {
+  if (fetchingStatus === "error" && existingCalendarEvents.length === 0) {
     return (
       <Empty>
         <Error />
@@ -238,6 +243,14 @@ export default function CalendarVerticalResource({
           Select spaces to view their availability, then click and drag to
           choose a time slot
         </Typography>
+      </Empty>
+    );
+  }
+  
+  if(fetchingStatus === "loading"){
+    return (
+      <Empty>
+        <Typography>Loading...</Typography>
       </Empty>
     );
   }


### PR DESCRIPTION
Track fetching calendar events status to render a message in case there was an error and render the calendar for booking in case there were no errors and there are just no future events. (Fixing #539)

