### PR TITLE
feat(booking): make room hour limits optional

### DIFF
--- a/booking-app/components/src/client/routes/booking/utils/bookingHourLimits.ts
+++ b/booking-app/components/src/client/routes/booking/utils/bookingHourLimits.ts
@@ -1,8 +1,9 @@
 import { Role } from "@/components/src/types";
 import { Resource } from "../../components/SchemaProvider";
 
-const DEFAULT_MAX_HOURS = 4;
-const DEFAULT_MIN_HOURS = 0.5;
+// No default limits - allow any duration
+const DEFAULT_MAX_HOURS = Number.POSITIVE_INFINITY;
+const DEFAULT_MIN_HOURS = 0;
 
 /**
  * Maps Role enum to the appropriate field name for maxHour/minHour
@@ -68,6 +69,11 @@ export function getBookingHourLimits(
   let minHours = DEFAULT_MIN_HOURS;
 
   for (const room of selectedRooms) {
+    // Skip limits if maxHour/minHour is not provided for the room
+    if (!room.maxHour && !room.minHour) {
+      continue;
+    }
+
     // Get maxHour with fallback logic
     const roomMaxHour = isWalkIn
       ? (room.maxHour?.[walkInRoleField] ?? // Try walk-in specific limit

--- a/booking-app/tests/unit/bookingHourLimits.unit.test.ts
+++ b/booking-app/tests/unit/bookingHourLimits.unit.test.ts
@@ -3,17 +3,17 @@ import { Role } from "@/components/src/types";
 import { getBookingHourLimits } from "@/components/src/client/routes/booking/utils/bookingHourLimits";
 
 describe("getBookingHourLimits", () => {
-  it("returns default limits when no rooms provided", () => {
+  it("returns unlimited duration when no rooms provided", () => {
     const { maxHours, minHours } = getBookingHourLimits([], Role.STUDENT, false);
-    expect(maxHours).toBe(4);
-    expect(minHours).toBe(0.5);
+    expect(maxHours).toBe(Number.POSITIVE_INFINITY);
+    expect(minHours).toBe(0);
   });
 
-  it("returns default limits when room has no hour settings", () => {
+  it("returns unlimited duration when room has no hour settings", () => {
     const rooms = [{ roomId: 1, name: "Test Room" }];
     const { maxHours, minHours } = getBookingHourLimits(rooms, Role.STUDENT, false);
-    expect(maxHours).toBe(4);
-    expect(minHours).toBe(0.5);
+    expect(maxHours).toBe(Number.POSITIVE_INFINITY);
+    expect(minHours).toBe(0);
   });
 
   it("uses regular role limits for non-walk-in booking", () => {
@@ -68,5 +68,24 @@ describe("getBookingHourLimits", () => {
     const { maxHours, minHours } = getBookingHourLimits(rooms, Role.STUDENT, false);
     expect(maxHours).toBe(2); // Uses lowest max
     expect(minHours).toBe(1); // Uses highest min
+  });
+
+  it("ignores rooms without limits when calculating restrictions", () => {
+    const rooms = [
+      {
+        roomId: 1,
+        name: "Room with limits",
+        maxHour: { student: 3 },
+        minHour: { student: 1 }
+      },
+      {
+        roomId: 2,
+        name: "Room without limits"
+        // No maxHour/minHour specified
+      }
+    ];
+    const { maxHours, minHours } = getBookingHourLimits(rooms, Role.STUDENT, false);
+    expect(maxHours).toBe(3); // Only considers the room with limits
+    expect(minHours).toBe(1); // Only considers the room with limits
   });
 });


### PR DESCRIPTION
- Remove default booking duration limits (was 4h max, 0.5h min)
- Allow unlimited duration when maxHour/minHour not specified
- Skip duration checks for rooms without hour limits
- Maintain backward compatibility for rooms with existing limits