### PR TITLE
fix: include tenant prefix in liaison/admin email approval URLs

### DIFF
--- a/booking-app/app/api/bookings/edit/route.ts
+++ b/booking-app/app/api/bookings/edit/route.ts
@@ -120,6 +120,7 @@ async function sendEditNotificationEmails(
         approverType: ApproverType.LIAISON,
         replyTo: email,
         schemaName: emailConfig.schemaName,
+        tenant,
       }),
     );
 

--- a/booking-app/app/api/bookings/route.ts
+++ b/booking-app/app/api/bookings/route.ts
@@ -357,6 +357,7 @@ async function handleBookingApprovalEmails(
         approverType: ApproverType.LIAISON,
         replyTo: email,
         schemaName: emailConfig.schemaName,
+        tenant,
       });
     });
 

--- a/booking-app/app/lib/sendHTMLEmail.ts
+++ b/booking-app/app/lib/sendHTMLEmail.ts
@@ -37,6 +37,27 @@ interface SendHTMLEmailParams {
   subjectStatusOverride?: string;
 }
 
+export const getApprovalUrl = (
+  calendarEventId: string,
+  approverType?: ApproverType,
+  tenant?: string,
+): string => {
+  const tenantPrefix = tenant ? `/${tenant}` : "";
+  let urlPath: string;
+  switch (approverType) {
+    case ApproverType.LIAISON:
+      urlPath = `${tenantPrefix}/liaison`;
+      break;
+    case ApproverType.FINAL_APPROVER:
+      urlPath = `${tenantPrefix}/admin`;
+      break;
+    default:
+      urlPath = "/";
+  }
+
+  return `${process.env.NEXT_PUBLIC_BASE_URL}${urlPath}?calendarEventId=${calendarEventId}`;
+};
+
 export const sendHTMLEmail = async (params: SendHTMLEmailParams) => {
   const {
     templateName,
@@ -72,25 +93,6 @@ export const sendHTMLEmail = async (params: SendHTMLEmailParams) => {
   const subjectStatus = subjectStatusOverride || status;
   const subj = `${getEmailBranchTag()}${subjectStatus} - ${schemaName} Request #${requestNumber}: "${eventTitle}"`;
 
-  const getUrlPathByApproverType = (
-    calendarEventId,
-    approverType?: ApproverType,
-  ): string => {
-    let path: string;
-    switch (approverType) {
-      case ApproverType.LIAISON:
-        path = "/liaison";
-        break;
-      case ApproverType.FINAL_APPROVER:
-        path = "/admin";
-        break;
-      default:
-        path = "/";
-    }
-
-    return `${process.env.NEXT_PUBLIC_BASE_URL}${path}?calendarEventId=${calendarEventId}`;
-  };
-
   // Get booking logs
   const bookingLogs = await getBookingLogs(requestNumber, tenant);
 
@@ -117,7 +119,7 @@ export const sendHTMLEmail = async (params: SendHTMLEmailParams) => {
 
   const template = Handlebars.compile(templateSource);
   const approvalUrl = approverType
-    ? getUrlPathByApproverType(contents.calendarEventId, approverType)
+    ? getApprovalUrl(contents.calendarEventId, approverType, tenant)
     : undefined;
 
   // Update contents with formatted data for the template

--- a/booking-app/app/lib/sendHTMLEmail.ts
+++ b/booking-app/app/lib/sendHTMLEmail.ts
@@ -5,6 +5,7 @@ import {
 import { MEDIA_COMMONS_EMAIL } from "@/components/src/mediaCommonsPolicy";
 import { admins } from "@/components/src/server/admin";
 import { getEmailBranchTag } from "@/components/src/server/emails";
+import { DEFAULT_TENANT } from "@/components/src/constants/tenants";
 import { ApproverType } from "@/components/src/types";
 import { getBookingLogs } from "@/lib/firebase/server/adminDb";
 import { getGmailClient } from "@/lib/googleClient";
@@ -42,14 +43,14 @@ export const getApprovalUrl = (
   approverType?: ApproverType,
   tenant?: string,
 ): string => {
-  const tenantPrefix = tenant ? `/${tenant}` : "";
+  const resolvedTenant = tenant || DEFAULT_TENANT;
   let urlPath: string;
   switch (approverType) {
     case ApproverType.LIAISON:
-      urlPath = `${tenantPrefix}/liaison`;
+      urlPath = `/${resolvedTenant}/liaison`;
       break;
     case ApproverType.FINAL_APPROVER:
-      urlPath = `${tenantPrefix}/admin`;
+      urlPath = `/${resolvedTenant}/admin`;
       break;
     default:
       urlPath = "/";

--- a/booking-app/tests/unit/email-approval-url-tenant.unit.test.ts
+++ b/booking-app/tests/unit/email-approval-url-tenant.unit.test.ts
@@ -1,0 +1,43 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { getApprovalUrl } from "../../app/lib/sendHTMLEmail";
+import { ApproverType } from "../../components/src/types";
+
+describe("getApprovalUrl – tenant-aware URL generation", () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_BASE_URL = "https://example.com";
+  });
+
+  it("liaison URL includes tenant prefix when tenant is provided", () => {
+    const url = getApprovalUrl("evt-123", ApproverType.LIAISON, "media-commons");
+    expect(url).toBe(
+      "https://example.com/media-commons/liaison?calendarEventId=evt-123",
+    );
+  });
+
+  it("admin URL includes tenant prefix when tenant is provided", () => {
+    const url = getApprovalUrl("evt-123", ApproverType.FINAL_APPROVER, "itp");
+    expect(url).toBe(
+      "https://example.com/itp/admin?calendarEventId=evt-123",
+    );
+  });
+
+  it("liaison URL has no tenant prefix when tenant is undefined", () => {
+    const url = getApprovalUrl("evt-123", ApproverType.LIAISON);
+    expect(url).toBe(
+      "https://example.com/liaison?calendarEventId=evt-123",
+    );
+  });
+
+  it("admin URL has no tenant prefix when tenant is undefined", () => {
+    const url = getApprovalUrl("evt-123", ApproverType.FINAL_APPROVER);
+    expect(url).toBe(
+      "https://example.com/admin?calendarEventId=evt-123",
+    );
+  });
+
+  it("defaults to root path when approverType is not recognized", () => {
+    const url = getApprovalUrl("evt-123", undefined, "media-commons");
+    expect(url).toBe("https://example.com/?calendarEventId=evt-123");
+  });
+});

--- a/booking-app/tests/unit/email-approval-url-tenant.unit.test.ts
+++ b/booking-app/tests/unit/email-approval-url-tenant.unit.test.ts
@@ -1,11 +1,22 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { getApprovalUrl } from "../../app/lib/sendHTMLEmail";
+import { DEFAULT_TENANT } from "../../components/src/constants/tenants";
 import { ApproverType } from "../../components/src/types";
 
 describe("getApprovalUrl – tenant-aware URL generation", () => {
+  const originalBaseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+
   beforeEach(() => {
     process.env.NEXT_PUBLIC_BASE_URL = "https://example.com";
+  });
+
+  afterEach(() => {
+    if (originalBaseUrl === undefined) {
+      delete process.env.NEXT_PUBLIC_BASE_URL;
+    } else {
+      process.env.NEXT_PUBLIC_BASE_URL = originalBaseUrl;
+    }
   });
 
   it("liaison URL includes tenant prefix when tenant is provided", () => {
@@ -22,17 +33,17 @@ describe("getApprovalUrl – tenant-aware URL generation", () => {
     );
   });
 
-  it("liaison URL has no tenant prefix when tenant is undefined", () => {
+  it("falls back to DEFAULT_TENANT when tenant is undefined", () => {
     const url = getApprovalUrl("evt-123", ApproverType.LIAISON);
     expect(url).toBe(
-      "https://example.com/liaison?calendarEventId=evt-123",
+      `https://example.com/${DEFAULT_TENANT}/liaison?calendarEventId=evt-123`,
     );
   });
 
-  it("admin URL has no tenant prefix when tenant is undefined", () => {
+  it("falls back to DEFAULT_TENANT for admin when tenant is undefined", () => {
     const url = getApprovalUrl("evt-123", ApproverType.FINAL_APPROVER);
     expect(url).toBe(
-      "https://example.com/admin?calendarEventId=evt-123",
+      `https://example.com/${DEFAULT_TENANT}/admin?calendarEventId=evt-123`,
     );
   });
 


### PR DESCRIPTION
## Summary of Changes

The "Open Booking Tool" link at the bottom of email notifications sent to liaisons (and admins) was broken. The URL was generated as `/liaison?calendarEventId=...` but the actual Next.js route requires a `[tenant]` segment: `/{tenant}/liaison?calendarEventId=...`.

- Extracted `getApprovalUrl` from the internal `sendHTMLEmail` function and added a `tenant` parameter to prepend the tenant prefix to the URL path
- Updated `bookings/route.ts` and `bookings/edit/route.ts` to pass `tenant` when calling `sendHTMLEmail` for liaison notifications
- Added unit tests covering tenant-aware URL generation for liaison, admin, undefined tenant, and default cases

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [x] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video

https://github.com/user-attachments/assets/9a58e530-63e1-4461-886f-85bcbf6c5bf5


