### PR TITLE
Fix: deleting blackout periods doesn't work

### DIFF
--- a/booking-app/lib/firebase/firebase.ts
+++ b/booking-app/lib/firebase/firebase.ts
@@ -38,7 +38,7 @@ export const getCurrentTenant = (): string | undefined => {
 
 // Helper function to get tenant-specific collection name
 export const getTenantCollection = (
-  baseCollection: TableNames,
+  baseCollection: string,
   tenant?: string,
 ): string => {
   const tenantToUse = tenant || getCurrentTenant();
@@ -57,10 +57,7 @@ export const clientDeleteDataFromFirestore = async (
 ) => {
   try {
     const db = getDb();
-    const tenantCollection = getTenantCollection(
-      collectionName as TableNames,
-      tenant,
-    );
+    const tenantCollection = getTenantCollection(collectionName, tenant);
     await deleteDoc(doc(db, tenantCollection, docId));
     console.log("Document successfully deleted with ID:", docId);
   } catch (error) {
@@ -147,10 +144,7 @@ export const clientSaveDataToFirestore = async (
 ) => {
   try {
     const db = getDb();
-    const tenantCollection = getTenantCollection(
-      collectionName as TableNames,
-      tenant,
-    );
+    const tenantCollection = getTenantCollection(collectionName, tenant);
     const docRef = await addDoc(collection(db, tenantCollection), data);
 
     console.log("Document successfully written with ID:", docRef.id);

--- a/booking-app/lib/firebase/firebase.ts
+++ b/booking-app/lib/firebase/firebase.ts
@@ -53,10 +53,15 @@ export type AdminUserData = {
 export const clientDeleteDataFromFirestore = async (
   collectionName: string,
   docId: string,
+  tenant?: string,
 ) => {
   try {
     const db = getDb();
-    await deleteDoc(doc(db, collectionName, docId));
+    const tenantCollection = getTenantCollection(
+      collectionName as TableNames,
+      tenant,
+    );
+    await deleteDoc(doc(db, tenantCollection, docId));
     console.log("Document successfully deleted with ID:", docId);
   } catch (error) {
     console.error("Error deleting document: ", error);
@@ -138,10 +143,15 @@ export const clientDeleteUserRightsData = async (
 export const clientSaveDataToFirestore = async (
   collectionName: string,
   data: object,
+  tenant?: string,
 ) => {
   try {
     const db = getDb();
-    const docRef = await addDoc(collection(db, collectionName), data);
+    const tenantCollection = getTenantCollection(
+      collectionName as TableNames,
+      tenant,
+    );
+    const docRef = await addDoc(collection(db, tenantCollection), data);
 
     console.log("Document successfully written with ID:", docRef.id);
   } catch (error) {

--- a/booking-app/tests/unit/firebase-client-tenant.unit.test.ts
+++ b/booking-app/tests/unit/firebase-client-tenant.unit.test.ts
@@ -51,6 +51,10 @@ describe("clientDeleteDataFromFirestore — tenant collection resolution", () =>
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it("uses the tenant-prefixed collection when the URL contains a tenant segment", async () => {
     vi.stubGlobal("location", { pathname: "/mc/admin/settings/policy" });
 
@@ -113,6 +117,10 @@ describe("clientSaveDataToFirestore — tenant collection resolution", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("uses the tenant-prefixed collection when the URL contains a tenant segment", async () => {

--- a/booking-app/tests/unit/firebase-client-tenant.unit.test.ts
+++ b/booking-app/tests/unit/firebase-client-tenant.unit.test.ts
@@ -1,0 +1,169 @@
+import { TableNames } from "@/components/src/policy";
+import {
+  clientDeleteDataFromFirestore,
+  clientSaveDataToFirestore,
+} from "@/lib/firebase/firebase";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockDeleteDoc = vi.fn().mockResolvedValue(undefined);
+const mockAddDoc = vi.fn().mockResolvedValue({ id: "new-doc-id" });
+const mockDoc = vi.fn((_db, collectionName, docId) => ({
+  _collection: collectionName,
+  _id: docId,
+}));
+const mockCollection = vi.fn((_db, collectionName) => ({
+  _collection: collectionName,
+}));
+
+vi.mock("firebase/firestore", () => ({
+  deleteDoc: (...args: any[]) => mockDeleteDoc(...args),
+  addDoc: (...args: any[]) => mockAddDoc(...args),
+  doc: (...args: any[]) => mockDoc(...args),
+  collection: (...args: any[]) => mockCollection(...args),
+  getDocs: vi.fn().mockResolvedValue({ docs: [] }),
+  getDoc: vi.fn(),
+  updateDoc: vi.fn(),
+  setDoc: vi.fn(),
+  query: vi.fn((ref) => ref),
+  where: vi.fn(),
+  orderBy: vi.fn(),
+  limit: vi.fn(),
+  startAfter: vi.fn(),
+  Timestamp: {
+    now: vi.fn(() => ({ toDate: () => new Date() })),
+    fromDate: vi.fn((d: Date) => ({ toDate: () => d })),
+  },
+}));
+
+vi.mock("@/lib/firebase/firebaseClient", () => ({
+  getDb: vi.fn().mockReturnValue({}),
+  initializeDb: vi.fn(),
+}));
+
+vi.mock("@/components/src/types", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual };
+});
+vi.mock("@/components/src/client/routes/components/SchemaProvider", () => ({}));
+
+describe("clientDeleteDataFromFirestore — tenant collection resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the tenant-prefixed collection when the URL contains a tenant segment", async () => {
+    vi.stubGlobal("location", { pathname: "/mc/admin/settings/policy" });
+
+    await clientDeleteDataFromFirestore(TableNames.BLACKOUT_PERIODS, "period-1");
+
+    expect(mockDoc).toHaveBeenCalledWith(
+      expect.anything(),
+      "mc-blackoutPeriods",
+      "period-1",
+    );
+    expect(mockDeleteDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the base collection name for non-tenant-specific collections", async () => {
+    vi.stubGlobal("location", { pathname: "/mc/admin/settings/policy" });
+
+    await clientDeleteDataFromFirestore("settings", "settings-1");
+
+    expect(mockDoc).toHaveBeenCalledWith(
+      expect.anything(),
+      "settings",
+      "settings-1",
+    );
+    expect(mockDeleteDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the base collection name when no tenant is in the URL", async () => {
+    vi.stubGlobal("location", { pathname: "/" });
+
+    await clientDeleteDataFromFirestore(TableNames.BLACKOUT_PERIODS, "period-1");
+
+    expect(mockDoc).toHaveBeenCalledWith(
+      expect.anything(),
+      "blackoutPeriods",
+      "period-1",
+    );
+    expect(mockDeleteDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects an explicit tenant argument over the URL", async () => {
+    vi.stubGlobal("location", { pathname: "/other/path" });
+
+    await clientDeleteDataFromFirestore(
+      TableNames.BLACKOUT_PERIODS,
+      "period-1",
+      "mc",
+    );
+
+    expect(mockDoc).toHaveBeenCalledWith(
+      expect.anything(),
+      "mc-blackoutPeriods",
+      "period-1",
+    );
+    expect(mockDeleteDoc).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("clientSaveDataToFirestore — tenant collection resolution", () => {
+  const sampleData = { name: "Winter Break", isActive: true };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses the tenant-prefixed collection when the URL contains a tenant segment", async () => {
+    vi.stubGlobal("location", { pathname: "/mc/admin/settings/policy" });
+
+    await clientSaveDataToFirestore(TableNames.BLACKOUT_PERIODS, sampleData);
+
+    expect(mockCollection).toHaveBeenCalledWith(
+      expect.anything(),
+      "mc-blackoutPeriods",
+    );
+    expect(mockAddDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the base collection name for non-tenant-specific collections", async () => {
+    vi.stubGlobal("location", { pathname: "/mc/admin/settings/policy" });
+
+    await clientSaveDataToFirestore("departments", sampleData);
+
+    expect(mockCollection).toHaveBeenCalledWith(
+      expect.anything(),
+      "departments",
+    );
+    expect(mockAddDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the base collection name when no tenant is in the URL", async () => {
+    vi.stubGlobal("location", { pathname: "/" });
+
+    await clientSaveDataToFirestore(TableNames.BLACKOUT_PERIODS, sampleData);
+
+    expect(mockCollection).toHaveBeenCalledWith(
+      expect.anything(),
+      "blackoutPeriods",
+    );
+    expect(mockAddDoc).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects an explicit tenant argument over the URL", async () => {
+    vi.stubGlobal("location", { pathname: "/other/path" });
+
+    await clientSaveDataToFirestore(
+      TableNames.BLACKOUT_PERIODS,
+      sampleData,
+      "mc",
+    );
+
+    expect(mockCollection).toHaveBeenCalledWith(
+      expect.anything(),
+      "mc-blackoutPeriods",
+    );
+    expect(mockAddDoc).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary of Changes

`clientDeleteDataFromFirestore` and `clientSaveDataToFirestore` were deleting from the wrong Firestore collection because they used the base collection name instead of the tenant-prefixed one. Both were updated to call `getTenantCollection()` before operations so they align with the fetch and update logic.

## Checklist

- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature
- [x] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversation as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate