### PR TITLE
Fix staging crash: write New Relic log to /tmp on read-only filesystem

### DIFF
--- a/booking-app/newrelic.js
+++ b/booking-app/newrelic.js
@@ -36,6 +36,7 @@ exports.config = {
      * production applications.
      */
     level: process.env.NEW_RELIC_LOG_LEVEL || "info",
+    filepath: "/tmp/newrelic_agent.log",
   },
   /**
    * When true, all request headers except for those listed in attributes.exclude


### PR DESCRIPTION
## Summary of Changes

App Engine basic_scaling uses a read-only filesystem, causing New Relic to crash with EROFS when writing to /workspace/newrelic_agent.log.

## Checklist

- [ ] I checked for existing implementations and confirmed there is no duplication
- [ ] I thoroughly tested this feature locally
- [ ] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversation as resolved
- [ ] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [ ] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video

<!-- Attach screenshots or a video demonstrating the feature here -->
