### PR TITLE
Fix E2E test failure on month boundary dates

### DIFF
--- a/booking-app/tests/e2e/helpers/test-utils.ts
+++ b/booking-app/tests/e2e/helpers/test-utils.ts
@@ -41,14 +41,24 @@ export async function selectTimeSlot(
 
   if (!skipDatePicker) {
     // Navigate to tomorrow via the CalendarDatePicker
+    const today = new Date();
     const tomorrow = new Date();
     tomorrow.setDate(tomorrow.getDate() + 1);
     const tomorrowDay = tomorrow.getDate().toString();
 
-    const calendarGrid = page.locator('div[role="grid"]');
-    await calendarGrid.waitFor({ state: "visible", timeout: 10000 });
-    await calendarGrid
+    const datePicker = page.locator(".MuiDateCalendar-root");
+    await datePicker.waitFor({ state: "visible", timeout: 10000 });
+
+    // If tomorrow is in a different month, navigate forward
+    if (tomorrow.getMonth() !== today.getMonth()) {
+      await datePicker.getByRole("button", { name: "Next month" }).click();
+      const monthName = tomorrow.toLocaleString("en-US", { month: "long" });
+      await datePicker.getByText(new RegExp(monthName)).waitFor();
+    }
+
+    await datePicker
       .getByRole("gridcell", { name: tomorrowDay, exact: true })
+      .first()
       .click();
   }
 


### PR DESCRIPTION
## Summary of Changes

When tomorrow is in a different month (e.g. Feb 28 -> Mar 1), the date picker now navigates to the next month before selecting the day. Also scopes the selector to MuiDateCalendar-root to avoid conflicts with FullCalendar's grid.

## Checklist

- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I tested this feature locally
- [ ] I had Copilot review the PR and incorporated feedback (or explained why not)
- [x] I confirmed there are no conflicts
- [ ] I confirmed my PR passed all tests
- [x] I added or updated unit tests (or explained why not)
- [ ] I attached screenshots or a video demonstrating the feature
- [ ] I requested a code review from at least one other teammate
