### PR TITLE
fix: prevent flaky test in useBookingDateRestrictions by using far-future dates

### DIFF
--- a/booking-app/tests/unit/useBookingDateRestrictions.unit.test.tsx
+++ b/booking-app/tests/unit/useBookingDateRestrictions.unit.test.tsx
@@ -16,8 +16,8 @@ const mockBlackoutPeriods: BlackoutPeriod[] = [
   {
     id: "1",
     name: "Summer Break",
-    startDate: Timestamp.fromDate(dayjs("2026-06-01").toDate()),
-    endDate: Timestamp.fromDate(dayjs("2026-08-31").toDate()),
+    startDate: Timestamp.fromDate(dayjs("2030-06-01").toDate()),
+    endDate: Timestamp.fromDate(dayjs("2030-08-31").toDate()),
     isActive: true,
     createdAt: Timestamp.now(),
     updatedAt: Timestamp.now(),
@@ -25,8 +25,8 @@ const mockBlackoutPeriods: BlackoutPeriod[] = [
   {
     id: "2",
     name: "Winter Holidays",
-    startDate: Timestamp.fromDate(dayjs("2026-12-20").toDate()),
-    endDate: Timestamp.fromDate(dayjs("2027-01-05").toDate()),
+    startDate: Timestamp.fromDate(dayjs("2030-12-20").toDate()),
+    endDate: Timestamp.fromDate(dayjs("2031-01-05").toDate()),
     isActive: true,
     createdAt: Timestamp.now(),
     updatedAt: Timestamp.now(),
@@ -34,8 +34,8 @@ const mockBlackoutPeriods: BlackoutPeriod[] = [
   {
     id: "3",
     name: "Maintenance Period",
-    startDate: Timestamp.fromDate(dayjs("2026-03-15").toDate()),
-    endDate: Timestamp.fromDate(dayjs("2026-03-20").toDate()),
+    startDate: Timestamp.fromDate(dayjs("2030-03-15").toDate()),
+    endDate: Timestamp.fromDate(dayjs("2030-03-20").toDate()),
     isActive: false, // This period is inactive
     createdAt: Timestamp.now(),
     updatedAt: Timestamp.now(),
@@ -43,8 +43,8 @@ const mockBlackoutPeriods: BlackoutPeriod[] = [
   {
     id: "4",
     name: "Room 221 Maintenance",
-    startDate: Timestamp.fromDate(dayjs("2026-04-01").toDate()),
-    endDate: Timestamp.fromDate(dayjs("2026-04-07").toDate()),
+    startDate: Timestamp.fromDate(dayjs("2030-04-01").toDate()),
+    endDate: Timestamp.fromDate(dayjs("2030-04-07").toDate()),
     isActive: true,
     roomIds: [221], // Only applies to room 221
     createdAt: Timestamp.now(),
@@ -53,8 +53,8 @@ const mockBlackoutPeriods: BlackoutPeriod[] = [
   {
     id: "5",
     name: "Audio Equipment Upgrade",
-    startDate: Timestamp.fromDate(dayjs("2026-05-01").toDate()),
-    endDate: Timestamp.fromDate(dayjs("2026-05-15").toDate()),
+    startDate: Timestamp.fromDate(dayjs("2030-05-01").toDate()),
+    endDate: Timestamp.fromDate(dayjs("2030-05-15").toDate()),
     isActive: true,
     roomIds: [230, 221], // Applies to rooms 230 and 221
     createdAt: Timestamp.now(),
@@ -106,34 +106,26 @@ describe("useBookingDateRestrictions Hook", () => {
     });
 
     // Test dates within Summer Break (active period)
-    const summerDate = dayjs("2026-07-15");
+    const summerDate = dayjs("2030-07-15");
     expect(result.current.isDateDisabled(summerDate)).toBe(true);
 
     // Test dates within Winter Holidays (active period)
-    const winterDate = dayjs("2026-12-25");
+    const winterDate = dayjs("2030-12-25");
     expect(result.current.isDateDisabled(winterDate)).toBe(true);
   });
 
   it("should not disable dates within inactive blackout periods", () => {
-    // Freeze "today" so the test date stays in the future; otherwise past-date
-    // logic hides whether inactive blackouts are ignored.
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-03-01T12:00:00.000Z"));
-    try {
-      const { result } = renderHook(() => useBookingDateRestrictions(), {
-        wrapper: ({ children }) => (
-          <DatabaseContext.Provider value={mockDatabaseContext as any}>
-            {children}
-          </DatabaseContext.Provider>
-        ),
-      });
+    const { result } = renderHook(() => useBookingDateRestrictions(), {
+      wrapper: ({ children }) => (
+        <DatabaseContext.Provider value={mockDatabaseContext as any}>
+          {children}
+        </DatabaseContext.Provider>
+      ),
+    });
 
-      // Test date within Maintenance Period (inactive period)
-      const maintenanceDate = dayjs("2026-03-17");
-      expect(result.current.isDateDisabled(maintenanceDate)).toBe(false);
-    } finally {
-      vi.useRealTimers();
-    }
+    // Test date within Maintenance Period (inactive period)
+    const maintenanceDate = dayjs("2030-03-17");
+    expect(result.current.isDateDisabled(maintenanceDate)).toBe(false);
   });
 
   it("should not disable dates outside blackout periods", () => {
@@ -145,9 +137,9 @@ describe("useBookingDateRestrictions Hook", () => {
       ),
     });
 
-    const normalDate1 = dayjs("2026-04-15"); // Between maintenance and summer
-    const normalDate2 = dayjs("2026-10-15"); // Between summer and winter
-    const normalDate3 = dayjs("2027-02-15"); // After winter
+    const normalDate1 = dayjs("2030-04-15"); // Between maintenance and summer
+    const normalDate2 = dayjs("2030-10-15"); // Between summer and winter
+    const normalDate3 = dayjs("2031-02-15"); // After winter
 
     expect(result.current.isDateDisabled(normalDate1)).toBe(false);
     expect(result.current.isDateDisabled(normalDate2)).toBe(false);
@@ -164,17 +156,17 @@ describe("useBookingDateRestrictions Hook", () => {
     });
 
     // Test start and end dates of Summer Break
-    const startDate = dayjs("2026-06-01");
-    const endDate = dayjs("2026-08-31");
+    const startDate = dayjs("2030-06-01");
+    const endDate = dayjs("2030-08-31");
     expect(result.current.isDateDisabled(startDate)).toBe(true);
     expect(result.current.isDateDisabled(endDate)).toBe(true);
 
     // Test day before Summer Break
-    const dayBefore = dayjs("2026-05-31");
+    const dayBefore = dayjs("2030-05-31");
     expect(result.current.isDateDisabled(dayBefore)).toBe(false);
 
     // Test day after Summer Break
-    const dayAfter = dayjs("2026-09-01");
+    const dayAfter = dayjs("2030-09-01");
     expect(result.current.isDateDisabled(dayAfter)).toBe(false);
   });
 
@@ -193,7 +185,7 @@ describe("useBookingDateRestrictions Hook", () => {
     });
 
     // Any future date should be allowed when no blackout periods exist
-    const testDate = dayjs("2026-07-15");
+    const testDate = dayjs("2030-07-15");
     expect(result.current.isDateDisabled(testDate)).toBe(false);
   });
 
@@ -212,7 +204,7 @@ describe("useBookingDateRestrictions Hook", () => {
     });
 
     // Should not throw error and should allow dates
-    const testDate = dayjs("2026-07-15");
+    const testDate = dayjs("2030-07-15");
     expect(result.current.isDateDisabled(testDate)).toBe(false);
   });
 
@@ -222,8 +214,8 @@ describe("useBookingDateRestrictions Hook", () => {
       {
         id: "4",
         name: "Overlapping Period",
-        startDate: Timestamp.fromDate(dayjs("2026-07-01").toDate()),
-        endDate: Timestamp.fromDate(dayjs("2026-07-31").toDate()),
+        startDate: Timestamp.fromDate(dayjs("2030-07-01").toDate()),
+        endDate: Timestamp.fromDate(dayjs("2030-07-31").toDate()),
         isActive: true,
         createdAt: Timestamp.now(),
         updatedAt: Timestamp.now(),
@@ -244,7 +236,7 @@ describe("useBookingDateRestrictions Hook", () => {
     });
 
     // Date that falls in both Summer Break and Overlapping Period
-    const overlappingDate = dayjs("2026-07-15");
+    const overlappingDate = dayjs("2030-07-15");
     expect(result.current.isDateDisabled(overlappingDate)).toBe(true);
   });
 
@@ -253,8 +245,8 @@ describe("useBookingDateRestrictions Hook", () => {
       {
         id: "5",
         name: "Single Day Event",
-        startDate: Timestamp.fromDate(dayjs("2026-06-15").toDate()),
-        endDate: Timestamp.fromDate(dayjs("2026-06-15").toDate()),
+        startDate: Timestamp.fromDate(dayjs("2030-06-15").toDate()),
+        endDate: Timestamp.fromDate(dayjs("2030-06-15").toDate()),
         isActive: true,
         createdAt: Timestamp.now(),
         updatedAt: Timestamp.now(),
@@ -275,12 +267,12 @@ describe("useBookingDateRestrictions Hook", () => {
     });
 
     // The exact date should be disabled
-    const exactDate = dayjs("2026-06-15");
+    const exactDate = dayjs("2030-06-15");
     expect(result.current.isDateDisabled(exactDate)).toBe(true);
 
     // Days before and after should not be disabled
-    const dayBefore = dayjs("2026-06-14");
-    const dayAfter = dayjs("2026-06-16");
+    const dayBefore = dayjs("2030-06-14");
+    const dayAfter = dayjs("2030-06-16");
     expect(result.current.isDateDisabled(dayBefore)).toBe(false);
     expect(result.current.isDateDisabled(dayAfter)).toBe(false);
   });
@@ -295,12 +287,12 @@ describe("useBookingDateRestrictions Hook", () => {
     });
 
     // Test getting blackout period for a date within Summer Break
-    const summerDate = dayjs("2026-07-15");
+    const summerDate = dayjs("2030-07-15");
     const blackoutPeriod = result.current.getBlackoutPeriodForDate(summerDate);
     expect(blackoutPeriod?.name).toBe("Summer Break");
 
     // Test getting blackout period for a date outside any period
-    const normalDate = dayjs("2026-04-15");
+    const normalDate = dayjs("2030-04-15");
     const noBlackoutPeriod =
       result.current.getBlackoutPeriodForDate(normalDate);
     expect(noBlackoutPeriod).toBeUndefined();
@@ -317,7 +309,7 @@ describe("useBookingDateRestrictions Hook", () => {
       });
 
       // Test room 221 during its maintenance period
-      const room221MaintenanceDate = dayjs("2026-04-03");
+      const room221MaintenanceDate = dayjs("2030-04-03");
       expect(
         result.current.isDateDisabledForRooms(room221MaintenanceDate, [221])
       ).toBe(true);
@@ -342,7 +334,7 @@ describe("useBookingDateRestrictions Hook", () => {
       });
 
       // Test during Audio Equipment Upgrade (affects rooms 230 and 221)
-      const audioUpgradeDate = dayjs("2026-05-10");
+      const audioUpgradeDate = dayjs("2030-05-10");
       expect(
         result.current.isDateDisabledForRooms(audioUpgradeDate, [230])
       ).toBe(true);
@@ -370,7 +362,7 @@ describe("useBookingDateRestrictions Hook", () => {
       });
 
       // Test getting blackout periods for room 221 during Audio Equipment Upgrade
-      const audioUpgradeDate = dayjs("2026-05-10");
+      const audioUpgradeDate = dayjs("2030-05-10");
       const periodsForRoom221 =
         result.current.getBlackoutPeriodsForDateAndRooms(audioUpgradeDate, [
           221,
@@ -386,7 +378,7 @@ describe("useBookingDateRestrictions Hook", () => {
       expect(periodsForRoom222).toHaveLength(0);
 
       // Test during global blackout period (Summer Break)
-      const summerDate = dayjs("2026-07-15");
+      const summerDate = dayjs("2030-07-15");
       const periodsForSummer = result.current.getBlackoutPeriodsForDateAndRooms(
         summerDate,
         [221, 222]
@@ -405,7 +397,7 @@ describe("useBookingDateRestrictions Hook", () => {
       });
 
       // Test during Summer Break (global blackout - affects all rooms)
-      const summerDate = dayjs("2026-07-15");
+      const summerDate = dayjs("2030-07-15");
       expect(result.current.isDateDisabledForRooms(summerDate, [221])).toBe(
         true
       );
@@ -430,13 +422,13 @@ describe("useBookingDateRestrictions Hook", () => {
       });
 
       // Test with empty room list during room-specific blackout
-      const room221MaintenanceDate = dayjs("2026-04-03");
+      const room221MaintenanceDate = dayjs("2030-04-03");
       expect(
         result.current.isDateDisabledForRooms(room221MaintenanceDate, [])
       ).toBe(false);
 
       // Test with empty room list during global blackout
-      const summerDate = dayjs("2026-07-15");
+      const summerDate = dayjs("2030-07-15");
       expect(result.current.isDateDisabledForRooms(summerDate, [])).toBe(true);
     });
 
@@ -446,8 +438,8 @@ describe("useBookingDateRestrictions Hook", () => {
         {
           id: "6",
           name: "Room 221 Summer Maintenance",
-          startDate: Timestamp.fromDate(dayjs("2026-07-01").toDate()),
-          endDate: Timestamp.fromDate(dayjs("2026-07-31").toDate()),
+          startDate: Timestamp.fromDate(dayjs("2030-07-01").toDate()),
+          endDate: Timestamp.fromDate(dayjs("2030-07-31").toDate()),
           isActive: true,
           roomIds: [221],
           createdAt: Timestamp.now(),
@@ -471,7 +463,7 @@ describe("useBookingDateRestrictions Hook", () => {
       });
 
       // Test during overlap (both Summer Break and Room 221 Summer Maintenance)
-      const overlapDate = dayjs("2026-07-15");
+      const overlapDate = dayjs("2030-07-15");
       const periodsForRoom221 =
         result.current.getBlackoutPeriodsForDateAndRooms(overlapDate, [221]);
       expect(periodsForRoom221).toHaveLength(2);


### PR DESCRIPTION
## Summary of Changes

Fixes the flaky unit test in `useBookingDateRestrictions.unit.test.tsx` that was failing in CI ([run #23263414237](https://github.com/ITPNYU/booking-app/actions/runs/23263414237/job/67637722508)).

**Root cause:** The "Maintenance Period" blackout period was defined with dates `2026-03-15~20`. The `useBookingDateRestrictions` hook always disables past dates (`date.isBefore(dayjs(), "day")`). When CI ran on 2026-03-18, the test date `2026-03-17` had already become a past date, causing `isDateDisabled` to return `true` — regardless of the period being `isActive: false`.

**Fix:** Moved the inactive Maintenance Period and its test date from 2026 to 2030, ensuring the test remains valid long-term without needing to mock system time.

## Checklist

- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature
- [x] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversation as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video

N/A — test-only fix, no UI changes.