### PR TITLE
Add tenant schema validation to deploy pipeline

### DIFF
--- a/.github/workflows/deploy_production_app_engine.yml
+++ b/.github/workflows/deploy_production_app_engine.yml
@@ -72,6 +72,16 @@ jobs:
           cd booking-app
           npm ci
 
+      - name: Validate tenant schemas
+        run: |
+          cd booking-app
+          cat > .env.local << EOF
+          FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID }}
+          FIREBASE_CLIENT_EMAIL=${{ secrets.FIREBASE_CLIENT_EMAIL }}
+          FIREBASE_PRIVATE_KEY="${{ secrets.FIREBASE_PRIVATE_KEY }}"
+          EOF
+          npx ts-node scripts/validateTenantSchemas.ts --database production
+
       - name: Build
         run: |
           cd booking-app

--- a/.github/workflows/deploy_production_app_engine.yml
+++ b/.github/workflows/deploy_production_app_engine.yml
@@ -73,14 +73,12 @@ jobs:
           npm ci
 
       - name: Validate tenant schemas
-        run: |
-          cd booking-app
-          cat > .env.local << EOF
-          FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID }}
-          FIREBASE_CLIENT_EMAIL=${{ secrets.FIREBASE_CLIENT_EMAIL }}
-          FIREBASE_PRIVATE_KEY="${{ secrets.FIREBASE_PRIVATE_KEY }}"
-          EOF
-          npx ts-node scripts/validateTenantSchemas.ts --database production
+        working-directory: ./booking-app
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+          FIREBASE_CLIENT_EMAIL: ${{ secrets.FIREBASE_CLIENT_EMAIL }}
+          FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
+        run: npm run validate:schemas -- --database production
 
       - name: Build
         run: |

--- a/.github/workflows/deploy_staging_app_engine.yml
+++ b/.github/workflows/deploy_staging_app_engine.yml
@@ -73,14 +73,12 @@ jobs:
           npm ci
 
       - name: Validate tenant schemas
-        run: |
-          cd booking-app
-          cat > .env.local << EOF
-          FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID }}
-          FIREBASE_CLIENT_EMAIL=${{ secrets.FIREBASE_CLIENT_EMAIL }}
-          FIREBASE_PRIVATE_KEY="${{ secrets.FIREBASE_PRIVATE_KEY }}"
-          EOF
-          npx ts-node scripts/validateTenantSchemas.ts --database staging
+        working-directory: ./booking-app
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+          FIREBASE_CLIENT_EMAIL: ${{ secrets.FIREBASE_CLIENT_EMAIL }}
+          FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
+        run: npm run validate:schemas -- --database staging
 
       - name: Build
         run: |

--- a/.github/workflows/deploy_staging_app_engine.yml
+++ b/.github/workflows/deploy_staging_app_engine.yml
@@ -72,6 +72,16 @@ jobs:
           cd booking-app
           npm ci
 
+      - name: Validate tenant schemas
+        run: |
+          cd booking-app
+          cat > .env.local << EOF
+          FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID }}
+          FIREBASE_CLIENT_EMAIL=${{ secrets.FIREBASE_CLIENT_EMAIL }}
+          FIREBASE_PRIVATE_KEY="${{ secrets.FIREBASE_PRIVATE_KEY }}"
+          EOF
+          npx ts-node scripts/validateTenantSchemas.ts --database staging
+
       - name: Build
         run: |
           cd booking-app

--- a/.github/workflows/sync-tenant-schema.yml
+++ b/.github/workflows/sync-tenant-schema.yml
@@ -87,6 +87,10 @@ jobs:
             booking-app/dry-run-staging-*.json
           retention-days: 30
 
+      - name: Validate tenant schemas (staging)
+        working-directory: ./booking-app
+        run: npx ts-node scripts/validateTenantSchemas.ts --database staging
+
   sync-to-production:
     name: Dry Run - Analyze tenantSchema Sync to Production
     runs-on: ubuntu-latest
@@ -155,4 +159,8 @@ jobs:
             booking-app/dry-run-production-*.md
             booking-app/dry-run-production-*.json
           retention-days: 30
