### PR TITLE
Fixed bug that prevents users from selecting before 10:15 by only blo…

### DIFF
--- a/booking-app/app/api/bookings/shared.ts
+++ b/booking-app/app/api/bookings/shared.ts
@@ -7,7 +7,7 @@ import { NextRequest } from "next/server";
 import { format, toZonedTime } from "date-fns-tz";
 
 // All times in the booking app are in Eastern Time
-const TIMEZONE = "America/New_York";
+export const TIMEZONE = "America/New_York";
 
 /**
  * Checks if a school value represents "Other" selection.

--- a/booking-app/components/src/client/routes/booking/components/CalendarVerticalResource.tsx
+++ b/booking-app/components/src/client/routes/booking/components/CalendarVerticalResource.tsx
@@ -28,11 +28,10 @@ import { DatabaseContext } from "../../components/Provider";
 import { BookingContext } from "../bookingProvider";
 import { useBookingDateRestrictions } from "../hooks/useBookingDateRestrictions";
 import { TIMEZONE } from "../../../utils/date";
-import { toZonedTime } from "date-fns-tz";
 import { minutesToDurationString } from "@/components/src/constants/tenants";
-import { roundTimeUp } from "@/components/src/client/utils/date";
 import { DEFAULT_START_HOUR } from "../utils/getStartHour";
 import { DEFAULT_SLOT_UNIT } from "../utils/getSlotUnit";
+import { buildBlockPastTimes } from "../utils/buildBlockPastTimes";
 import momentTimezonePlugin from "@fullcalendar/moment-timezone";
 
 interface Props {
@@ -233,56 +232,12 @@ export default function CalendarVerticalResource({
       return [];
     }
 
-    // Get current time in Eastern timezone for comparison
-    const now = new Date();
-    const easternNow = toZonedTime(now, TIMEZONE);
-
-    // Check if we're viewing today's date (in Eastern timezone)
-    const viewDate = new Date(dateView);
-    const isViewingToday =
-      viewDate.getFullYear() === easternNow.getFullYear() &&
-      viewDate.getMonth() === easternNow.getMonth() &&
-      viewDate.getDate() === easternNow.getDate();
-
-    // Only block past times when viewing today's date
-    // For future dates, all slots starting from startHour should be selectable
-    if (!isViewingToday) {
-      return [];
-    }
-
-    // Get the rounded-up current time as the block end
-    const roundedNow = roundTimeUp(slotUnit ?? DEFAULT_SLOT_UNIT);
-
-    const blocks = rooms
-      .map((room) => {
-        // derive slot start from the date being viewed, using startHour from server data
-        const start = new Date(dateView);
-        const [minHour, minMinute] = (startHour || DEFAULT_START_HOUR)
-          .split(":")
-          .map((s) => parseInt(s, 10));
-        start.setHours(Number.isFinite(minHour) ? minHour : 9);
-        start.setMinutes(Number.isFinite(minMinute) ? minMinute : 0);
-        start.setSeconds(0);
-        start.setMilliseconds(0);
-
-        // Skip if there's no past time to block (current rounded time is at or before startHour)
-        // This makes the first slot selectable when we're still before or at the startHour boundary
-        if (roundedNow <= start) {
-          return null;
-        }
-
-        return {
-          start: start.toISOString(),
-          end: roundedNow.toISOString(),
-          id: room.roomId + "bg",
-          resourceId: room.roomId + "",
-          overlap: false,
-          display: "background",
-          classNames: ["disabled"],
-        };
-      })
-      .filter(Boolean);
-    return blocks;
+    return buildBlockPastTimes(
+      rooms,
+      dateView,
+      startHour ?? DEFAULT_START_HOUR,
+      slotUnit ?? DEFAULT_SLOT_UNIT
+    );
   }, [rooms, formContext, dateView, startHour, slotUnit]);
 
   const handleEventSelect = (selectInfo: DateSelectArg) => {

--- a/booking-app/components/src/client/routes/booking/utils/buildBlockPastTimes.ts
+++ b/booking-app/components/src/client/routes/booking/utils/buildBlockPastTimes.ts
@@ -1,6 +1,6 @@
 import { fromZonedTime, toZonedTime } from "date-fns-tz";
-
-export const BLOCK_PAST_TIMES_TIMEZONE = "America/New_York";
+import { TIMEZONE } from "@/components/src/client/utils/date";
+import { DEFAULT_START_HOUR } from "./getStartHour";
 
 export interface BlockPastTimeEvent {
   start: string;
@@ -31,11 +31,9 @@ export function buildBlockPastTimes(
   slotUnit: number,
   now: Date = new Date()
 ): BlockPastTimeEvent[] {
-  const tz = BLOCK_PAST_TIMES_TIMEZONE;
-
   // Convert both dates to Eastern so all comparisons use the same timezone.
-  const easternNow = toZonedTime(now, tz);
-  const easternView = toZonedTime(new Date(dateView), tz);
+  const easternNow = toZonedTime(now, TIMEZONE);
+  const easternView = toZonedTime(new Date(dateView), TIMEZONE);
 
   // Only block past slots when the user is viewing today (Eastern date).
   const isViewingToday =
@@ -48,7 +46,7 @@ export function buildBlockPastTimes(
   }
 
   // Parse startHour ("HH:MM:SS") into hour/minute components.
-  const [rawHour, rawMinute] = (startHour ?? "09:00:00")
+  const [rawHour, rawMinute] = (startHour ?? DEFAULT_START_HOUR)
     .split(":")
     .map((s) => parseInt(s, 10));
   const startH = Number.isFinite(rawHour) ? rawHour : 9;
@@ -67,7 +65,7 @@ export function buildBlockPastTimes(
       0,
       0
     ),
-    tz
+    TIMEZONE
   );
 
   // Round current Eastern time UP to the next slot boundary.
@@ -87,7 +85,7 @@ export function buildBlockPastTimes(
     );
   }
   // Convert the rounded Eastern time back to a proper UTC Date.
-  const blockEnd = fromZonedTime(roundedEastern, tz);
+  const blockEnd = fromZonedTime(roundedEastern, TIMEZONE);
 
   // Nothing to block if current rounded time is at or before the calendar start.
   if (blockEnd <= blockStart) {

--- a/booking-app/components/src/client/routes/booking/utils/buildBlockPastTimes.ts
+++ b/booking-app/components/src/client/routes/booking/utils/buildBlockPastTimes.ts
@@ -1,0 +1,106 @@
+import { fromZonedTime, toZonedTime } from "date-fns-tz";
+
+export const BLOCK_PAST_TIMES_TIMEZONE = "America/New_York";
+
+export interface BlockPastTimeEvent {
+  start: string;
+  end: string;
+  id: string;
+  resourceId: string;
+  overlap: boolean;
+  display: string;
+  classNames: string[];
+}
+
+/**
+ * Builds FullCalendar background events that block past time slots on today's
+ * calendar. All date comparisons are performed in Eastern timezone so the
+ * result is correct for users in any browser timezone.
+ *
+ * @param rooms      - Array of rooms (only roomId is used).
+ * @param dateView   - The calendar date currently being viewed.
+ * @param startHour  - Earliest visible slot, e.g. "09:00:00" (Eastern).
+ * @param slotUnit   - Slot / snap duration in minutes (e.g. 15).
+ * @param now        - Current moment in time (default: new Date()). Injected
+ *                     as a parameter so unit tests can control the clock.
+ */
+export function buildBlockPastTimes(
+  rooms: Array<{ roomId: number | string }>,
+  dateView: Date,
+  startHour: string | undefined,
+  slotUnit: number,
+  now: Date = new Date()
+): BlockPastTimeEvent[] {
+  const tz = BLOCK_PAST_TIMES_TIMEZONE;
+
+  // Convert both dates to Eastern so all comparisons use the same timezone.
+  const easternNow = toZonedTime(now, tz);
+  const easternView = toZonedTime(new Date(dateView), tz);
+
+  // Only block past slots when the user is viewing today (Eastern date).
+  const isViewingToday =
+    easternView.getFullYear() === easternNow.getFullYear() &&
+    easternView.getMonth() === easternNow.getMonth() &&
+    easternView.getDate() === easternNow.getDate();
+
+  if (!isViewingToday) {
+    return [];
+  }
+
+  // Parse startHour ("HH:MM:SS") into hour/minute components.
+  const [rawHour, rawMinute] = (startHour ?? "09:00:00")
+    .split(":")
+    .map((s) => parseInt(s, 10));
+  const startH = Number.isFinite(rawHour) ? rawHour : 9;
+  const startM = Number.isFinite(rawMinute) ? rawMinute : 0;
+
+  // Build the block-start moment: startHour on the viewed Eastern date, as UTC.
+  // fromZonedTime() treats its first argument's year/month/day/hour/minute as
+  // being in the given timezone and returns the corresponding UTC Date.
+  const blockStart = fromZonedTime(
+    new Date(
+      easternView.getFullYear(),
+      easternView.getMonth(),
+      easternView.getDate(),
+      startH,
+      startM,
+      0,
+      0
+    ),
+    tz
+  );
+
+  // Round current Eastern time UP to the next slot boundary.
+  const minutes = easternNow.getMinutes();
+  const remainder = minutes % slotUnit;
+  const roundedEastern = new Date(easternNow);
+  if (remainder === 0) {
+    roundedEastern.setSeconds(0, 0);
+  } else {
+    const carry = slotUnit - remainder;
+    const totalMinutes = minutes + carry;
+    roundedEastern.setHours(
+      easternNow.getHours() + Math.floor(totalMinutes / 60),
+      totalMinutes % 60,
+      0,
+      0
+    );
+  }
+  // Convert the rounded Eastern time back to a proper UTC Date.
+  const blockEnd = fromZonedTime(roundedEastern, tz);
+
+  // Nothing to block if current rounded time is at or before the calendar start.
+  if (blockEnd <= blockStart) {
+    return [];
+  }
+
+  return rooms.map((room) => ({
+    start: blockStart.toISOString(),
+    end: blockEnd.toISOString(),
+    id: `${room.roomId}bg`,
+    resourceId: `${room.roomId}`,
+    overlap: false,
+    display: "background",
+    classNames: ["disabled"],
+  }));
+}

