### PR TITLE
edit `origin` field display order

### DIFF
--- a/booking-app/components/src/client/routes/components/bookingTable/MoreInfoModal.tsx
+++ b/booking-app/components/src/client/routes/components/bookingTable/MoreInfoModal.tsx
@@ -511,10 +511,6 @@ export default function MoreInfoModal({
                   <TableCell>{booking.bookingType ?? BLANK}</TableCell>
                 </TableRow>
                 <TableRow>
-                  <LabelCell>Origin</LabelCell>
-                  <TableCell>{formatOrigin(booking.origin)}</TableCell>
-                </TableRow>
-                <TableRow>
                   <LabelCell>Expected Attendance</LabelCell>
                   <TableCell>{booking.expectedAttendance ?? BLANK}</TableCell>
                 </TableRow>

--- a/booking-app/components/src/server/calendars.ts
+++ b/booking-app/components/src/server/calendars.ts
@@ -88,6 +88,10 @@ export const bookingContentsToDescription = (
     `${getProperty(bookingContents, "startTime")} - ${getProperty(bookingContents, "endTime")}`
   );
   description += listItem("Status", getProperty(bookingContents, "status"));
+  description += listItem(
+    "Origin",
+    formatOrigin(getProperty(bookingContents, "origin"))
+  );
   description += "</ul>";
 
   // Requester Section
@@ -131,10 +135,6 @@ export const bookingContentsToDescription = (
   description += listItem(
     "Booking Type",
     getProperty(bookingContents, "bookingType")
-  );
-  description += listItem(
-    "Origin",
-    formatOrigin(getProperty(bookingContents, "origin"))
   );
   description += listItem(
     "Expected Attendance",


### PR DESCRIPTION
deleted duplicate `Origin` field appearance in the details modal and changed the `Origin` field location in the Google Calendar event description (I'd indicated the wrong section in #629).