+
+      - name: Validate tenant schemas (production)
+        working-directory: ./booking-app
+        run: npx ts-node scripts/validateTenantSchemas.ts --database production
 

--- a/.github/workflows/sync-tenant-schema.yml
+++ b/.github/workflows/sync-tenant-schema.yml
@@ -37,17 +37,12 @@ jobs:
         working-directory: ./booking-app
         run: npm ci
 
-      - name: Create .env.local file
-        working-directory: ./booking-app
-        run: |
-          cat > .env.local << EOF
-          FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID }}
-          FIREBASE_CLIENT_EMAIL=${{ secrets.FIREBASE_CLIENT_EMAIL }}
-          FIREBASE_PRIVATE_KEY="${{ secrets.FIREBASE_PRIVATE_KEY }}"
-          EOF
-
       - name: Dry Run - Analyze tenantSchema Sync to Staging
         working-directory: ./booking-app
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+          FIREBASE_CLIENT_EMAIL: ${{ secrets.FIREBASE_CLIENT_EMAIL }}
+          FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
         run: |
           node scripts/copyCollection.js \
             --source-database development \
@@ -89,7 +84,11 @@ jobs:
 
       - name: Validate tenant schemas (staging)
         working-directory: ./booking-app
-        run: npx ts-node scripts/validateTenantSchemas.ts --database staging
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+          FIREBASE_CLIENT_EMAIL: ${{ secrets.FIREBASE_CLIENT_EMAIL }}
+          FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
+        run: npm run validate:schemas -- --database staging
 
   sync-to-production:
     name: Dry Run - Analyze tenantSchema Sync to Production
@@ -110,17 +109,12 @@ jobs:
         working-directory: ./booking-app
         run: npm ci
 
-      - name: Create .env.local file
-        working-directory: ./booking-app
-        run: |
-          cat > .env.local << EOF
-          FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID }}
-          FIREBASE_CLIENT_EMAIL=${{ secrets.FIREBASE_CLIENT_EMAIL }}
-          FIREBASE_PRIVATE_KEY="${{ secrets.FIREBASE_PRIVATE_KEY }}"
-          EOF
-
       - name: Dry Run - Analyze tenantSchema Sync to Production
         working-directory: ./booking-app
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+          FIREBASE_CLIENT_EMAIL: ${{ secrets.FIREBASE_CLIENT_EMAIL }}
+          FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
         run: |
           node scripts/copyCollection.js \
             --source-database development \
@@ -162,5 +156,9 @@ jobs:
 
       - name: Validate tenant schemas (production)
         working-directory: ./booking-app
-        run: npx ts-node scripts/validateTenantSchemas.ts --database production
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+          FIREBASE_CLIENT_EMAIL: ${{ secrets.FIREBASE_CLIENT_EMAIL }}
+          FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
+        run: npm run validate:schemas -- --database production
 

--- a/booking-app/package.json
+++ b/booking-app/package.json
@@ -18,7 +18,8 @@
     "copy:production:dry-run": "node scripts/copyCollection.js --source-database development --target-database production --source-collection tenantSchema --target-collection tenantSchema --dry-run --report-file dry-run-production-details.json",
     "mergeUsers": "node scripts/mergeUsersCollections.js",
     "sync:schemas": "npx ts-node --transpile-only --compiler-options '{\"module\":\"commonjs\",\"jsx\":\"react\"}' scripts/syncTenantSchemas.ts",