--- a/booking-app/tests/unit/buildBlockPastTimes.unit.test.ts
+++ b/booking-app/tests/unit/buildBlockPastTimes.unit.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from "vitest";
+import { buildBlockPastTimes } from "@/components/src/client/routes/booking/utils/buildBlockPastTimes";
+
+/**
+ * All timestamps use UTC. February 2026 uses EST (UTC-5), so:
+ *   Eastern time  = UTC - 5h
+ *   e.g. 14:00Z   = 9:00 AM ET
+ *        15:15Z   = 10:15 AM ET
+ */
+
+const ROOMS_SINGLE = [{ roomId: 1 }];
+const ROOMS_MULTI = [{ roomId: 1 }, { roomId: 2 }];
+
+// Feb 18 2026 at various UTC times (EST = UTC-5)
+const FEB18_MIDNIGHT_ET = new Date("2026-02-18T05:00:00Z"); // midnight ET on Feb 18
+const FEB19_MIDNIGHT_ET = new Date("2026-02-19T05:00:00Z"); // midnight ET on Feb 19
+
+describe("buildBlockPastTimes", () => {
+  describe("future dates", () => {
+    it("returns empty array when viewing a future date", () => {
+      // now = 9:12 AM ET Feb 18; viewing Feb 19
+      const now = new Date("2026-02-18T14:12:00Z");
+      const result = buildBlockPastTimes(
+        ROOMS_SINGLE,
+        FEB19_MIDNIGHT_ET,
+        "09:00:00",
+        15,
+        now
+      );
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array when viewing a date far in the future", () => {
+      const now = new Date("2026-02-18T14:00:00Z");
+      const futureDate = new Date("2026-03-15T05:00:00Z");
+      const result = buildBlockPastTimes(
+        ROOMS_SINGLE,
+        futureDate,
+        "09:00:00",
+        15,
+        now
+      );
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("current time before or at startHour (today)", () => {
+    it("returns empty array when current time is before startHour", () => {
+      // now = 8:30 AM ET; aligned to slot so roundedNow = 8:30 AM ET < 9:00 AM startHour
+      const now = new Date("2026-02-18T13:30:00Z"); // 8:30 AM ET
+      const result = buildBlockPastTimes(
+        ROOMS_SINGLE,
+        FEB18_MIDNIGHT_ET,
+        "09:00:00",
+        15,
+        now
+      );
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array when current time rounds up to exactly startHour", () => {
+      // now = 8:55 AM ET; rounds up to 9:00 AM ET = blockEnd <= blockStart
+      const now = new Date("2026-02-18T13:55:00Z"); // 8:55 AM ET
+      const result = buildBlockPastTimes(
+        ROOMS_SINGLE,
+        FEB18_MIDNIGHT_ET,
+        "09:00:00",
+        15,
+        now
+      );
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array when current time is exactly at startHour", () => {
+      // now = 9:00 AM ET exactly; already on boundary → roundedNow = 9:00 AM ET = blockStart
+      const now = new Date("2026-02-18T14:00:00Z"); // 9:00 AM ET
+      const result = buildBlockPastTimes(
+        ROOMS_SINGLE,
+        FEB18_MIDNIGHT_ET,
+        "09:00:00",
+        15,
+        now
+      );
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("blocking past slots today", () => {
+    it("blocks from startHour to next slot boundary when mid-slot", () => {
+      // now = 9:12 AM ET; rounds up to 9:15 AM ET
+      const now = new Date("2026-02-18T14:12:00Z");
+      const result = buildBlockPastTimes(
+        ROOMS_SINGLE,
+        FEB18_MIDNIGHT_ET,
+        "09:00:00",
+        15,
+        now
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].start).toBe("2026-02-18T14:00:00.000Z"); // 9:00 AM ET
+      expect(result[0].end).toBe("2026-02-18T14:15:00.000Z"); // 9:15 AM ET
+      expect(result[0].resourceId).toBe("1");
+      expect(result[0].id).toBe("1bg");
+      expect(result[0].overlap).toBe(false);
+      expect(result[0].display).toBe("background");
+      expect(result[0].classNames).toContain("disabled");
+    });
+
+    it("blocks up to an exact slot boundary when current time is on a boundary", () => {
+      // now = 10:15 AM ET exactly on boundary
+      const now = new Date("2026-02-18T15:15:00Z");
+      const result = buildBlockPastTimes(
+        ROOMS_SINGLE,
+        FEB18_MIDNIGHT_ET,
+        "09:00:00",
+        15,
+        now
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].start).toBe("2026-02-18T14:00:00.000Z"); // 9:00 AM ET
+      expect(result[0].end).toBe("2026-02-18T15:15:00.000Z"); // 10:15 AM ET
+    });
+
+    it("produces one block per room", () => {
+      const now = new Date("2026-02-18T14:12:00Z"); // 9:12 AM ET
+      const result = buildBlockPastTimes(
+        ROOMS_MULTI,
+        FEB18_MIDNIGHT_ET,
+        "09:00:00",
+        15,
+        now
+      );
+      expect(result).toHaveLength(2);
+      expect(result[0].resourceId).toBe("1");
+      expect(result[1].resourceId).toBe("2");
+      // Both blocks share the same start/end
+      expect(result[0].start).toBe(result[1].start);
+      expect(result[0].end).toBe(result[1].end);
+    });
+
+    it("respects a non-default startHour", () => {
+      // startHour = 10:00 AM ET; now = 10:07 AM ET → rounds to 10:15 AM ET
+      const now = new Date("2026-02-18T15:07:00Z"); // 10:07 AM ET
+      const result = buildBlockPastTimes(
+        ROOMS_SINGLE,
+        FEB18_MIDNIGHT_ET,
+        "10:00:00",
+        15,
+        now
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].start).toBe("2026-02-18T15:00:00.000Z"); // 10:00 AM ET
+      expect(result[0].end).toBe("2026-02-18T15:15:00.000Z"); // 10:15 AM ET
+    });
+
+    it("falls back to 09:00:00 when startHour is undefined", () => {
+      const now = new Date("2026-02-18T14:05:00Z"); // 9:05 AM ET → rounds to 9:15
+      const result = buildBlockPastTimes(
+        ROOMS_SINGLE,
+        FEB18_MIDNIGHT_ET,
+        undefined,
+        15,
+        now
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].start).toBe("2026-02-18T14:00:00.000Z"); // 9:00 AM ET
+      expect(result[0].end).toBe("2026-02-18T14:15:00.000Z"); // 9:15 AM ET
+    });
+
+    it("handles 30-minute slot units", () => {
+      // now = 9:10 AM ET; slotUnit = 30 → rounds up to 9:30 AM ET
+      const now = new Date("2026-02-18T14:10:00Z");
+      const result = buildBlockPastTimes(
+        ROOMS_SINGLE,
+        FEB18_MIDNIGHT_ET,
+        "09:00:00",
+        30,
+        now
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].start).toBe("2026-02-18T14:00:00.000Z"); // 9:00 AM ET
+      expect(result[0].end).toBe("2026-02-18T14:30:00.000Z"); // 9:30 AM ET
+    });
+  });
+
+  describe("timezone correctness", () => {
+    it("uses Eastern timezone for today check, not browser local timezone", () => {
+      // A user whose browser is in PT (UTC-8) picks "Feb 19" from the date picker.
+      // Their midnight = 2026-02-19T08:00:00Z = 3:00 AM ET on Feb 19 (still Feb 19 ET).
+      // now = 9:12 AM ET on Feb 18 → should NOT produce blocks (viewing future ET date).
+      const now = new Date("2026-02-18T14:12:00Z"); // 9:12 AM ET, Feb 18
+      const pacificFeb19Midnight = new Date("2026-02-19T08:00:00Z"); // midnight PT = 3 AM ET Feb 19
+      const result = buildBlockPastTimes(
+        ROOMS_SINGLE,
+        pacificFeb19Midnight,
+        "09:00:00",
+        15,
+        now
+      );
+      expect(result).toEqual([]);
+    });
+
+    it("treats today correctly for Pacific timezone browser viewing today", () => {
+      // Pacific midnight for Feb 18 = 2026-02-18T08:00:00Z = 3:00 AM ET on Feb 18.
+      // now = 9:12 AM ET → should produce blocks.
+      const now = new Date("2026-02-18T14:12:00Z"); // 9:12 AM ET
+      const pacificFeb18Midnight = new Date("2026-02-18T08:00:00Z"); // 3 AM ET Feb 18
+      const result = buildBlockPastTimes(
+        ROOMS_SINGLE,
+        pacificFeb18Midnight,
+        "09:00:00",
+        15,
+        now
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].start).toBe("2026-02-18T14:00:00.000Z");
+      expect(result[0].end).toBe("2026-02-18T14:15:00.000Z");
+    });
+
+    it("block start time is anchored in Eastern timezone regardless of dateView UTC offset", () => {
+      // Both a PT and an ET user viewing Feb 18 "today" should get the same
+      // block start (9:00 AM ET = 14:00Z) even though their dateView differs.
+      const now = new Date("2026-02-18T14:12:00Z");
+      const etFeb18Midnight = new Date("2026-02-18T05:00:00Z");
+      const ptFeb18Midnight = new Date("2026-02-18T08:00:00Z");
+
+      const etResult = buildBlockPastTimes(
+        ROOMS_SINGLE,
+        etFeb18Midnight,
+        "09:00:00",
+        15,
+        now
+      );
+      const ptResult = buildBlockPastTimes(
+        ROOMS_SINGLE,
+        ptFeb18Midnight,
+        "09:00:00",
+        15,
+        now
+      );
+
+      expect(etResult[0].start).toBe(ptResult[0].start);
+      expect(etResult[0].end).toBe(ptResult[0].end);
+    });
+  });
+});


### PR DESCRIPTION
…cking past times when viewing today; Skip blocking when current time hasn't reached startHour; compare dates in Eastern timezone consistently

## Checklist

- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I tested this feature locally
- [x] I had Copilot review the PR and incorporated feedback (or explained why not)
- [x] I confirmed there are no conflicts
- [x] I confirmed my PR passed all tests
- [x] I added or updated unit tests (or explained why not)
- [x] I attached screenshots or a video demonstrating the feature
- [x] I requested a code review from at least one other teammate

## Screenshots / Video

<img width="1569" height="1120" alt="4562d032e4c8e116a395ded30948b4e0" src="https://github.com/user-attachments/assets/32e32e53-95d5-4a14-9724-cf663357f752" />