### PR TITLE
fix BUG: On Dev a Walk-In request does not display Staffing options for the Garage.

### DIFF
--- a/booking-app/components/src/client/routes/booking/components/BookingFormMediaServices.tsx
+++ b/booking-app/components/src/client/routes/booking/components/BookingFormMediaServices.tsx
@@ -30,17 +30,15 @@ export default function BookingFormMediaServices(props: Props) {
     trigger,
     showMediaServices,
     setShowMediaServices,
-    formContext,
+    formContext: _formContext,
   } = props;
   const { selectedRooms } = useContext(BookingContext);
   const schema = useTenantSchema();
   const { showEquipment, showStaffing } = schema;
   const roomIds = selectedRooms.map((room) => room.roomId);
 
-  const limitedContexts = [
-    FormContextLevel.WALK_IN,
-    FormContextLevel.MODIFICATION,
-  ];
+  // Previously, walk-in/modification contexts were limited to equipment-only.
+  // This restriction has been removed, so technician options should be available in all contexts.
 
   const checkboxes = useMemo(() => {
     const options: MediaServices[] = [];
@@ -84,8 +82,6 @@ export default function BookingFormMediaServices(props: Props) {
                 if (!e.target.checked) {
                   // de-select boxes if switch says "no media services"
                   field.onChange("");
-                } else if (limitedContexts.includes(formContext)) {
-                  field.onChange(MediaServices.CHECKOUT_EQUIPMENT);
                 }
 
                 trigger(id);
@@ -103,16 +99,6 @@ export default function BookingFormMediaServices(props: Props) {
 
   if (!mediaServicesEnabled) {
     return null;
-  }
-
-  if (limitedContexts.includes(formContext)) {
-    return (
-      <div style={{ marginBottom: 8 }}>
-        <Label htmlFor={id}>Media Services</Label>
-        <p style={{ fontSize: "0.75rem" }}>Check out equipment</p>
-        {toggle}
-      </div>
-    );
   }
 
   return (

--- a/booking-app/components/src/client/routes/booking/components/BookingFormStaffingServices.tsx
+++ b/booking-app/components/src/client/routes/booking/components/BookingFormStaffingServices.tsx
@@ -36,7 +36,7 @@ export default function BookingFormStaffingServices(props: Props) {
     trigger,
     showStaffingServices,
     setShowStaffingServices,
-    formContext,
+    formContext: _formContext,
   } = props;
   const { selectedRooms } = useContext(BookingContext);
   const roomIds = selectedRooms.map((room) => room.roomId);
@@ -44,10 +44,7 @@ export default function BookingFormStaffingServices(props: Props) {
     (room) => room.staffingServices && room.staffingServices.length > 0
   );
 
-  const limitedContexts = [
-    FormContextLevel.WALK_IN,
-    FormContextLevel.MODIFICATION,
-  ];
+  // Previously limited for walk-in/modification; restriction removed so full options show in all contexts
 
   const { staffingSections, staffingServices } = useMemo(() => {
     let sections: { name: string; indexes: number[] }[] = [];
@@ -103,16 +100,6 @@ export default function BookingFormStaffingServices(props: Props) {
   // If staffing is disabled at the schema level, hide the entire control
   if (!showStaffing) {
     return null;
-  }
-
-  if (limitedContexts.includes(formContext)) {
-    return (
-      <div style={{ marginBottom: 8 }}>
-        <Label htmlFor={id}>Staffing Services?</Label>
-        <p style={{ fontSize: "0.75rem" }}>Request technicians and support</p>
-        {toggle}
-      </div>
-    );
   }
 
   return (


### PR DESCRIPTION
Remove restrictions on media and staffing services display for all contexts, allowing full options in BookingFormMediaServices and BookingFormStaffingServices components.

[BUG: On Dev a Walk-In request does not display Staffing options for the Garage.](https://github.com/ITPNYU/booking-app/issues/956)