-    "sync:schemas:dry-run": "npx ts-node --transpile-only --compiler-options '{\"module\":\"commonjs\",\"jsx\":\"react\"}' scripts/syncTenantSchemas.ts --dry-run"
+    "sync:schemas:dry-run": "npx ts-node --transpile-only --compiler-options '{\"module\":\"commonjs\",\"jsx\":\"react\"}' scripts/syncTenantSchemas.ts --dry-run",
+    "validate:schemas": "npx ts-node --transpile-only --compiler-options '{\"module\":\"commonjs\",\"jsx\":\"react\"}' scripts/validateTenantSchemas.ts"
   },
   "dependencies": {
     "@emotion/styled": "^11.13.0",

--- a/booking-app/scripts/validateTenantSchemas.ts
+++ b/booking-app/scripts/validateTenantSchemas.ts
@@ -1,0 +1,310 @@
+/**
+ * Validate Tenant Schemas Script
+ *
+ * Checks that all tenant schemas in Firestore have valid, non-empty values
+ * for critical fields. Run after sync to catch missing configuration before deploy.
+ *
+ * Usage:
+ *   npx ts-node scripts/validateTenantSchemas.ts [--database <env>] [--tenant <tenant>]
+ *
+ * Exit codes:
+ *   0 = all schemas valid
+ *   1 = validation errors found
+ */
+
+require("dotenv").config({ path: ".env.local" });
+import * as admin from "firebase-admin";
+import type { SchemaContextType } from "../components/src/client/routes/components/SchemaProvider";
+
+const TENANTS = ["mc", "itp"] as const;
+const TENANT_SCHEMA_COLLECTION = "tenantSchema";
+
+const DATABASES: Record<string, string> = {
+  development: "default",
+  staging: "booking-app-staging",
+  production: "booking-app-prod",
+};
+
+// ---------------------------------------------------------------------------
+// Validation rules
+// ---------------------------------------------------------------------------
+
+type ValidationError = {
+  field: string;
+  message: string;
+  severity: "error" | "warning";
+};
+
+type ValidationRule = {
+  field: string;
+  check: (schema: SchemaContextType, env: string) => string | null;
+  severity: "error" | "warning";
+};
+
+/**
+ * Define validation rules here. Each rule checks a single concern.
+ * Return a string message if validation fails, null if it passes.
+ *
+ * Add new rules as more fields move to schema.
+ */
+const VALIDATION_RULES: ValidationRule[] = [
+  // --- Identity ---
+  {
+    field: "name",
+    severity: "error",
+    check: (s) => (!s.name ? "Tenant name is empty" : null),
+  },
+  {
+    field: "logo",
+    severity: "warning",
+    check: (s) => (!s.logo ? "Logo path is empty" : null),
+  },
+  {
+    field: "nameForPolicy",
+    severity: "warning",
+    check: (s) => (!s.nameForPolicy ? "nameForPolicy is empty" : null),
+  },
+
+  // --- Roles & Mappings ---
+  {
+    field: "roles",
+    severity: "error",
+    check: (s) =>
+      !s.roles || s.roles.length === 0 ? "No roles defined" : null,
+  },
+  {
+    field: "roleMapping",
+    severity: "error",
+    check: (s) =>
+      !s.roleMapping || Object.keys(s.roleMapping).length === 0
+        ? "roleMapping is empty"
+        : null,
+  },
+  {
+    field: "schoolMapping",
+    severity: "error",
+    check: (s) =>
+      !s.schoolMapping || Object.keys(s.schoolMapping).length === 0
+        ? "schoolMapping is empty"
+        : null,
+  },
+
+  // --- Resources ---
+  {
+    field: "resources",
+    severity: "error",
+    check: (s) =>
+      !s.resources || s.resources.length === 0
+        ? "No resources defined"
+        : null,
+  },
+  {
+    field: "resources[].calendarId",
+    severity: "error",
+    check: (s) => {
+      if (!s.resources) return null;
+      const missing = s.resources.filter((r) => !r.calendarId);
+      return missing.length > 0
+        ? `${missing.length} resource(s) missing calendarId: ${missing.map((r) => r.name || "(unnamed)").join(", ")}`
+        : null;
+    },
+  },
+  {
+    field: "resources[].name",
+    severity: "error",
+    check: (s) => {
+      if (!s.resources) return null;
+      const missing = s.resources.filter((r) => !r.name);
+      return missing.length > 0
+        ? `${missing.length} resource(s) have no name`
+        : null;
+    },
+  },
+
+  // --- Agreements ---
+  {
+    field: "agreements",
+    severity: "warning",
+    check: (s) =>
+      !s.agreements || s.agreements.length === 0
+        ? "No agreements defined"
+        : null,
+  },
+
+  // --- CC Emails (added by schema-driven-tenant-policy branch) ---
+  {
+    field: "ccEmails.approved",
+    severity: "warning",
+    check: (s, env) => {
+      const ccEmails = (s as any).ccEmails;
+      if (!ccEmails?.approved) return "ccEmails.approved is not configured";
+      const email = ccEmails.approved[env];
+      return !email
+        ? `ccEmails.approved.${env} is empty — CC notifications will be skipped`
+        : null;
+    },
+  },
+  {
+    field: "ccEmails.canceled",
+    severity: "warning",
+    check: (s, env) => {
+      const ccEmails = (s as any).ccEmails;
+      if (!ccEmails?.canceled) return "ccEmails.canceled is not configured";
+      const email = ccEmails.canceled[env];
+      return !email
+        ? `ccEmails.canceled.${env} is empty — cancel CC notifications will be skipped`
+        : null;
+    },
+  },
+
+  // --- Email Messages ---
+  {
+    field: "emailMessages",
+    severity: "warning",
+    check: (s) => {
+      if (!s.emailMessages) return "emailMessages is not configured";
+      const empty = Object.entries(s.emailMessages).filter(
+        ([, v]) => !v,
+      );
+      return empty.length > 0
+        ? `${empty.length} email message(s) are empty: ${empty.map(([k]) => k).join(", ")}`
+        : null;
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Script logic
+// ---------------------------------------------------------------------------
+
+function parseArgs(): { database: string; tenant?: string } {
+  const args = process.argv.slice(2);
+  const options: { database: string; tenant?: string } = {
+    database: "development",
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--database") options.database = args[++i] || "development";
+    if (args[i] === "--tenant") options.tenant = args[++i];
+    if (args[i] === "--help") {
+      console.log(`
+Usage: npx ts-node scripts/validateTenantSchemas.ts [options]
+
+Options:
+  --database <env>    Database environment: development, staging, production (default: development)
+  --tenant <tenant>   Validate only a specific tenant (default: all tenants)
+  --help              Show this help message
+`);
+      process.exit(0);
+    }
+  }
+
+  return options;
+}
+
+function initializeDb(databaseName: string) {
+  if (!admin.apps.length) {
+    admin.initializeApp({
+      credential: admin.credential.cert({
+        projectId: process.env.FIREBASE_PROJECT_ID,
+        clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+        privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n"),
+      }),
+    });
+  }
+
+  const db = admin.firestore();
+  if (databaseName !== "default") {
+    db.settings({ databaseId: databaseName });
+  }
+  return db;
+}
+
+function validateSchema(
+  schema: SchemaContextType,
+  env: string,
+): ValidationError[] {
+  const errors: ValidationError[] = [];
+
+  for (const rule of VALIDATION_RULES) {
+    const message = rule.check(schema, env);
+    if (message) {
+      errors.push({
+        field: rule.field,
+        message,
+        severity: rule.severity,
+      });
+    }
+  }
+
+  return errors;
+}
+
+async function main() {
+  const options = parseArgs();
+
+  if (!DATABASES[options.database]) {
+    console.error(`Invalid database: ${options.database}`);
+    process.exit(1);
+  }
+
+  const db = initializeDb(DATABASES[options.database]);
+  const tenantsToValidate = options.tenant ? [options.tenant] : [...TENANTS];
+
+  console.log(`\nValidating tenant schemas (${options.database})...\n`);
+
+  let hasErrors = false;
+
+  for (const tenant of tenantsToValidate) {
+    const docSnap = await db
+      .collection(TENANT_SCHEMA_COLLECTION)
+      .doc(tenant)
+      .get();
+
+    if (!docSnap.exists) {
+      console.log(`  ${tenant}: MISSING — no schema document found`);
+      hasErrors = true;
+      continue;
+    }
+
+    const schema = docSnap.data() as SchemaContextType;
+    const errors = validateSchema(schema, options.database);
+
+    const errorCount = errors.filter((e) => e.severity === "error").length;
+    const warningCount = errors.filter((e) => e.severity === "warning").length;
+
+    if (errors.length === 0) {
+      console.log(`  ${tenant}: OK`);
+    } else {
+      console.log(
+        `  ${tenant}: ${errorCount} error(s), ${warningCount} warning(s)`,
+      );
+      for (const err of errors) {
+        const icon = err.severity === "error" ? "ERR" : "WARN";
+        console.log(`    [${icon}] ${err.field}: ${err.message}`);
+      }
+      if (errorCount > 0) hasErrors = true;
+    }
+  }
+
+  console.log("");
+
+  // Clean up
+  for (const app of admin.apps) {
+    if (app) await app.delete();
+  }
+
+  if (hasErrors) {
+    console.log("Validation FAILED — fix errors before deploying.\n");
+    process.exit(1);
+  } else {
+    console.log("Validation passed.\n");
+    process.exit(0);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+export { validateSchema, VALIDATION_RULES };

--- a/booking-app/tests/unit/validate-tenant-schemas.unit.test.ts
+++ b/booking-app/tests/unit/validate-tenant-schemas.unit.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "vitest";
+import { validateSchema } from "@/scripts/validateTenantSchemas";
+import type { SchemaContextType } from "@/components/src/client/routes/components/SchemaProvider";
+
+function makeSchema(
+  overrides: Partial<SchemaContextType> = {},
+): SchemaContextType {
+  return {
+    tenant: "test",
+    name: "Test Tenant",
+    logo: "/logo.svg",
+    nameForPolicy: "Test",
+    policy: "<p>Policy</p>",
+    programMapping: { Dept: ["PROG"] },
+    roles: ["Student"],
+    roleMapping: { Student: ["STUDENT"] },
+    schoolMapping: { School: ["Dept"] },
+    showNNumber: false,
+    showSponsor: false,
+    showSetup: false,
+    showEquipment: false,
+    showStaffing: false,
+    showCatering: false,
+    showHireSecurity: false,
+    showBookingTypes: false,
+    agreements: [{ id: "policy", html: "<p>Agree</p>" }],
+    resources: [
+      {
+        capacity: 20,
+        name: "Room A",
+        roomId: 1,
+        isEquipment: false,
+        calendarId: "cal-1",
+        isWalkIn: false,
+        isWalkInCanBookTwo: false,
+        services: [],
+      },
+    ],
+    supportVIP: false,
+    supportWalkIn: false,
+    resourceName: "Room(s)",
+    ccEmails: {
+      approved: {
+        development: "dev@test.com",
+        staging: "stg@test.com",
+        production: "prod@test.com",
+      },
+      canceled: {
+        development: "dev@test.com",
+        staging: "stg@test.com",
+        production: "prod@test.com",
+      },
+    },
+    emailMessages: {
+      requestConfirmation: "msg",
+      firstApprovalRequest: "msg",
+      secondApprovalRequest: "msg",
+      walkInConfirmation: "msg",
+      vipConfirmation: "msg",
+      checkoutConfirmation: "msg",
+      checkinConfirmation: "msg",
+      declined: "msg",
+      canceled: "msg",
+      lateCancel: "msg",
+      noShow: "msg",
+      closed: "msg",
+      approvalNotice: "msg",
+    },
+    ...overrides,
+  } as SchemaContextType;
+}
+
+describe("validateSchema", () => {
+  it("passes for a fully configured schema", () => {
+    const errors = validateSchema(makeSchema(), "production");
+    expect(errors).toEqual([]);
+  });
+
+  it("reports error when name is empty", () => {
+    const errors = validateSchema(makeSchema({ name: "" }), "production");
+    expect(errors).toContainEqual(
+      expect.objectContaining({ field: "name", severity: "error" }),
+    );
+  });
+
+  it("reports error when roles are empty", () => {
+    const errors = validateSchema(makeSchema({ roles: [] }), "production");
+    expect(errors).toContainEqual(
+      expect.objectContaining({ field: "roles", severity: "error" }),
+    );
+  });
+
+  it("reports error when resources are empty", () => {
+    const errors = validateSchema(
+      makeSchema({ resources: [] }),
+      "production",
+    );
+    expect(errors).toContainEqual(
+      expect.objectContaining({ field: "resources", severity: "error" }),
+    );
+  });
+
+  it("reports error when resource missing calendarId", () => {
+    const errors = validateSchema(
+      makeSchema({
+        resources: [
+          {
+            capacity: 10,
+            name: "Room B",
+            roomId: 2,
+            isEquipment: false,
+            calendarId: "",
+            isWalkIn: false,
+            isWalkInCanBookTwo: false,
+            services: [],
+          },
+        ],
+      }),
+      "production",
+    );
+    expect(errors).toContainEqual(
+      expect.objectContaining({
+        field: "resources[].calendarId",
+        severity: "error",
+      }),
+    );
+  });
+
+  it("reports warning when ccEmails.approved is missing for env", () => {
+    const errors = validateSchema(
+      makeSchema({
+        ccEmails: {
+          approved: { development: "", staging: "", production: "" },
+          canceled: {
+            development: "d@t.com",
+            staging: "s@t.com",
+            production: "p@t.com",
+          },
+        },
+      }),
+      "production",
+    );
+    expect(errors).toContainEqual(
+      expect.objectContaining({
+        field: "ccEmails.approved",
+        severity: "warning",
+      }),
+    );
+  });
+
+  it("reports warning when ccEmails is not configured at all", () => {
+    const schema = makeSchema();
+    delete (schema as any).ccEmails;
+    const errors = validateSchema(schema, "production");
+    const ccErrors = errors.filter((e) => e.field.startsWith("ccEmails"));
+    expect(ccErrors.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("reports warning for empty email messages", () => {
+    const errors = validateSchema(
+      makeSchema({
+        emailMessages: {
+          requestConfirmation: "",
+          firstApprovalRequest: "",
+          secondApprovalRequest: "",
+          walkInConfirmation: "",
+          vipConfirmation: "",
+          checkoutConfirmation: "",
+          checkinConfirmation: "",
+          declined: "",
+          canceled: "",
+          lateCancel: "",
+          noShow: "",
+          closed: "",
+          approvalNotice: "",
+        },
+      }),
+      "production",
+    );
+    expect(errors).toContainEqual(
+      expect.objectContaining({
+        field: "emailMessages",
+        severity: "warning",
+      }),
+    );
+  });
+
+  it("checks correct env for ccEmails", () => {
+    const schema = makeSchema({
+      ccEmails: {
+        approved: {
+          development: "dev@t.com",
+          staging: "",
+          production: "prod@t.com",
+        },
+        canceled: {
+          development: "dev@t.com",
+          staging: "",
+          production: "prod@t.com",
+        },
+      },
+    });
+
+    // staging should warn
+    const stagingErrors = validateSchema(schema, "staging");
+    const stagingCcErrors = stagingErrors.filter((e) =>
+      e.field.startsWith("ccEmails"),
+    );
+    expect(stagingCcErrors.length).toBe(2);
+
+    // production should pass
+    const prodErrors = validateSchema(schema, "production");
+    const prodCcErrors = prodErrors.filter((e) =>
+      e.field.startsWith("ccEmails"),
+    );
+    expect(prodCcErrors.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary of Changes

Adds a validation step to staging and production deploy workflows that checks Firestore tenant schemas for missing or empty critical fields before deploying. If validation fails (error-level), the deploy is blocked.

**What it checks:**
- Tenant identity: `name`, `logo`, `nameForPolicy`
- Roles & mappings: `roles`, `roleMapping`, `schoolMapping`
- Resources: presence, `calendarId`, `name` for each resource
- CC emails: `ccEmails.approved` / `ccEmails.canceled` for the target environment
- Email messages: all notification templates

**Severity levels:**
- `error` → deploy blocked (e.g., missing roles, empty resources)
- `warning` → informational only (e.g., empty logo, missing CC email)

**Where it runs:**
- `deploy_staging_app_engine.yml` — before build
- `deploy_production_app_engine.yml` — before build
- `sync-tenant-schema.yml` — after sync completes

## Checklist

- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversation as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video

No UI changes — CI/CD pipeline and validation script only.