### PR TITLE
Fix missing data for long bookings

### DIFF
--- a/booking-app/components/src/client/routes/components/bookingTable/Bookings.tsx
+++ b/booking-app/components/src/client/routes/components/bookingTable/Bookings.tsx
@@ -390,14 +390,26 @@ export const Bookings: React.FC<BookingsProps> = ({
     // You could also trigger a refetch of bookings here if needed
   };
 
+  const pageSize = 100;
+  const showFooter = useMemo(() => {
+    return filteredRows.length > pageSize;
+  }, [filteredRows.length, pageSize]);
+
   return (
     <Box sx={{ marginTop: 4 }}>
       <DataGrid
         rows={filteredRows}
         columns={columns}
         getRowId={(row) => row.calendarEventId}
-        hideFooterPagination={true}
-        hideFooter={true}
+        hideFooter={!showFooter}
+        initialState={{
+          pagination: {
+            paginationModel: {
+              pageSize: pageSize,
+            },
+          },
+        }}
+        pageSizeOptions={[pageSize]}
         checkboxSelection={false}
         disableRowSelectionOnClick
         slots={{


### PR DESCRIPTION
> https://github.com/ITPNYU/booking-app/issues/793

The missing issue is likely because the free version of DataGrid only allows displaying fewer than 100 rows without pagination.

<img width="1190" alt="image" src="https://github.com/user-attachments/assets/7bc25382-843f-47b1-8ad7-a9c6e0b74a00" />

If we still want to use the free version, one solution is to show pagination when the number of rows exceeds 100.

Take the following example as a reference. The page size is 2 for demonstration:

<img width="1493" alt="image" src="https://github.com/user-attachments/assets/4537e60d-28a3-4c7d-badf-42f1cbd3aff8" />

