### PR TITLE
for PA and Admin, default to today instead of all future.

### DIFF
--- a/booking-app/components/src/client/routes/components/bookingTable/Bookings.tsx
+++ b/booking-app/components/src/client/routes/components/bookingTable/Bookings.tsx
@@ -46,6 +46,9 @@ export const Bookings: React.FC<BookingsProps> = ({
   const isUserView = pageContext === PageContextLevel.USER;
 
   useEffect(() => {
+    if(pageContext > PageContextLevel.LIAISON) {
+      setSelectedDateRange("Today");
+    }
     return ()=>{
       setLastItem(null);
     }


### PR DESCRIPTION
For PA and Admin dashboard, the date range defaults to Today instead of All Future. (Fixes #572)