### PR TITLE
Add NEXT_PUBLIC_BASE_URL and CRON_SECRET to CI env

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -26,6 +26,8 @@ jobs:
       NEXT_PUBLIC_MEASUREMENT_ID: test-measurement-id
       NEXT_PUBLIC_DATABASE_NAME: test-database
       NEXT_PUBLIC_BRANCH_NAME: development-local
+      NEXT_PUBLIC_BASE_URL: http://localhost:3000
+      CRON_SECRET: test-cron-secret-for-e2e
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary of Changes

Add missing environment variables to the E2E CI workflow.

- Add `NEXT_PUBLIC_BASE_URL=http://localhost:3000` — without this, `useSubmitBooking` fetch URLs resolve to `undefined/api/...` causing E2E tests that submit bookings to fail
- Add `CRON_SECRET=test-cron-secret-for-e2e` — needed for cron-related test coverage

## Checklist

- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [ ] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversation as resolved
- [ ] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [ ] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video

N/A - CI environment variable addition only