### PR TITLE
Add HTTP 404 to staging tolerance in cron workflows

### DIFF
--- a/.github/workflows/auto-cancel-declined-cron.yml
+++ b/.github/workflows/auto-cancel-declined-cron.yml
@@ -58,7 +58,7 @@ jobs:
           if [ "$HTTP_STATUS" -ge 200 ] 2>/dev/null && [ "$HTTP_STATUS" -lt 400 ] 2>/dev/null; then
             echo "${ENV_NAME}: success (HTTP ${HTTP_STATUS})"
             cat /tmp/response.txt
-          elif [ "${ENV_NAME}" = "staging" ] && { [ "$HTTP_STATUS" = "000" ] || [ "$HTTP_STATUS" = "502" ] || [ "$HTTP_STATUS" = "503" ]; }; then
+          elif [ "${ENV_NAME}" = "staging" ] && { [ "$HTTP_STATUS" = "000" ] || [ "$HTTP_STATUS" = "404" ] || [ "$HTTP_STATUS" = "502" ] || [ "$HTTP_STATUS" = "503" ]; }; then
             echo "::warning::${ENV_NAME}: server unreachable (HTTP ${HTTP_STATUS}). Environment may be stopped."
           else
             echo "${ENV_NAME}: failed (HTTP ${HTTP_STATUS})"

--- a/.github/workflows/auto-checkout-cron.yml
+++ b/.github/workflows/auto-checkout-cron.yml
@@ -58,7 +58,7 @@ jobs:
           if [ "$HTTP_STATUS" -ge 200 ] 2>/dev/null && [ "$HTTP_STATUS" -lt 400 ] 2>/dev/null; then
             echo "${ENV_NAME}: success (HTTP ${HTTP_STATUS})"
             cat /tmp/response.txt
-          elif [ "${ENV_NAME}" = "staging" ] && { [ "$HTTP_STATUS" = "000" ] || [ "$HTTP_STATUS" = "502" ] || [ "$HTTP_STATUS" = "503" ]; }; then
+          elif [ "${ENV_NAME}" = "staging" ] && { [ "$HTTP_STATUS" = "000" ] || [ "$HTTP_STATUS" = "404" ] || [ "$HTTP_STATUS" = "502" ] || [ "$HTTP_STATUS" = "503" ]; }; then
             echo "::warning::${ENV_NAME}: server unreachable (HTTP ${HTTP_STATUS}). Environment may be stopped."
           else
             echo "${ENV_NAME}: failed (HTTP ${HTTP_STATUS})"


### PR DESCRIPTION
## Summary of Changes

When staging is stopped, its URL may return HTTP 404 from the load balancer instead of 502/503. The cron job workflows (auto-checkout, auto-cancel-declined) were failing because 404 was not in the staging tolerance list.

Added HTTP 404 to the staging tolerance condition in both workflow files.

## Checklist

- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [ ] I added or updated unit tests (or explained why not in the PR description)
  - N/A: This is a CI workflow change, no unit tests applicable
- [ ] I attached screenshots or a video demonstrating the feature
  - N/A: CI workflow change
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversation as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video

N/A - CI workflow change. See [failing run](https://github.com/ITPNYU/booking-app/actions/runs/22878420030/job/66375519046) for context.