### PR TITLE
Fix staging startup: skip /_ah/ paths in Next.js middleware

### DIFF
--- a/booking-app/middleware.ts
+++ b/booking-app/middleware.ts
@@ -14,9 +14,10 @@ export function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // Skip API routes and static files
+  // Skip API routes, App Engine health checks, and static files
   if (
     pathname.startsWith("/api") ||
+    pathname.startsWith("/_ah/") ||
     pathname.includes(".") ||
     pathname.startsWith("/$dash")
   ) {


### PR DESCRIPTION
The middleware was redirecting App Engine's /_ah/start health check to /mc/_ah/start (307), causing instance startup to fail. Basic scaling requires /_ah/start to return 200-299 or 404.

## Summary of Changes

<!-- Briefly describe what was changed and why -->

## Checklist

- [ ] I checked for existing implementations and confirmed there is no duplication
- [ ] I thoroughly tested this feature locally
- [ ] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversation as resolved
- [ ] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [ ] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video

<!-- Attach screenshots or a video demonstrating the feature here -->
