### PR TITLE
Implimented TenantEntitlementGuard for tenant-specific access control

### DIFF
--- a/booking-app/app/[tenant]/layout.tsx
+++ b/booking-app/app/[tenant]/layout.tsx
@@ -2,6 +2,7 @@ import ClientProvider from "@/components/src/client/routes/components/ClientProv
 import NavBar from "@/components/src/client/routes/components/navBar";
 import type { SchemaContextType } from "@/components/src/client/routes/components/SchemaProvider";
 import SchemaProviderWrapper from "@/components/src/client/routes/components/SchemaProviderWrapper";
+import TenantEntitlementGuard from "@/components/src/client/routes/components/TenantEntitlementGuard";
 import { ALLOWED_TENANTS } from "@/components/src/constants/tenants";
 import { getCachedTenantSchema } from "@/lib/tenant/getCachedTenantSchema";
 import { applyEnvironmentCalendarIds } from "@/lib/utils/calendarEnvironment";
@@ -92,8 +93,10 @@ const Layout: React.FC<LayoutProps> = async ({ children, params }) => {
     return (
       <SchemaProviderWrapper value={serializedTenantSchema}>
         <ClientProvider>
-          <NavBar />
-          {children}
+          <TenantEntitlementGuard>
+            <NavBar />
+            {children}
+          </TenantEntitlementGuard>
         </ClientProvider>
       </SchemaProviderWrapper>
     );

--- a/booking-app/components/src/client/routes/components/TenantEntitlementGuard.tsx
+++ b/booking-app/components/src/client/routes/components/TenantEntitlementGuard.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useAuth } from "@/components/src/client/routes/components/AuthProvider";
+import { TENANTS, TenantValue } from "@/components/src/constants/tenants";
+import { Box, CircularProgress } from "@mui/material";
+import { useParams, useRouter } from "next/navigation";
+import React, { useEffect, useState } from "react";
+
+/** Normalize mediaCommons → mc so comparisons use a single canonical value. */
+const canonicalize = (tenant: string): TenantValue =>
+  tenant === TENANTS.MEDIA_COMMONS ? TENANTS.MC : (tenant as TenantValue);
+
+const FALLBACK_TENANTS: TenantValue[] = [TENANTS.MC];
+
+/**
+ * Checks whether the authenticated user is entitled to access the current
+ * tenant. Redirects to the root URL if they are not.
+ *
+ * Wraps its children and renders a loading spinner while the check is in
+ * flight. On API failure the guard fails open (allows access) to avoid
+ * blocking users due to a transient error.
+ */
+const TenantEntitlementGuard: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const { user, loading: authLoading, isOnTestEnv } = useAuth();
+  const params = useParams();
+  const router = useRouter();
+
+  // null  → check not yet complete
+  // true  → entitled; render children
+  // false → not entitled; redirect in progress
+  const [entitled, setEntitled] = useState<boolean | null>(null);
+
+  const tenant =
+    typeof params?.tenant === "string" ? params.tenant : null;
+  const netId = user?.email?.split("@")[0];
+
+  useEffect(() => {
+    if (authLoading) return;
+
+    // AuthProvider handles unauthenticated users; skip the entitlement check
+    // until we have a verified user.
+    if (!user || !netId || !tenant) return;
+
+    // Test environments bypass entitlement enforcement.
+    if (isOnTestEnv) {
+      setEntitled(true);
+      return;
+    }
+
+    let cancelled = false;
+
+    const checkEntitlement = async () => {
+      try {
+        const idToken = await user.getIdToken();
+        const response = await fetch(`/api/nyu/entitlements/${netId}`, {
+          headers: { Authorization: `Bearer ${idToken}` },
+        });
+
+        if (cancelled) return;
+
+        const canonicalTenant = canonicalize(tenant);
+
+        if (response.ok) {
+          const data = await response.json();
+          const entitledTenants: TenantValue[] = (
+            data.entitledTenants ?? FALLBACK_TENANTS
+          ).map(canonicalize);
+
+          if (entitledTenants.includes(canonicalTenant)) {
+            setEntitled(true);
+          } else {
+            setEntitled(false);
+            router.replace("/");
+          }
+        } else {
+          // Fail open on non-OK responses to avoid blocking users unexpectedly.
+          console.warn(
+            `TenantEntitlementGuard: entitlements API returned ${response.status} — allowing access`
+          );
+          setEntitled(true);
+        }
+      } catch (err) {
+        // Fail open on network/parse errors.
+        console.warn(
+          "TenantEntitlementGuard: failed to fetch entitlements — allowing access",
+          err
+        );
+        if (!cancelled) setEntitled(true);
+      }
+    };
+
+    checkEntitlement();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authLoading, user, netId, tenant, isOnTestEnv, router]);
+
+  if (authLoading || entitled === null) {
+    return (
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        minHeight="100vh"
+      >
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  // entitled === false means the redirect is already in flight; render nothing.
+  if (!entitled) return null;
+
+  return <>{children}</>;
+};
+
+export default TenantEntitlementGuard;

--- a/booking-app/components/src/client/routes/components/TenantEntitlementGuard.tsx
+++ b/booking-app/components/src/client/routes/components/TenantEntitlementGuard.tsx
@@ -17,8 +17,9 @@ const FALLBACK_TENANTS: TenantValue[] = [TENANTS.MC];
  * tenant. Redirects to the root URL if they are not.
  *
  * Wraps its children and renders a loading spinner while the check is in
- * flight. On API failure the guard fails open (allows access) to avoid
- * blocking users due to a transient error.
+ * flight. Auth failures (401/403) are treated as fail-closed (redirect).
+ * Transient upstream errors (5xx, network) are treated as fail-open to avoid
+ * locking out authenticated users due to a flaky entitlements service.
  */
 const TenantEntitlementGuard: React.FC<{ children: React.ReactNode }> = ({
   children,
@@ -38,6 +39,10 @@ const TenantEntitlementGuard: React.FC<{ children: React.ReactNode }> = ({
 
   useEffect(() => {
     if (authLoading) return;
+
+    // Reset to loading state so children don't render optimistically while a
+    // new check is in-flight (e.g. client-side navigation between tenants).
+    setEntitled(null);
 
     // No authenticated user yet — let unauthenticated pages (e.g. /signin)
     // render normally; AuthProvider will drive the auth flow independently.

--- a/booking-app/components/src/client/routes/components/TenantEntitlementGuard.tsx
+++ b/booking-app/components/src/client/routes/components/TenantEntitlementGuard.tsx
@@ -39,9 +39,12 @@ const TenantEntitlementGuard: React.FC<{ children: React.ReactNode }> = ({
   useEffect(() => {
     if (authLoading) return;
 
-    // AuthProvider handles unauthenticated users; skip the entitlement check
-    // until we have a verified user.
-    if (!user || !netId || !tenant) return;
+    // No authenticated user yet — let unauthenticated pages (e.g. /signin)
+    // render normally; AuthProvider will drive the auth flow independently.
+    if (!user || !netId || !tenant) {
+      setEntitled(true);
+      return;
+    }
 
     // Test environments bypass entitlement enforcement.
     if (isOnTestEnv) {
@@ -74,8 +77,17 @@ const TenantEntitlementGuard: React.FC<{ children: React.ReactNode }> = ({
             setEntitled(false);
             router.replace("/");
           }
+        } else if (response.status === 401 || response.status === 403) {
+          // Auth failures mean the caller is not authenticated or not
+          // authorized — fail closed to avoid granting access on bad tokens.
+          console.warn(
+            `TenantEntitlementGuard: auth failure (${response.status}) — denying access`
+          );
+          setEntitled(false);
+          router.replace("/");
         } else {
-          // Fail open on non-OK responses to avoid blocking users unexpectedly.
+          // Transient upstream errors (5xx, etc.) — fail open so a flaky
+          // entitlements service doesn't lock out authenticated users.
           console.warn(
             `TenantEntitlementGuard: entitlements API returned ${response.status} — allowing access`
           );

--- a/booking-app/tests/unit/TenantEntitlementGuard.unit.test.tsx
+++ b/booking-app/tests/unit/TenantEntitlementGuard.unit.test.tsx
@@ -161,33 +161,65 @@ describe("TenantEntitlementGuard", () => {
 
   // ---------------------------------------------------------------------------
 
-  describe("error handling — fail open", () => {
-    it("renders children when the entitlements API returns a non-ok response", async () => {
-      mockUseParams.mockReturnValue({ tenant: "itp" });
-      vi.mocked(global.fetch).mockResolvedValue(makeErrorFetch(503));
+  describe("error handling", () => {
+    describe("fail open — transient errors", () => {
+      it("renders children when the entitlements API returns a 503", async () => {
+        mockUseParams.mockReturnValue({ tenant: "itp" });
+        vi.mocked(global.fetch).mockResolvedValue(await makeErrorFetch(503));
 
-      render(
-        <TenantEntitlementGuard>
-          <div>Fallback content</div>
-        </TenantEntitlementGuard>
-      );
+        render(
+          <TenantEntitlementGuard>
+            <div>Fallback content</div>
+          </TenantEntitlementGuard>
+        );
 
-      await waitFor(() => screen.getByText("Fallback content"));
-      expect(mockReplace).not.toHaveBeenCalled();
+        await waitFor(() => screen.getByText("Fallback content"));
+        expect(mockReplace).not.toHaveBeenCalled();
+      });
+
+      it("renders children when fetch throws a network error", async () => {
+        mockUseParams.mockReturnValue({ tenant: "itp" });
+        vi.mocked(global.fetch).mockRejectedValue(new Error("network failure"));
+
+        render(
+          <TenantEntitlementGuard>
+            <div>Fallback content</div>
+          </TenantEntitlementGuard>
+        );
+
+        await waitFor(() => screen.getByText("Fallback content"));
+        expect(mockReplace).not.toHaveBeenCalled();
+      });
     });
 
-    it("renders children when fetch throws a network error", async () => {
-      mockUseParams.mockReturnValue({ tenant: "itp" });
-      vi.mocked(global.fetch).mockRejectedValue(new Error("network failure"));
+    describe("fail closed — auth failures", () => {
+      it("redirects to / and renders nothing when the API returns 401", async () => {
+        mockUseParams.mockReturnValue({ tenant: "itp" });
+        vi.mocked(global.fetch).mockResolvedValue(await makeErrorFetch(401));
 
-      render(
-        <TenantEntitlementGuard>
-          <div>Fallback content</div>
-        </TenantEntitlementGuard>
-      );
+        const { container } = render(
+          <TenantEntitlementGuard>
+            <div>Protected content</div>
+          </TenantEntitlementGuard>
+        );
 
-      await waitFor(() => screen.getByText("Fallback content"));
-      expect(mockReplace).not.toHaveBeenCalled();
+        await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/"));
+        expect(container).toBeEmptyDOMElement();
+      });
+
+      it("redirects to / and renders nothing when the API returns 403", async () => {
+        mockUseParams.mockReturnValue({ tenant: "itp" });
+        vi.mocked(global.fetch).mockResolvedValue(await makeErrorFetch(403));
+
+        const { container } = render(
+          <TenantEntitlementGuard>
+            <div>Protected content</div>
+          </TenantEntitlementGuard>
+        );
+
+        await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/"));
+        expect(container).toBeEmptyDOMElement();
+      });
     });
   });
 
@@ -211,6 +243,29 @@ describe("TenantEntitlementGuard", () => {
       );
 
       await waitFor(() => screen.getByText("Test env content"));
+      expect(fetchSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("/api/nyu/entitlements"),
+        expect.anything()
+      );
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+
+  describe("unauthenticated bypass", () => {
+    it("renders children immediately when auth is done but user is null (e.g. signin page)", async () => {
+      mockUseParams.mockReturnValue({ tenant: "mc" });
+      mockUseAuth.mockReturnValue({ user: null, loading: false, isOnTestEnv: false, error: null });
+      const fetchSpy = vi.mocked(global.fetch);
+
+      render(
+        <TenantEntitlementGuard>
+          <div>Sign-in page</div>
+        </TenantEntitlementGuard>
+      );
+
+      await waitFor(() => screen.getByText("Sign-in page"));
       expect(fetchSpy).not.toHaveBeenCalledWith(
         expect.stringContaining("/api/nyu/entitlements"),
         expect.anything()

--- a/booking-app/tests/unit/TenantEntitlementGuard.unit.test.tsx
+++ b/booking-app/tests/unit/TenantEntitlementGuard.unit.test.tsx
@@ -243,10 +243,7 @@ describe("TenantEntitlementGuard", () => {
       );
 
       await waitFor(() => screen.getByText("Test env content"));
-      expect(fetchSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining("/api/nyu/entitlements"),
-        expect.anything()
-      );
+      expect(fetchSpy).not.toHaveBeenCalled();
       expect(mockReplace).not.toHaveBeenCalled();
     });
   });
@@ -266,10 +263,7 @@ describe("TenantEntitlementGuard", () => {
       );
 
       await waitFor(() => screen.getByText("Sign-in page"));
-      expect(fetchSpy).not.toHaveBeenCalledWith(
-        expect.stringContaining("/api/nyu/entitlements"),
-        expect.anything()
-      );
+      expect(fetchSpy).not.toHaveBeenCalled();
       expect(mockReplace).not.toHaveBeenCalled();
     });
   });

--- a/booking-app/tests/unit/TenantEntitlementGuard.unit.test.tsx
+++ b/booking-app/tests/unit/TenantEntitlementGuard.unit.test.tsx
@@ -1,0 +1,256 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { useParams, useRouter } from "next/navigation";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import TenantEntitlementGuard from "@/components/src/client/routes/components/TenantEntitlementGuard";
+
+// Override the global next/navigation mock so we control the router instance.
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(),
+  useParams: vi.fn(),
+  usePathname: vi.fn(() => "/"),
+}));
+
+vi.mock(
+  "@/components/src/client/routes/components/AuthProvider",
+  () => ({ useAuth: vi.fn() })
+);
+
+import { useAuth } from "@/components/src/client/routes/components/AuthProvider";
+
+const mockUseAuth = vi.mocked(useAuth);
+const mockUseParams = vi.mocked(useParams);
+const mockUseRouter = vi.mocked(useRouter);
+
+// Shared router spy — reused across all tests; cleared in afterEach.
+const mockReplace = vi.fn();
+
+const mockUser = {
+  email: "ab1234@nyu.edu",
+  getIdToken: vi.fn().mockResolvedValue("mock-id-token"),
+} as any;
+
+const makeOkFetch = (tenants: string[]) =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    json: async () => ({ entitledTenants: tenants }),
+  } as Response);
+
+const makeErrorFetch = (status = 503) =>
+  Promise.resolve({
+    ok: false,
+    status,
+    json: async () => ({}),
+  } as Response);
+
+beforeEach(() => {
+  mockUseRouter.mockReturnValue({ replace: mockReplace, push: vi.fn(), back: vi.fn() } as any);
+  mockUseAuth.mockReturnValue({ user: mockUser, loading: false, isOnTestEnv: false, error: null });
+  // Default: user is entitled to mc only.
+  vi.mocked(global.fetch).mockResolvedValue({
+    ok: true,
+    json: async () => ({ entitledTenants: ["mc"] }),
+  } as Response);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+
+describe("TenantEntitlementGuard", () => {
+  describe("entitled user", () => {
+    it("renders children when the user is entitled to the current tenant", async () => {
+      mockUseParams.mockReturnValue({ tenant: "mc" });
+      vi.mocked(global.fetch).mockResolvedValue(await makeOkFetch(["mc"]));
+
+      render(
+        <TenantEntitlementGuard>
+          <div>Protected content</div>
+        </TenantEntitlementGuard>
+      );
+
+      await waitFor(() => screen.getByText("Protected content"));
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+
+    it("canonicalizes mediaCommons to mc and renders children", async () => {
+      mockUseParams.mockReturnValue({ tenant: "mediaCommons" });
+      vi.mocked(global.fetch).mockResolvedValue(await makeOkFetch(["mc"]));
+
+      render(
+        <TenantEntitlementGuard>
+          <div>MC content</div>
+        </TenantEntitlementGuard>
+      );
+
+      await waitFor(() => screen.getByText("MC content"));
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+
+    it("renders children when the user is entitled to itp and visiting /itp", async () => {
+      mockUseParams.mockReturnValue({ tenant: "itp" });
+      vi.mocked(global.fetch).mockResolvedValue(await makeOkFetch(["mc", "itp"]));
+
+      render(
+        <TenantEntitlementGuard>
+          <div>ITP content</div>
+        </TenantEntitlementGuard>
+      );
+
+      await waitFor(() => screen.getByText("ITP content"));
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+
+    it("sends the Firebase ID token in the Authorization header", async () => {
+      mockUseParams.mockReturnValue({ tenant: "mc" });
+      const fetchSpy = vi.mocked(global.fetch).mockResolvedValue(
+        await makeOkFetch(["mc"])
+      );
+
+      render(
+        <TenantEntitlementGuard>
+          <div>Content</div>
+        </TenantEntitlementGuard>
+      );
+
+      await waitFor(() => screen.getByText("Content"));
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/api/nyu/entitlements/ab1234"),
+        expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: "Bearer mock-id-token" }),
+        })
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+
+  describe("non-entitled user", () => {
+    it("redirects to / when the tenant is not in the user's entitlements", async () => {
+      mockUseParams.mockReturnValue({ tenant: "itp" });
+      vi.mocked(global.fetch).mockResolvedValue(
+        await makeOkFetch(["mc"]) // mc only — itp not granted
+      );
+
+      render(
+        <TenantEntitlementGuard>
+          <div>ITP content</div>
+        </TenantEntitlementGuard>
+      );
+
+      await waitFor(() => expect(mockReplace).toHaveBeenCalledWith("/"));
+      expect(screen.queryByText("ITP content")).not.toBeInTheDocument();
+    });
+
+    it("does not render children when redirecting", async () => {
+      mockUseParams.mockReturnValue({ tenant: "itp" });
+      vi.mocked(global.fetch).mockResolvedValue(await makeOkFetch(["mc"]));
+
+      const { container } = render(
+        <TenantEntitlementGuard>
+          <div data-testid="child">Child</div>
+        </TenantEntitlementGuard>
+      );
+
+      await waitFor(() => expect(mockReplace).toHaveBeenCalled());
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+
+  describe("error handling — fail open", () => {
+    it("renders children when the entitlements API returns a non-ok response", async () => {
+      mockUseParams.mockReturnValue({ tenant: "itp" });
+      vi.mocked(global.fetch).mockResolvedValue(makeErrorFetch(503));
+
+      render(
+        <TenantEntitlementGuard>
+          <div>Fallback content</div>
+        </TenantEntitlementGuard>
+      );
+
+      await waitFor(() => screen.getByText("Fallback content"));
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+
+    it("renders children when fetch throws a network error", async () => {
+      mockUseParams.mockReturnValue({ tenant: "itp" });
+      vi.mocked(global.fetch).mockRejectedValue(new Error("network failure"));
+
+      render(
+        <TenantEntitlementGuard>
+          <div>Fallback content</div>
+        </TenantEntitlementGuard>
+      );
+
+      await waitFor(() => screen.getByText("Fallback content"));
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+
+  describe("test environment bypass", () => {
+    it("skips the entitlements fetch and renders children when isOnTestEnv is true", async () => {
+      mockUseParams.mockReturnValue({ tenant: "itp" });
+      mockUseAuth.mockReturnValue({
+        user: mockUser,
+        loading: false,
+        isOnTestEnv: true,
+        error: null,
+      });
+      const fetchSpy = vi.mocked(global.fetch);
+
+      render(
+        <TenantEntitlementGuard>
+          <div>Test env content</div>
+        </TenantEntitlementGuard>
+      );
+
+      await waitFor(() => screen.getByText("Test env content"));
+      expect(fetchSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("/api/nyu/entitlements"),
+        expect.anything()
+      );
+      expect(mockReplace).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+
+  describe("loading states", () => {
+    it("shows a spinner and hides children while auth is loading", () => {
+      mockUseParams.mockReturnValue({ tenant: "mc" });
+      mockUseAuth.mockReturnValue({ user: null, loading: true, isOnTestEnv: false, error: null });
+
+      render(
+        <TenantEntitlementGuard>
+          <div>Content</div>
+        </TenantEntitlementGuard>
+      );
+
+      expect(screen.getByRole("progressbar")).toBeInTheDocument();
+      expect(screen.queryByText("Content")).not.toBeInTheDocument();
+    });
+
+    it("shows a spinner while the entitlements check is in flight", async () => {
+      mockUseParams.mockReturnValue({ tenant: "mc" });
+      // Fetch that never resolves — guard stays in loading state.
+      vi.mocked(global.fetch).mockReturnValue(new Promise(() => {}));
+
+      render(
+        <TenantEntitlementGuard>
+          <div>Content</div>
+        </TenantEntitlementGuard>
+      );
+
+      await waitFor(() =>
+        expect(screen.getByRole("progressbar")).toBeInTheDocument()
+      );
+      expect(screen.queryByText("Content")).not.toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary of Changes

Redirect users back to the root url if they try to access an authorized tenant

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [x] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [ ] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [ ] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate