### PR TITLE
Add health check after staging start to verify it's accessible

### DIFF
--- a/.github/workflows/staging-control.yml
+++ b/.github/workflows/staging-control.yml
@@ -40,3 +40,20 @@ jobs:
             gcloud app versions ${{ inputs.action }} $VERSION --service=staging --project=${{ secrets.GCP_PROJECT_ID }} --quiet
           done
           echo "Done. Staging is now ${{ inputs.action == 'start' && 'started' || 'stopped' }}."
+
+      - name: Verify staging is accessible
+        if: inputs.action == 'start'
+        run: |
+          URL="https://staging-dot-${{ secrets.GCP_PROJECT_ID }}.uc.r.appspot.com/"
+          echo "Waiting for staging to become accessible at $URL"
+          for i in $(seq 1 30); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$URL" || true)
+            echo "Attempt $i: HTTP $STATUS"
+            if [ "$STATUS" -ge 200 ] && [ "$STATUS" -lt 400 ]; then
+              echo "Staging is up and responding."
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "ERROR: Staging did not become accessible within 5 minutes."
+          exit 1


### PR DESCRIPTION
Polls the staging URL for up to 5 minutes after start, failing the workflow if it never returns a 2xx/3xx response.

## Summary of Changes

<!-- Briefly describe what was changed and why -->

## Checklist

- [ ] I checked for existing implementations and confirmed there is no duplication
- [ ] I thoroughly tested this feature locally
- [ ] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversation as resolved
- [ ] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [ ] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video

<!-- Attach screenshots or a video demonstrating the feature here -->
