### PR TITLE
Potential fix for code scanning alert no. 11: Use of externally-controlled format string

### DIFF
--- a/booking-app/components/src/server/calendars.ts
+++ b/booking-app/components/src/server/calendars.ts
@@ -361,7 +361,9 @@ export const updateCalendarEvent = async (
       );
     } catch (error) {
       console.error(
-        `Error updating event ${calendarEventId} in calendar ${roomCalendarId}:`,
+        "Error updating event %s in calendar %s:",
+        calendarEventId,
+        roomCalendarId,
         error
       );
     }


### PR DESCRIPTION
Potential fix for [https://github.com/ITPNYU/booking-app/security/code-scanning/11](https://github.com/ITPNYU/booking-app/security/code-scanning/11)

To fix the problem, we should ensure that user-controlled values are passed as arguments to the `console.error` call, rather than being directly interpolated into a format string through template literals. Specifically, we should avoid constructing a string using `${calendarEventId}` and then passing it as the first argument followed by `error` to `console.error`, as this allows the value to influence formatting. Instead, change the logging call to use a fixed format string containing placeholders (such as `%s`) and pass user-controlled values as additional arguments. This guarantees that formatting specifiers cannot be injected via tainted values, and output will always be correct.

Only lines relevant to the vulnerable sink (line 364 in booking-app/components/src/server/calendars.ts) need to be changed. No new imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
