### PR TITLE
Feat/redirect to highest priority clean

### DIFF
--- a/booking-app/app/[tenant]/edit/[id]/page.tsx
+++ b/booking-app/app/[tenant]/edit/[id]/page.tsx
@@ -3,10 +3,11 @@
 "use client";
 
 import EditLandingPage from "@/components/src/client/routes/edit/EditLandingPage";
-import React, { use } from "react";
+import { useParams } from "next/navigation";
+import React from "react";
 
-const HomePage = ({ params }: { params: Promise<{ id: string }> }) => {
-  const { id } = use(params);
+const HomePage = () => {
+  const { id } = useParams<{ id: string }>();
   return <EditLandingPage calendarEventId={id} />;
 };
 

--- a/booking-app/app/[tenant]/edit/form/[id]/page.tsx
+++ b/booking-app/app/[tenant]/edit/form/[id]/page.tsx
@@ -4,10 +4,11 @@
 
 import BookingFormDetailsPage from "@/components/src/client/routes/booking/formPages/BookingFormDetailsPage";
 import { FormContextLevel } from "@/components/src/types";
-import React, { use } from "react";
+import { useParams } from "next/navigation";
+import React from "react";
 
-const Form = ({ params }: { params: Promise<{ id: string }> }) => {
-  const { id } = use(params);
+const Form = () => {
+  const { id } = useParams<{ id: string }>();
   return (
     <BookingFormDetailsPage
       calendarEventId={id}

--- a/booking-app/app/[tenant]/edit/role/[id]/page.tsx
+++ b/booking-app/app/[tenant]/edit/role/[id]/page.tsx
@@ -2,11 +2,12 @@
 
 import { FormContextLevel } from "@/components/src/types";
 // app/edit/role/[id].tsx
-import React, { use } from "react";
+import { useParams } from "next/navigation";
+import React from "react";
 import UserRolePage from "@/components/src/client/routes/booking/formPages/UserRolePage";
 
-const Role = ({ params }: { params: Promise<{ id: string }> }) => {
-  const { id } = use(params);
+const Role = () => {
+  const { id } = useParams<{ id: string }>();
   return (
     <UserRolePage
       calendarEventId={id}

--- a/booking-app/app/[tenant]/edit/selectRoom/[id]/page.tsx
+++ b/booking-app/app/[tenant]/edit/selectRoom/[id]/page.tsx
@@ -3,11 +3,12 @@
 "use client";
 
 import { FormContextLevel } from "@/components/src/types";
-import React, { use } from "react";
+import { useParams } from "next/navigation";
+import React from "react";
 import SelectRoomPage from "@/components/src/client/routes/booking/formPages/SelectRoomPage";
 
-const SelectRoom = ({ params }: { params: Promise<{ id: string }> }) => {
-  const { id } = use(params);
+const SelectRoom = () => {
+  const { id } = useParams<{ id: string }>();
   return (
     <SelectRoomPage
       calendarEventId={id}

--- a/booking-app/app/[tenant]/modification/[id]/page.tsx
+++ b/booking-app/app/[tenant]/modification/[id]/page.tsx
@@ -3,10 +3,11 @@
 "use client";
 
 import ModificationLandingPage from "@/components/src/client/routes/modification/ModificationLandingPage";
-import React, { use } from "react";
+import { useParams } from "next/navigation";
+import React from "react";
 
-const HomePage = ({ params }: { params: Promise<{ id: string }> }) => {
-  const { id } = use(params);
+const HomePage = () => {
+  const { id } = useParams<{ id: string }>();
   return <ModificationLandingPage calendarEventId={id} />;
 };
 

--- a/booking-app/app/[tenant]/modification/form/[id]/page.tsx
+++ b/booking-app/app/[tenant]/modification/form/[id]/page.tsx
@@ -4,10 +4,11 @@
 
 import BookingFormDetailsPage from "@/components/src/client/routes/booking/formPages/BookingFormDetailsPage";
 import { FormContextLevel } from "@/components/src/types";
-import React, { use } from "react";
+import { useParams } from "next/navigation";
+import React from "react";
 
-const Form = ({ params }: { params: Promise<{ id: string }> }) => {
-  const { id } = use(params);
+const Form = () => {
+  const { id } = useParams<{ id: string }>();
   return (
     <BookingFormDetailsPage
       calendarEventId={id}

--- a/booking-app/app/[tenant]/modification/selectRoom/[id]/page.tsx
+++ b/booking-app/app/[tenant]/modification/selectRoom/[id]/page.tsx
@@ -3,11 +3,12 @@
 "use client";
 
 import { FormContextLevel } from "@/components/src/types";
-import React, { use } from "react";
+import { useParams } from "next/navigation";
+import React from "react";
 import SelectRoomPage from "@/components/src/client/routes/booking/formPages/SelectRoomPage";
 
-const SelectRoom = ({ params }: { params: Promise<{ id: string }> }) => {
-  const { id } = use(params);
+const SelectRoom = () => {
+  const { id } = useParams<{ id: string }>();
   return (
     <SelectRoomPage
       calendarEventId={id}

--- a/booking-app/app/[tenant]/page.tsx
+++ b/booking-app/app/[tenant]/page.tsx
@@ -1,10 +1,48 @@
-// app/page.tsx
+// app/[tenant]/page.tsx
 
 "use client";
 
+import { useContext, useEffect } from "react";
+import { useRouter, useParams } from "next/navigation";
+import { DatabaseContext } from "@/components/src/client/routes/components/Provider";
 import MyBookingsPage from "@/components/src/client/routes/myBookings/myBookingsPage";
+import { PagePermission } from "@/components/src/types";
 import React from "react";
 
-const HomePage: React.FC = () => <MyBookingsPage />;
+const FLAG_KEY = "hasRedirectedToDefaultContext";
+
+const PERMISSION_PATHS: Partial<Record<PagePermission, string>> = {
+  [PagePermission.SUPER_ADMIN]: "super",
+  [PagePermission.ADMIN]: "admin",
+  [PagePermission.SERVICES]: "services",
+  [PagePermission.LIAISON]: "liaison",
+  [PagePermission.PA]: "pa",
+};
+
+const HomePage: React.FC = () => {
+  const { permissionsLoading, pagePermission } = useContext(DatabaseContext);
+  const router = useRouter();
+  const { tenant } = useParams<{ tenant: string }>();
+
+  useEffect(() => {
+    if (permissionsLoading) return;
+    if (!tenant) return;
+    if (sessionStorage.getItem(FLAG_KEY) === "true") return;
+    const path = PERMISSION_PATHS[pagePermission];
+    if (path) {
+      sessionStorage.setItem(FLAG_KEY, "true");
+      router.replace(`/${tenant}/${path}`);
+    }
+  }, [permissionsLoading, pagePermission, tenant, router]);
+
+  // Render nothing while loading or while a redirect is about to fire.
+  if (permissionsLoading) return null;
+  const hasChosen =
+    typeof window !== "undefined" &&
+    sessionStorage.getItem(FLAG_KEY) === "true";
+  if (pagePermission !== PagePermission.BOOKING && !hasChosen) return null;
+
+  return <MyBookingsPage />;
+};
 
 export default HomePage;

--- a/booking-app/app/[tenant]/page.tsx
+++ b/booking-app/app/[tenant]/page.tsx
@@ -7,17 +7,10 @@ import { useRouter, useParams } from "next/navigation";
 import { DatabaseContext } from "@/components/src/client/routes/components/Provider";
 import MyBookingsPage from "@/components/src/client/routes/myBookings/myBookingsPage";
 import { PagePermission } from "@/components/src/types";
+import { PERMISSION_PATH } from "@/components/src/utils/permissions";
 import React from "react";
 
 const FLAG_KEY = "hasRedirectedToDefaultContext";
-
-const PERMISSION_PATHS: Partial<Record<PagePermission, string>> = {
-  [PagePermission.SUPER_ADMIN]: "super",
-  [PagePermission.ADMIN]: "admin",
-  [PagePermission.SERVICES]: "services",
-  [PagePermission.LIAISON]: "liaison",
-  [PagePermission.PA]: "pa",
-};
 
 const HomePage: React.FC = () => {
   const { permissionsLoading, pagePermission } = useContext(DatabaseContext);
@@ -28,7 +21,7 @@ const HomePage: React.FC = () => {
     if (permissionsLoading) return;
     if (!tenant) return;
     if (sessionStorage.getItem(FLAG_KEY) === "true") return;
-    const path = PERMISSION_PATHS[pagePermission];
+    const path = PERMISSION_PATH[pagePermission];
     if (path) {
       sessionStorage.setItem(FLAG_KEY, "true");
       router.replace(`/${tenant}/${path}`);

--- a/booking-app/components/src/client/routes/booking/components/CalendarEventBlock.tsx
+++ b/booking-app/components/src/client/routes/booking/components/CalendarEventBlock.tsx
@@ -14,7 +14,10 @@ interface Props {
   numrooms: number;
 }
 
-const Block = styled(Box)<Props>(({ theme, bgcolor, isnew, numrooms }) => ({
+const Block = styled(Box, {
+  shouldForwardProp: (prop) =>
+    prop !== "isnew" && prop !== "numrooms" && prop !== "bgcolor",
+})<Props>(({ theme, bgcolor, isnew, numrooms }) => ({
   backgroundColor: bgcolor || theme.palette.primary.main,
   border: `2px solid ${bgcolor || theme.palette.primary.main}`,
   borderRadius: "4px",

--- a/booking-app/components/src/client/routes/booking/formPages/BookingFormConfirmationPage.tsx
+++ b/booking-app/components/src/client/routes/booking/formPages/BookingFormConfirmationPage.tsx
@@ -34,7 +34,24 @@ export default function BookingFormConfirmationPage({ formContext }: Props) {
   const isVIP = formContext === FormContextLevel.VIP;
   const isMod = formContext === FormContextLevel.MODIFICATION;
 
-  // don't submit form via useEffect here b/c it submits twice in development strict mode
+  /** Return path after modification: privileged users go straight to their
+   *  default context so they never flash through the User bookings table. */
+  const getModReturnPath = (): string => {
+    switch (pagePermission) {
+      case PagePermission.SUPER_ADMIN:
+        return `/${tenant}/super`;
+      case PagePermission.ADMIN:
+        return `/${tenant}/admin`;
+      case PagePermission.SERVICES:
+        return `/${tenant}/services`;
+      case PagePermission.LIAISON:
+        return `/${tenant}/liaison`;
+      case PagePermission.PA:
+        return `/${tenant}/pa`;
+      default:
+        return `/${tenant}`;
+    }
+  };
 
   if (submitting === "submitting") {
     return (
@@ -94,8 +111,8 @@ export default function BookingFormConfirmationPage({ formContext }: Props) {
                   ? `/${tenant}/admin`
                   : isWalkIn
                     ? `/${tenant}/pa`
-                    : isMod && pagePermission === PagePermission.PA
-                      ? `/${tenant}/pa`
+                    : isMod
+                      ? getModReturnPath()
                       : `/${tenant}`,
               )
             }

--- a/booking-app/components/src/client/routes/booking/formPages/BookingFormConfirmationPage.tsx
+++ b/booking-app/components/src/client/routes/booking/formPages/BookingFormConfirmationPage.tsx
@@ -4,6 +4,7 @@ import { Box, Button, Typography, useTheme } from "@mui/material";
 import { Error, Event } from "@mui/icons-material";
 import React, { useContext } from "react";
 import { FormContextLevel, PagePermission } from "@/components/src/types";
+import { PERMISSION_PATH } from "@/components/src/utils/permissions";
 import { styled } from "@mui/system";
 import { useRouter, useParams } from "next/navigation";
 import { BookingContext } from "../bookingProvider";
@@ -34,23 +35,9 @@ export default function BookingFormConfirmationPage({ formContext }: Props) {
   const isVIP = formContext === FormContextLevel.VIP;
   const isMod = formContext === FormContextLevel.MODIFICATION;
 
-  /** Return path after modification: privileged users go straight to their
-   *  default context so they never flash through the User bookings table. */
   const getModReturnPath = (): string => {
-    switch (pagePermission) {
-      case PagePermission.SUPER_ADMIN:
-        return `/${tenant}/super`;
-      case PagePermission.ADMIN:
-        return `/${tenant}/admin`;
-      case PagePermission.SERVICES:
-        return `/${tenant}/services`;
-      case PagePermission.LIAISON:
-        return `/${tenant}/liaison`;
-      case PagePermission.PA:
-        return `/${tenant}/pa`;
-      default:
-        return `/${tenant}`;
-    }
+    const path = PERMISSION_PATH[pagePermission];
+    return path ? `/${tenant}/${path}` : `/${tenant}`;
   };
 
   if (submitting === "submitting") {

--- a/booking-app/components/src/client/routes/components/Provider.tsx
+++ b/booking-app/components/src/client/routes/components/Provider.tsx
@@ -49,6 +49,7 @@ export interface DatabaseContextType {
   blackoutPeriods: BlackoutPeriod[];
   allBookings: Booking[];
   bookingsLoading: boolean;
+  permissionsLoading: boolean;
   liaisonUsers: Approver[];
   equipmentUsers: Approver[];
   departmentNames: DepartmentType[];
@@ -93,6 +94,7 @@ export const DatabaseContext = createContext<DatabaseContextType>({
   blackoutPeriods: [],
   allBookings: [],
   bookingsLoading: true,
+  permissionsLoading: true,
   liaisonUsers: [],
   equipmentUsers: [],
   departmentNames: [],
@@ -138,6 +140,7 @@ export const DatabaseProvider = ({
   const [blackoutPeriods, setBlackoutPeriods] = useState<BlackoutPeriod[]>([]);
   // const [futureBookings, setFutureBookings] = useState<Booking[]>([]);
   const [bookingsLoading, setBookingsLoading] = useState<boolean>(true);
+  const [permissionsLoading, setPermissionsLoading] = useState<boolean>(true);
   const [allBookings, setAllBookings] = useState<Booking[]>([]);
   const [adminUsers, setAdminUsers] = useState<AdminUser[]>([]);
   const [liaisonUsers, setLiaisonUsers] = useState<Approver[]>([]);
@@ -245,12 +248,25 @@ export const DatabaseProvider = ({
   }, [filters]);
 
   useEffect(() => {
-    fetchActiveUserEmail();
-    if (tenant) {
-      fetchAdminUsers();
-      fetchPaUsers();
-      fetchSuperAdminUsers();
-    }
+    const loadPermissions = async () => {
+      fetchActiveUserEmail();
+      if (tenant) {
+        setPermissionsLoading(true);
+        try {
+          await Promise.all([
+            fetchAdminUsers(),
+            fetchPaUsers(),
+            fetchSuperAdminUsers(),
+            fetchApproverUsers(),
+          ]);
+        } finally {
+          setPermissionsLoading(false);
+        }
+      } else {
+        setPermissionsLoading(false);
+      }
+    };
+    loadPermissions();
   }, [user, tenant]);
 
   useEffect(() => {
@@ -783,6 +799,7 @@ export const DatabaseProvider = ({
         userEmail,
         netId,
         bookingsLoading,
+        permissionsLoading,
         userApiData,
         loadMoreEnabled,
         reloadAdminUsers: fetchAdminUsers,

--- a/booking-app/components/src/client/routes/components/Provider.tsx
+++ b/booking-app/components/src/client/routes/components/Provider.tsx
@@ -249,10 +249,12 @@ export const DatabaseProvider = ({
 
   useEffect(() => {
     const loadPermissions = async () => {
-      fetchActiveUserEmail();
       if (tenant) {
         setPermissionsLoading(true);
         try {
+          // Set user email synchronously so pagePermission is correct
+          // when we mark loading as done.
+          fetchActiveUserEmail();
           await Promise.all([
             fetchAdminUsers(),
             fetchPaUsers(),
@@ -260,7 +262,12 @@ export const DatabaseProvider = ({
             fetchApproverUsers(),
           ]);
         } finally {
-          setPermissionsLoading(false);
+          // Only mark done once we actually have a user email.  If auth hasn't
+          // resolved yet (user === null) keep the loading state so the redirect
+          // logic in NavBar doesn't fire prematurely with pagePermission=BOOKING.
+          if (user) {
+            setPermissionsLoading(false);
+          }
         }
       } else {
         setPermissionsLoading(false);

--- a/booking-app/components/src/client/routes/components/Provider.tsx
+++ b/booking-app/components/src/client/routes/components/Provider.tsx
@@ -573,7 +573,7 @@ export const DatabaseProvider = ({
       return;
     }
 
-    clientFetchAllDataFromCollection(TableNames.APPROVERS, [], tenant)
+    return clientFetchAllDataFromCollection(TableNames.APPROVERS, [], tenant)
       .then((fetchedData) => {
         const all = fetchedData.map((item: any) => ({
           id: item.id,

--- a/booking-app/components/src/client/routes/components/bookingTable/Bookings.tsx
+++ b/booking-app/components/src/client/routes/components/bookingTable/Bookings.tsx
@@ -214,9 +214,9 @@ export const Bookings: React.FC<BookingsProps> = ({
         headerName: "#",
         minWidth: 60,
         flex: 1,
-        renderHeader: () => <TableCell>Origin</TableCell>,
+        renderHeader: () => <TableCell component={"div" as any}>Origin</TableCell>,
         renderCell: (params) => (
-          <TableCell>
+          <TableCell component={"div" as any}>
             {formatOrigin(params.row.origin ?? BookingOrigin.USER)}
           </TableCell>
         ),
@@ -226,9 +226,9 @@ export const Bookings: React.FC<BookingsProps> = ({
         headerName: "#",
         minWidth: 80,
         flex: 1,
-        renderHeader: () => <TableCell>#</TableCell>,
+        renderHeader: () => <TableCell component={"div" as any}>#</TableCell>,
         renderCell: (params) => (
-          <TableCell>{params.row.requestNumber ?? "--"}</TableCell>
+          <TableCell component={"div" as any}>{params.row.requestNumber ?? "--"}</TableCell>
         ),
       },
       {
@@ -236,9 +236,9 @@ export const Bookings: React.FC<BookingsProps> = ({
         headerName: "Status",
         minWidth: 100,
         flex: 1,
-        renderHeader: () => <TableCell>Status</TableCell>,
+        renderHeader: () => <TableCell component={"div" as any}>Status</TableCell>,
         renderCell: (params) => (
-          <TableCell>
+          <TableCell component={"div" as any}>
             <StatusChip
               status={getBookingStatus(params.row)}
               allowTooltip={true}
@@ -251,7 +251,7 @@ export const Bookings: React.FC<BookingsProps> = ({
         headerName: "Date / Time",
         minWidth: 130,
         flex: 1,
-        renderHeader: () => <TableCell>Date / Time (ET)</TableCell>,
+        renderHeader: () => <TableCell component={"div" as any}>Date / Time (ET)</TableCell>,
         renderCell: (params) => (
           <StackedTableCell
             topText={formatDateTable(params.row.startDate.toDate())}
@@ -266,9 +266,9 @@ export const Bookings: React.FC<BookingsProps> = ({
         headerName: resourceName,
         minWidth: 100,
         flex: 1,
-        renderHeader: () => <TableCell>{resourceName}</TableCell>,
+        renderHeader: () => <TableCell component={"div" as any}>{resourceName}</TableCell>,
         renderCell: (params) => (
-          <TableCell sx={{ maxWidth: "150px" }}>{params.row.roomId}</TableCell>
+          <TableCell component={"div" as any} sx={{ maxWidth: "150px" }}>{params.row.roomId}</TableCell>
         ),
       },
       ...(!isUserView
@@ -278,7 +278,7 @@ export const Bookings: React.FC<BookingsProps> = ({
               headerName: "Department / Role",
               minWidth: 150,
               flex: 1,
-              renderHeader: () => <TableCell>Department / Role</TableCell>,
+              renderHeader: () => <TableCell component={"div" as any}>Department / Role</TableCell>,
               renderCell: (params) => (
                 <StackedTableCell
                   topText={
@@ -295,7 +295,7 @@ export const Bookings: React.FC<BookingsProps> = ({
               headerName: "Requestor",
               minWidth: 100,
               flex: 1,
-              renderHeader: () => <TableCell>Requestor</TableCell>,
+              renderHeader: () => <TableCell component={"div" as any}>Requestor</TableCell>,
               renderCell: (params) => (
                 <StackedTableCell
                   topText={params.row.netId}
@@ -308,7 +308,7 @@ export const Bookings: React.FC<BookingsProps> = ({
               headerName: "Contact Info",
               minWidth: 180,
               flex: 1,
-              renderHeader: () => <TableCell>Contact Info</TableCell>,
+              renderHeader: () => <TableCell component={"div" as any}>Contact Info</TableCell>,
               renderCell: (params) => (
                 <StackedTableCell
                   topText={params.row.email}
@@ -323,7 +323,7 @@ export const Bookings: React.FC<BookingsProps> = ({
         headerName: "Title",
         minWidth: 200,
         flex: 2,
-        renderHeader: () => <TableCell>Title</TableCell>,
+        renderHeader: () => <TableCell component={"div" as any}>Title</TableCell>,
         renderCell: (params) => (
           <Tooltip
             title={params.row.title}
@@ -344,6 +344,7 @@ export const Bookings: React.FC<BookingsProps> = ({
             }}
           >
             <TableCell
+              component={"div" as any}
               sx={{
                 maxWidth: "200px",
                 whiteSpace: "nowrap",
@@ -361,11 +362,11 @@ export const Bookings: React.FC<BookingsProps> = ({
         headerName: "Details",
         minWidth: 80,
         flex: 1,
-        renderHeader: () => <TableCell>Details</TableCell>,
         filterable: false,
         sortable: false,
+        renderHeader: () => <TableCell component={"div" as any}>Details</TableCell>,
         renderCell: (params) => (
-          <TableCell>
+          <TableCell component={"div" as any}>
             <IconButton onClick={() => setModalData(params.row)}>
               <MoreHoriz />
             </IconButton>
@@ -379,8 +380,8 @@ export const Bookings: React.FC<BookingsProps> = ({
               headerName: "Services",
               minWidth: 240,
               flex: 1,
-              renderHeader: () => <TableCell>Services</TableCell>,
               filterable: false,
+              renderHeader: () => <TableCell component={"div" as any}>Services</TableCell>,
               renderCell: (params) => {
                 const bookingRow = params.row as BookingRow;
 
@@ -498,6 +499,7 @@ export const Bookings: React.FC<BookingsProps> = ({
 
                 return (
                   <TableCell
+                    component={"div" as any}
                     style={{
                       display: "flex",
                       flexDirection: "row",
@@ -587,10 +589,10 @@ export const Bookings: React.FC<BookingsProps> = ({
               headerName: "Equip.",
               minWidth: 80,
               flex: 1,
-              renderHeader: () => <TableCell>Equip.</TableCell>,
               filterable: false,
+              renderHeader: () => <TableCell component={"div" as any}>Equip.</TableCell>,
               renderCell: (params) => (
-                <TableCell>
+                <TableCell component={"div" as any}>
                   <EquipmentCartDisplay
                     booking={params.row}
                     onCartClick={() => setModalData(params.row)}
@@ -606,11 +608,11 @@ export const Bookings: React.FC<BookingsProps> = ({
         headerName: "Action",
         minWidth: 200,
         flex: 1,
-        renderHeader: () => <TableCell>Action</TableCell>,
         filterable: false,
         sortable: false,
+        renderHeader: () => <TableCell component={"div" as any}>Action</TableCell>,
         renderCell: (params) => (
-          <TableCell width={200}>
+          <TableCell component={"div" as any} width={200}>
             <BookingActions
               status={getBookingStatus(params.row, tenant)}
               calendarEventId={params.row.calendarEventId}

--- a/booking-app/components/src/client/routes/components/bookingTable/StackedTableCell.tsx
+++ b/booking-app/components/src/client/routes/components/bookingTable/StackedTableCell.tsx
@@ -15,7 +15,7 @@ const Stacked = styled(TableCell)({
 
 export default function StackedTableCell({ topText, bottomText }: Props) {
   return (
-    <Stacked>
+    <Stacked component={"div" as any}>
       <p>{topText}</p>
       <label>{bottomText}</label>
     </Stacked>

--- a/booking-app/components/src/client/routes/components/navBar.tsx
+++ b/booking-app/components/src/client/routes/components/navBar.tsx
@@ -52,8 +52,8 @@ const Divider = styled(Box)(({ theme }) => ({
 
 export default function NavBar() {
   const router = useRouter();
-  const { tenant } = useParams();
-  const { pagePermission, netId, setUserEmail } = useContext(DatabaseContext);
+  const { tenant } = useParams<{ tenant: string }>();
+  const { pagePermission, permissionsLoading, netId, setUserEmail } = useContext(DatabaseContext);
   const handleStartBooking = useHandleStartBooking();
   const [selectedView, setSelectedView] = useState<PagePermission>(
     PagePermission.BOOKING,
@@ -61,7 +61,6 @@ export default function NavBar() {
   const pathname = usePathname();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
-  const isRoot = pathname === "/";
   const tenantSchema = useContext(SchemaContext);
   const {
     name = "",
@@ -69,6 +68,27 @@ export default function NavBar() {
     supportVIP = false,
     supportWalkIn = false,
   } = tenantSchema || {};
+
+  // Check if we're on the tenant root (where redirect should happen)
+  const isRoot = pathname === "/" || (tenant && pathname === `/${tenant}`);
+
+  // Helper function to get URL path from PagePermission
+  const getPathFromPermission = (permission: PagePermission): string => {
+    switch (permission) {
+      case PagePermission.PA:
+        return "pa";
+      case PagePermission.ADMIN:
+        return "admin";
+      case PagePermission.LIAISON:
+        return "liaison";
+      case PagePermission.SERVICES:
+        return "services";
+      case PagePermission.SUPER_ADMIN:
+        return "super";
+      default:
+        return "";
+    }
+  };
 
   const handleRoleChange = (e: any) => {
     const pathOf = (x: string) => (tenant ? `/${tenant}/${x}` : `/${x}`);
@@ -97,11 +117,13 @@ export default function NavBar() {
 
   const handleClickHome = () => {
     setSelectedView(PagePermission.BOOKING);
+    sessionStorage.removeItem("hasRedirectedToDefaultContext");
     router.push(`/${tenant || ""}`);
   };
 
   const handleClickRoot = () => {
     setSelectedView(PagePermission.BOOKING);
+    sessionStorage.removeItem("hasRedirectedToDefaultContext");
     router.push("/");
   };
 
@@ -135,6 +157,7 @@ export default function NavBar() {
   const handleSignOut = async () => {
     try {
       await signOut(auth);
+      sessionStorage.removeItem("hasRedirectedToDefaultContext");
       console.log("Sign-out successful");
       router.push("/signin");
       setUserEmail(null);
@@ -142,6 +165,25 @@ export default function NavBar() {
       console.error("Sign-out error", error);
     }
   };
+
+  // Auto-redirect to highest priority role on tenant root
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (permissionsLoading) return;
+    if (!isRoot) return;
+    if (!tenant) return;
+
+    const hasRedirected = sessionStorage.getItem("hasRedirectedToDefaultContext");
+    if (hasRedirected) return;
+
+    if (pagePermission !== PagePermission.BOOKING) {
+      const targetPath = getPathFromPermission(pagePermission);
+      if (targetPath) {
+        router.push(`/${tenant}/${targetPath}`);
+        sessionStorage.setItem("hasRedirectedToDefaultContext", "true");
+      }
+    }
+  }, [pagePermission, permissionsLoading, tenant, router, isRoot]);
 
   const hasUserPermission = (roles: PagePermission[]) =>
     roles.includes(pagePermission);
@@ -153,6 +195,7 @@ export default function NavBar() {
         PagePermission.ADMIN,
         PagePermission.PA,
         PagePermission.LIAISON,
+        PagePermission.SERVICES,
         PagePermission.SUPER_ADMIN,
       ])
     ) {

--- a/booking-app/components/src/client/routes/components/navBar.tsx
+++ b/booking-app/components/src/client/routes/components/navBar.tsx
@@ -91,28 +91,10 @@ export default function NavBar() {
   };
 
   const handleRoleChange = (e: any) => {
-    const pathOf = (x: string) => (tenant ? `/${tenant}/${x}` : `/${x}`);
-
-    switch (e.target.value as PagePermission) {
-      case PagePermission.BOOKING:
-        router.push(pathOf(""));
-        break;
-      case PagePermission.PA:
-        router.push(pathOf("pa"));
-        break;
-      case PagePermission.ADMIN:
-        router.push(pathOf("admin"));
-        break;
-      case PagePermission.LIAISON:
-        router.push(pathOf("liaison"));
-        break;
-      case PagePermission.SERVICES:
-        router.push(pathOf("services"));
-        break;
-      case PagePermission.SUPER_ADMIN:
-        router.push(pathOf("super"));
-        break;
-    }
+    const role = e.target.value as PagePermission;
+    const path = getPathFromPermission(role);
+    const fullPath = tenant ? `/${tenant}/${path}` : `/${path}`;
+    router.push(fullPath);
   };
 
   const handleClickHome = () => {

--- a/booking-app/components/src/client/routes/components/navBar.tsx
+++ b/booking-app/components/src/client/routes/components/navBar.tsx
@@ -152,6 +152,12 @@ export default function NavBar() {
     } else if (pathname.includes("/super")) {
       setSelectedView(PagePermission.SUPER_ADMIN);
     }
+
+    // Clear redirect flag when navigating away from root
+    // so auto-redirect works when returning
+    if (!(pathname === "/" || isTenantRoot)) {
+      sessionStorage.removeItem("hasRedirectedToDefaultContext");
+    }
   }, [pathname]);
 
   const handleSignOut = async () => {

--- a/booking-app/components/src/client/routes/components/navBar.tsx
+++ b/booking-app/components/src/client/routes/components/navBar.tsx
@@ -53,7 +53,7 @@ const Divider = styled(Box)(({ theme }) => ({
 export default function NavBar() {
   const router = useRouter();
   const { tenant } = useParams<{ tenant: string }>();
-  const { pagePermission, permissionsLoading, netId, setUserEmail } = useContext(DatabaseContext);
+  const { pagePermission, netId, setUserEmail } = useContext(DatabaseContext);
   const handleStartBooking = useHandleStartBooking();
   const [selectedView, setSelectedView] = useState<PagePermission>(
     PagePermission.BOOKING,
@@ -69,8 +69,8 @@ export default function NavBar() {
     supportWalkIn = false,
   } = tenantSchema || {};
 
-  // Check if we're on the tenant root (where redirect should happen)
-  const isRoot = pathname === "/" || (tenant && pathname === `/${tenant}`);
+  // True app root ("/") — used to hide navbar chrome (no tenant context yet)
+  const isAppRoot = pathname === "/";
 
   // Helper function to get URL path from PagePermission
   const getPathFromPermission = (permission: PagePermission): string => {
@@ -93,7 +93,15 @@ export default function NavBar() {
   const handleRoleChange = (e: any) => {
     const role = e.target.value as PagePermission;
     const path = getPathFromPermission(role);
-    const fullPath = tenant ? `/${tenant}/${path}` : `/${path}`;
+    // Build path without trailing slash when switching to User context (path="")
+    const fullPath = path
+      ? tenant ? `/${tenant}/${path}` : `/${path}`
+      : `/${tenant || ""}`;
+    // When user explicitly selects User (BOOKING) context, prevent auto-redirect
+    // so they aren't immediately bounced back to their highest-privilege view.
+    if (role === PagePermission.BOOKING) {
+      sessionStorage.setItem("hasRedirectedToDefaultContext", "true");
+    }
     router.push(fullPath);
   };
 
@@ -153,25 +161,6 @@ export default function NavBar() {
       console.error("Sign-out error", error);
     }
   };
-
-  // Auto-redirect to highest priority role on tenant root
-  useEffect(() => {
-    if (typeof window === "undefined") return;
-    if (permissionsLoading) return;
-    if (!isRoot) return;
-    if (!tenant) return;
-
-    const hasRedirected = sessionStorage.getItem("hasRedirectedToDefaultContext");
-    if (hasRedirected) return;
-
-    if (pagePermission !== PagePermission.BOOKING) {
-      const targetPath = getPathFromPermission(pagePermission);
-      if (targetPath) {
-        router.push(`/${tenant}/${targetPath}`);
-        sessionStorage.setItem("hasRedirectedToDefaultContext", "true");
-      }
-    }
-  }, [pagePermission, permissionsLoading, tenant, router, isRoot]);
 
   const hasUserPermission = (roles: PagePermission[]) =>
     roles.includes(pagePermission);
@@ -303,7 +292,7 @@ export default function NavBar() {
             style={{ transform: "translateY(4px)", marginRight: 15 }}
           />
         </LogoBox> */}
-        {!isRoot && (
+        {!isAppRoot && (
           <LogoBox onClick={handleClickHome}>
             <img src={logo} alt={`${name} logo`} style={{ height: 40 }} />
             {!isMobile && (
@@ -315,7 +304,7 @@ export default function NavBar() {
         )}
       </div>
       <Box display="flex" alignItems="center">
-        {!isRoot && (
+        {!isAppRoot && (
           <>
             {button}
             {dropdown}

--- a/booking-app/components/src/client/routes/components/navBar.tsx
+++ b/booking-app/components/src/client/routes/components/navBar.tsx
@@ -17,6 +17,7 @@ import { auth } from "@/lib/firebase/firebaseClient";
 import { styled } from "@mui/system";
 import { signOut } from "firebase/auth";
 import { PagePermission } from "../../../types";
+import { PERMISSION_PATH } from "../../../utils/permissions";
 import useHandleStartBooking from "../booking/hooks/useHandleStartBooking";
 import ConfirmDialog from "./ConfirmDialog";
 import { DatabaseContext } from "./Provider";

--- a/booking-app/components/src/client/routes/components/navBar.tsx
+++ b/booking-app/components/src/client/routes/components/navBar.tsx
@@ -72,23 +72,9 @@ export default function NavBar() {
   // True app root ("/") — used to hide navbar chrome (no tenant context yet)
   const isAppRoot = pathname === "/";
 
-  // Helper function to get URL path from PagePermission
-  const getPathFromPermission = (permission: PagePermission): string => {
-    switch (permission) {
-      case PagePermission.PA:
-        return "pa";
-      case PagePermission.ADMIN:
-        return "admin";
-      case PagePermission.LIAISON:
-        return "liaison";
-      case PagePermission.SERVICES:
-        return "services";
-      case PagePermission.SUPER_ADMIN:
-        return "super";
-      default:
-        return "";
-    }
-  };
+  const getPathFromPermission = (permission: PagePermission): string =>
+    PERMISSION_PATH[permission] ?? "";
+
 
   const handleRoleChange = (e: any) => {
     const role = e.target.value as PagePermission;

--- a/booking-app/components/src/utils/permissions.ts
+++ b/booking-app/components/src/utils/permissions.ts
@@ -1,6 +1,18 @@
 import { PagePermission } from "../types";
 
 /**
+ * Maps privileged PagePermission values to their URL path segment.
+ * BOOKING is omitted — it maps to the tenant root, not a sub-path.
+ */
+export const PERMISSION_PATH: Partial<Record<PagePermission, string>> = {
+  [PagePermission.SUPER_ADMIN]: "super",
+  [PagePermission.ADMIN]: "admin",
+  [PagePermission.SERVICES]: "services",
+  [PagePermission.LIAISON]: "liaison",
+  [PagePermission.PA]: "pa",
+};
+
+/**
  * Permission hierarchy definition
  * Defines which lower-level permissions each permission includes
  */

--- a/booking-app/package-lock.json
+++ b/booking-app/package-lock.json
@@ -16295,21 +16295,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.30",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.30.tgz",
-      "integrity": "sha512-pVZMnFok5qEX4RT59mK2hEVtJX+XFfak+/rjHpyFh7juiT52r177bfFKhnlafm0UOSldhXjj32b+LZIOdswGTg==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
     }
   }
 }

--- a/booking-app/package-lock.json
+++ b/booking-app/package-lock.json
@@ -16295,6 +16295,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.30",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.30.tgz",
+      "integrity": "sha512-pVZMnFok5qEX4RT59mK2hEVtJX+XFfak+/rjHpyFh7juiT52r177bfFKhnlafm0UOSldhXjj32b+LZIOdswGTg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/booking-app/tests/unit/navbar-redirect.unit.test.ts
+++ b/booking-app/tests/unit/navbar-redirect.unit.test.ts
@@ -1,0 +1,350 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PagePermission } from "../../components/src/types";
+
+// Mock sessionStorage
+const createMockSessionStorage = () => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] || null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    _getStore: () => store,
+  };
+};
+
+/**
+ * Helper function matching navBar.tsx getPathFromPermission
+ */
+const getPathFromPermission = (permission: PagePermission): string => {
+  switch (permission) {
+    case PagePermission.PA:
+      return "pa";
+    case PagePermission.ADMIN:
+      return "admin";
+    case PagePermission.LIAISON:
+      return "liaison";
+    case PagePermission.SERVICES:
+      return "services";
+    case PagePermission.SUPER_ADMIN:
+      return "super";
+    default:
+      return "";
+  }
+};
+
+/**
+ * Simulates the core redirect logic from navBar.tsx useEffect
+ */
+const simulateRedirectLogic = (params: {
+  isRoot: boolean;
+  tenant: string | undefined;
+  pagePermission: PagePermission;
+  permissionsLoading: boolean;
+  hasRedirectedFlag: boolean;
+}): { shouldRedirect: boolean; targetPath: string | null } => {
+  const { isRoot, tenant, pagePermission, permissionsLoading, hasRedirectedFlag } = params;
+
+  // Match navBar.tsx conditions
+  if (permissionsLoading) return { shouldRedirect: false, targetPath: null };
+  if (!isRoot) return { shouldRedirect: false, targetPath: null };
+  if (!tenant) return { shouldRedirect: false, targetPath: null };
+  if (hasRedirectedFlag) return { shouldRedirect: false, targetPath: null };
+  if (pagePermission === PagePermission.BOOKING) {
+    return { shouldRedirect: false, targetPath: null };
+  }
+
+  const targetPath = getPathFromPermission(pagePermission);
+  if (targetPath) {
+    return { shouldRedirect: true, targetPath: `/${tenant}/${targetPath}` };
+  }
+  return { shouldRedirect: false, targetPath: null };
+};
+
+/**
+ * Simulates the isRoot calculation from navBar.tsx
+ */
+const calculateIsRoot = (pathname: string, tenant: string | undefined): boolean => {
+  return pathname === "/" || (!!tenant && pathname === `/${tenant}`);
+};
+
+describe("NavBar Redirect Logic", () => {
+  let mockSessionStorage: ReturnType<typeof createMockSessionStorage>;
+
+  beforeEach(() => {
+    mockSessionStorage = createMockSessionStorage();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("getPathFromPermission", () => {
+    it("returns 'admin' for ADMIN permission", () => {
+      expect(getPathFromPermission(PagePermission.ADMIN)).toBe("admin");
+    });
+
+    it("returns 'pa' for PA permission", () => {
+      expect(getPathFromPermission(PagePermission.PA)).toBe("pa");
+    });
+
+    it("returns 'liaison' for LIAISON permission", () => {
+      expect(getPathFromPermission(PagePermission.LIAISON)).toBe("liaison");
+    });
+
+    it("returns 'services' for SERVICES permission", () => {
+      expect(getPathFromPermission(PagePermission.SERVICES)).toBe("services");
+    });
+
+    it("returns 'super' for SUPER_ADMIN permission", () => {
+      expect(getPathFromPermission(PagePermission.SUPER_ADMIN)).toBe("super");
+    });
+
+    it("returns empty string for BOOKING permission", () => {
+      expect(getPathFromPermission(PagePermission.BOOKING)).toBe("");
+    });
+  });
+
+  describe("calculateIsRoot", () => {
+    it("returns true for root path '/'", () => {
+      expect(calculateIsRoot("/", undefined)).toBe(true);
+    });
+
+    it("returns true for tenant root '/media-commons'", () => {
+      expect(calculateIsRoot("/media-commons", "media-commons")).toBe(true);
+    });
+
+    it("returns false for non-root paths", () => {
+      expect(calculateIsRoot("/media-commons/admin", "media-commons")).toBe(false);
+      expect(calculateIsRoot("/media-commons/pa", "media-commons")).toBe(false);
+      expect(calculateIsRoot("/media-commons/modification/123", "media-commons")).toBe(false);
+    });
+  });
+
+  describe("Auto-redirect to highest priority role", () => {
+    it("redirects ADMIN users to /tenant/admin on root page", () => {
+      const result = simulateRedirectLogic({
+        isRoot: true,
+        tenant: "media-commons",
+        pagePermission: PagePermission.ADMIN,
+        permissionsLoading: false,
+        hasRedirectedFlag: false,
+      });
+
+      expect(result.shouldRedirect).toBe(true);
+      expect(result.targetPath).toBe("/media-commons/admin");
+    });
+
+    it("redirects LIAISON users to /tenant/liaison on root page", () => {
+      const result = simulateRedirectLogic({
+        isRoot: true,
+        tenant: "media-commons",
+        pagePermission: PagePermission.LIAISON,
+        permissionsLoading: false,
+        hasRedirectedFlag: false,
+      });
+
+      expect(result.shouldRedirect).toBe(true);
+      expect(result.targetPath).toBe("/media-commons/liaison");
+    });
+
+    it("redirects SERVICES users to /tenant/services on root page", () => {
+      const result = simulateRedirectLogic({
+        isRoot: true,
+        tenant: "media-commons",
+        pagePermission: PagePermission.SERVICES,
+        permissionsLoading: false,
+        hasRedirectedFlag: false,
+      });
+
+      expect(result.shouldRedirect).toBe(true);
+      expect(result.targetPath).toBe("/media-commons/services");
+    });
+
+    it("redirects PA users to /tenant/pa on root page", () => {
+      const result = simulateRedirectLogic({
+        isRoot: true,
+        tenant: "media-commons",
+        pagePermission: PagePermission.PA,
+        permissionsLoading: false,
+        hasRedirectedFlag: false,
+      });
+
+      expect(result.shouldRedirect).toBe(true);
+      expect(result.targetPath).toBe("/media-commons/pa");
+    });
+
+    it("redirects SUPER_ADMIN users to /tenant/super on root page", () => {
+      const result = simulateRedirectLogic({
+        isRoot: true,
+        tenant: "media-commons",
+        pagePermission: PagePermission.SUPER_ADMIN,
+        permissionsLoading: false,
+        hasRedirectedFlag: false,
+      });
+
+      expect(result.shouldRedirect).toBe(true);
+      expect(result.targetPath).toBe("/media-commons/super");
+    });
+
+    it("does NOT redirect BOOKING users (regular students stay on root)", () => {
+      const result = simulateRedirectLogic({
+        isRoot: true,
+        tenant: "media-commons",
+        pagePermission: PagePermission.BOOKING,
+        permissionsLoading: false,
+        hasRedirectedFlag: false,
+      });
+
+      expect(result.shouldRedirect).toBe(false);
+      expect(result.targetPath).toBeNull();
+    });
+  });
+
+  describe("Redirect prevention conditions", () => {
+    it("does NOT redirect if already redirected this session", () => {
+      const result = simulateRedirectLogic({
+        isRoot: true,
+        tenant: "media-commons",
+        pagePermission: PagePermission.ADMIN,
+        permissionsLoading: false,
+        hasRedirectedFlag: true, // Already redirected
+      });
+
+      expect(result.shouldRedirect).toBe(false);
+    });
+
+    it("does NOT redirect if not on root page", () => {
+      const result = simulateRedirectLogic({
+        isRoot: false, // Not on root
+        tenant: "media-commons",
+        pagePermission: PagePermission.ADMIN,
+        permissionsLoading: false,
+        hasRedirectedFlag: false,
+      });
+
+      expect(result.shouldRedirect).toBe(false);
+    });
+
+    it("does NOT redirect if tenant is not available", () => {
+      const result = simulateRedirectLogic({
+        isRoot: true,
+        tenant: undefined, // No tenant
+        pagePermission: PagePermission.ADMIN,
+        permissionsLoading: false,
+        hasRedirectedFlag: false,
+      });
+
+      expect(result.shouldRedirect).toBe(false);
+    });
+
+    it("does NOT redirect while permissions are still loading", () => {
+      const result = simulateRedirectLogic({
+        isRoot: true,
+        tenant: "media-commons",
+        pagePermission: PagePermission.ADMIN,
+        permissionsLoading: true, // Still loading
+        hasRedirectedFlag: false,
+      });
+
+      expect(result.shouldRedirect).toBe(false);
+    });
+  });
+
+  describe("Session storage flag management", () => {
+    it("flag should be cleared on sign-out (simulated)", () => {
+      mockSessionStorage.setItem("hasRedirectedToDefaultContext", "true");
+      expect(mockSessionStorage.getItem("hasRedirectedToDefaultContext")).toBe("true");
+
+      // Simulate sign-out clearing the flag
+      mockSessionStorage.removeItem("hasRedirectedToDefaultContext");
+
+      expect(mockSessionStorage.getItem("hasRedirectedToDefaultContext")).toBeNull();
+    });
+
+    it("flag should be cleared when clicking home logo (simulated)", () => {
+      mockSessionStorage.setItem("hasRedirectedToDefaultContext", "true");
+
+      // Simulate handleClickHome clearing the flag
+      mockSessionStorage.removeItem("hasRedirectedToDefaultContext");
+
+      expect(mockSessionStorage.getItem("hasRedirectedToDefaultContext")).toBeNull();
+    });
+
+    it("flag should be cleared when navigating away from root (simulated)", () => {
+      mockSessionStorage.setItem("hasRedirectedToDefaultContext", "true");
+
+      // Simulate navigating to /media-commons/modification/123 which clears flag
+      const pathname: string = "/media-commons/modification/123";
+      const isTenantRoot = /^\/[^/]+$/.test(pathname);
+      const isRootOrTenantRoot = pathname === "/" || isTenantRoot;
+
+      if (!isRootOrTenantRoot) {
+        mockSessionStorage.removeItem("hasRedirectedToDefaultContext");
+      }
+
+      expect(mockSessionStorage.getItem("hasRedirectedToDefaultContext")).toBeNull();
+    });
+
+    it("flag should be set after successful redirect", () => {
+      const result = simulateRedirectLogic({
+        isRoot: true,
+        tenant: "media-commons",
+        pagePermission: PagePermission.PA,
+        permissionsLoading: false,
+        hasRedirectedFlag: false,
+      });
+
+      if (result.shouldRedirect) {
+        mockSessionStorage.setItem("hasRedirectedToDefaultContext", "true");
+      }
+
+      expect(mockSessionStorage.getItem("hasRedirectedToDefaultContext")).toBe("true");
+    });
+  });
+
+  describe("PA user modification flow", () => {
+    it("PA user redirects to /pa on initial visit", () => {
+      const result = simulateRedirectLogic({
+        isRoot: true,
+        tenant: "media-commons",
+        pagePermission: PagePermission.PA,
+        permissionsLoading: false,
+        hasRedirectedFlag: false,
+      });
+
+      expect(result.shouldRedirect).toBe(true);
+      expect(result.targetPath).toBe("/media-commons/pa");
+    });
+
+    it("PA user can return to root after modification (flag cleared)", () => {
+      // Initially redirected
+      mockSessionStorage.setItem("hasRedirectedToDefaultContext", "true");
+
+      // Navigate to modification page (which clears flag per navBar logic)
+      const modificationPath = "/media-commons/modification/abc123";
+      const isTenantRoot = /^\/[^/]+$/.test(modificationPath);
+      if (!(modificationPath === "/" || isTenantRoot)) {
+        mockSessionStorage.removeItem("hasRedirectedToDefaultContext");
+      }
+
+      // Return to root - should redirect again
+      const result = simulateRedirectLogic({
+        isRoot: true,
+        tenant: "media-commons",
+        pagePermission: PagePermission.PA,
+        permissionsLoading: false,
+        hasRedirectedFlag: mockSessionStorage.getItem("hasRedirectedToDefaultContext") === "true",
+      });
+
+      expect(result.shouldRedirect).toBe(true);
+      expect(result.targetPath).toBe("/media-commons/pa");
+    });
+  });
+});

--- a/booking-app/tests/unit/navbar-redirect.unit.test.ts
+++ b/booking-app/tests/unit/navbar-redirect.unit.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PagePermission } from "../../components/src/types";
+import { PERMISSION_PATH } from "../../components/src/utils/permissions";
 
 // Mock sessionStorage
 const createMockSessionStorage = () => {
@@ -20,27 +21,13 @@ const createMockSessionStorage = () => {
 };
 
 /**
- * Helper function matching navBar.tsx getPathFromPermission
+ * Helper function using the shared PERMISSION_PATH mapping from permissions.ts
  */
-const getPathFromPermission = (permission: PagePermission): string => {
-  switch (permission) {
-    case PagePermission.PA:
-      return "pa";
-    case PagePermission.ADMIN:
-      return "admin";
-    case PagePermission.LIAISON:
-      return "liaison";
-    case PagePermission.SERVICES:
-      return "services";
-    case PagePermission.SUPER_ADMIN:
-      return "super";
-    default:
-      return "";
-  }
-};
+const getPathFromPermission = (permission: PagePermission): string =>
+  PERMISSION_PATH[permission] ?? "";
 
 /**
- * Simulates the core redirect logic from navBar.tsx useEffect
+ * Simulates the core redirect logic from app/[tenant]/page.tsx useEffect
  */
 const simulateRedirectLogic = (params: {
   isRoot: boolean;
@@ -51,7 +38,7 @@ const simulateRedirectLogic = (params: {
 }): { shouldRedirect: boolean; targetPath: string | null } => {
   const { isRoot, tenant, pagePermission, permissionsLoading, hasRedirectedFlag } = params;
 
-  // Match navBar.tsx conditions
+  // Match page.tsx conditions
   if (permissionsLoading) return { shouldRedirect: false, targetPath: null };
   if (!isRoot) return { shouldRedirect: false, targetPath: null };
   if (!tenant) return { shouldRedirect: false, targetPath: null };
@@ -68,7 +55,7 @@ const simulateRedirectLogic = (params: {
 };
 
 /**
- * Simulates isRedirectRoot from navBar.tsx (used only for auto-redirect trigger)
+ * Simulates the tenant-root check used in app/[tenant]/page.tsx (auto-redirect trigger)
  */
 const calculateIsRedirectRoot = (pathname: string, tenant: string | undefined): boolean => {
   return pathname === "/" || (!!tenant && pathname === `/${tenant}`);

--- a/booking-app/tests/unit/navbar-redirect.unit.test.ts
+++ b/booking-app/tests/unit/navbar-redirect.unit.test.ts
@@ -68,10 +68,17 @@ const simulateRedirectLogic = (params: {
 };
 
 /**
- * Simulates the isRoot calculation from navBar.tsx
+ * Simulates isRedirectRoot from navBar.tsx (used only for auto-redirect trigger)
  */
-const calculateIsRoot = (pathname: string, tenant: string | undefined): boolean => {
+const calculateIsRedirectRoot = (pathname: string, tenant: string | undefined): boolean => {
   return pathname === "/" || (!!tenant && pathname === `/${tenant}`);
+};
+
+/**
+ * Simulates isAppRoot from navBar.tsx (used for hiding navbar chrome)
+ */
+const calculateIsAppRoot = (pathname: string): boolean => {
+  return pathname === "/";
 };
 
 describe("NavBar Redirect Logic", () => {
@@ -111,19 +118,35 @@ describe("NavBar Redirect Logic", () => {
     });
   });
 
-  describe("calculateIsRoot", () => {
+  describe("calculateIsRedirectRoot", () => {
     it("returns true for root path '/'", () => {
-      expect(calculateIsRoot("/", undefined)).toBe(true);
+      expect(calculateIsRedirectRoot("/", undefined)).toBe(true);
     });
 
     it("returns true for tenant root '/media-commons'", () => {
-      expect(calculateIsRoot("/media-commons", "media-commons")).toBe(true);
+      expect(calculateIsRedirectRoot("/media-commons", "media-commons")).toBe(true);
     });
 
     it("returns false for non-root paths", () => {
-      expect(calculateIsRoot("/media-commons/admin", "media-commons")).toBe(false);
-      expect(calculateIsRoot("/media-commons/pa", "media-commons")).toBe(false);
-      expect(calculateIsRoot("/media-commons/modification/123", "media-commons")).toBe(false);
+      expect(calculateIsRedirectRoot("/media-commons/admin", "media-commons")).toBe(false);
+      expect(calculateIsRedirectRoot("/media-commons/pa", "media-commons")).toBe(false);
+      expect(calculateIsRedirectRoot("/media-commons/modification/123", "media-commons")).toBe(false);
+    });
+  });
+
+  describe("calculateIsAppRoot (navbar chrome visibility)", () => {
+    it("returns true only for the literal app root '/'", () => {
+      expect(calculateIsAppRoot("/")).toBe(true);
+    });
+
+    it("returns false for tenant root — dropdown/logo must be visible on User page", () => {
+      expect(calculateIsAppRoot("/media-commons")).toBe(false);
+    });
+
+    it("returns false for all sub-pages", () => {
+      expect(calculateIsAppRoot("/media-commons/admin")).toBe(false);
+      expect(calculateIsAppRoot("/media-commons/pa")).toBe(false);
+      expect(calculateIsAppRoot("/media-commons/modification/123")).toBe(false);
     });
   });
 
@@ -345,6 +368,100 @@ describe("NavBar Redirect Logic", () => {
 
       expect(result.shouldRedirect).toBe(true);
       expect(result.targetPath).toBe("/media-commons/pa");
+    });
+  });
+
+  describe("User tab accessibility (bug fix)", () => {
+    /**
+     * Simulates handleRoleChange selecting BOOKING (User) tab.
+     * The fix: set the hasRedirectedToDefaultContext flag before navigating to root
+     * so the auto-redirect useEffect does NOT immediately bounce the user back.
+     */
+    const simulateHandleRoleChangeToUser = (
+      tenant: string,
+      storage: ReturnType<typeof createMockSessionStorage>
+    ): string => {
+      const role = PagePermission.BOOKING;
+      const path = ""; // getPathFromPermission(BOOKING) returns ""
+      // Fixed path construction: no trailing slash when path is empty
+      const fullPath = path ? `/${tenant}/${path}` : `/${tenant}`;
+      // Fix: set flag so auto-redirect does not fire
+      storage.setItem("hasRedirectedToDefaultContext", "true");
+      return fullPath;
+    };
+
+    it("Admin can navigate to User context without being bounced back", () => {
+      // Step 1: admin was auto-redirected to /admin earlier, which cleared the flag
+      mockSessionStorage.removeItem("hasRedirectedToDefaultContext");
+
+      // Step 2: admin selects 'User' from dropdown
+      const targetPath = simulateHandleRoleChangeToUser("media-commons", mockSessionStorage);
+      expect(targetPath).toBe("/media-commons");
+
+      // Step 3: flag should now be set to prevent auto-redirect
+      expect(mockSessionStorage.getItem("hasRedirectedToDefaultContext")).toBe("true");
+
+      // Step 4: auto-redirect logic should NOT redirect away from root
+      const result = simulateRedirectLogic({
+        isRoot: true,
+        tenant: "media-commons",
+        pagePermission: PagePermission.ADMIN,
+        permissionsLoading: false,
+        hasRedirectedFlag: mockSessionStorage.getItem("hasRedirectedToDefaultContext") === "true",
+      });
+
+      expect(result.shouldRedirect).toBe(false);
+    });
+
+    it("PA can navigate to User context without being bounced back", () => {
+      mockSessionStorage.removeItem("hasRedirectedToDefaultContext");
+
+      simulateHandleRoleChangeToUser("media-commons", mockSessionStorage);
+
+      const result = simulateRedirectLogic({
+        isRoot: true,
+        tenant: "media-commons",
+        pagePermission: PagePermission.PA,
+        permissionsLoading: false,
+        hasRedirectedFlag: mockSessionStorage.getItem("hasRedirectedToDefaultContext") === "true",
+      });
+
+      expect(result.shouldRedirect).toBe(false);
+    });
+
+    it("after User tab visit, navigating away clears flag and next root visit redirects to default", () => {
+      // User selects 'User' tab → flag set
+      simulateHandleRoleChangeToUser("media-commons", mockSessionStorage);
+      expect(mockSessionStorage.getItem("hasRedirectedToDefaultContext")).toBe("true");
+
+      // User navigates to /mc/book (non-root) → flag cleared by pathname effect
+      const bookPath = "/media-commons/book";
+      const isTenantRoot = /^\/[^/]+$/.test(bookPath);
+      if (!(bookPath === "/" || isTenantRoot)) {
+        mockSessionStorage.removeItem("hasRedirectedToDefaultContext");
+      }
+      expect(mockSessionStorage.getItem("hasRedirectedToDefaultContext")).toBeNull();
+
+      // User returns to root → auto-redirect fires again (PA/Admin goes to their default)
+      const result = simulateRedirectLogic({
+        isRoot: true,
+        tenant: "media-commons",
+        pagePermission: PagePermission.ADMIN,
+        permissionsLoading: false,
+        hasRedirectedFlag: false,
+      });
+
+      expect(result.shouldRedirect).toBe(true);
+      expect(result.targetPath).toBe("/media-commons/admin");
+    });
+
+    it("User context path has no trailing slash", () => {
+      // Regression: old code produced '/${tenant}/' which is different from isRoot check
+      const path = ""; // getPathFromPermission(BOOKING)
+      const tenant = "mc";
+      const fullPath = path ? `/${tenant}/${path}` : `/${tenant}`;
+      expect(fullPath).toBe("/mc");
+      expect(fullPath.endsWith("/")).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary of Changes

This is to address https://github.com/ITPNYU/booking-app/issues/1110 and 
https://github.com/ITPNYU/booking-app/issues/677, and is a refactored version of https://github.com/ITPNYU/booking-app/pull/1193. 

`Provider.tsx` state that tracks when admin/PA/approver user lists finish loading
`navBar.tsx` Added auto-redirect logic that runs once permissions load - redirects users to their highest priority role (super > admin > services > liaison > pa > booking)

Fixed `use(params)` hook in 7 client component pages that were for some reason incorrectly using React's `use()` hook (for server components) instead of `useParams()`

Added logic to clear `sessionStorage` redirect flag when navigating away from root, so auto-redirect works when returning

## Checklist

- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [x] I attached screenshots or a video demonstrating the feature
- [x] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversation as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [x] I requested a code review from at least one other teammate

## Screenshots / Video

https://github.com/user-attachments/assets/74c7ae21-4c58-405f-905e-1ae58de9657a

