### PR TITLE
fix: prevent auto-approval banner from showing before eligibility check

### DIFF
--- a/booking-app/components/src/client/routes/booking/components/BookingStatusBar.tsx
+++ b/booking-app/components/src/client/routes/booking/components/BookingStatusBar.tsx
@@ -42,10 +42,8 @@ const NavGrid = styled(Box)`
 export default function BookingStatusBar({ formContext, ...props }: Props) {
   const isWalkIn = formContext === FormContextLevel.WALK_IN;
   const isVIP = formContext === FormContextLevel.VIP;
-  const { isAutoApproval, errorMessage } = useCheckAutoApproval(
-    isWalkIn,
-    isVIP,
-  );
+  const { isAutoApproval, isCheckingAutoApproval, errorMessage } =
+    useCheckAutoApproval(isWalkIn, isVIP);
   const { durationError } = useCheckDurationLimits(isWalkIn, isVIP);
   const {
     bookingCalendarInfo,
@@ -182,7 +180,12 @@ export default function BookingStatusBar({ formContext, ...props }: Props) {
         ),
         severity: "error",
       };
-    if ((isWalkIn || isVIP) && !isAutoApproval && errorMessage) {
+    if (
+      (isWalkIn || isVIP) &&
+      !isCheckingAutoApproval &&
+      !isAutoApproval &&
+      errorMessage
+    ) {
       // Show actual error from auto-approval check (e.g., duration limits, services requested, multiple rooms, etc.)
       return {
         btnDisabled: true,

--- a/booking-app/components/src/client/routes/booking/hooks/useCheckAutoApproval.tsx
+++ b/booking-app/components/src/client/routes/booking/hooks/useCheckAutoApproval.tsx
@@ -33,7 +33,7 @@ export default function useCheckAutoApproval(isWalkIn = false, isVIP = false) {
     useContext(BookingContext);
   const schema = useTenantSchema();
 
-  const [isAutoApproval, setIsAutoApproval] = useState(true);
+  const [isAutoApproval, setIsAutoApproval] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const throwError = (msg: string) => {

--- a/booking-app/components/src/client/routes/booking/hooks/useCheckAutoApproval.tsx
+++ b/booking-app/components/src/client/routes/booking/hooks/useCheckAutoApproval.tsx
@@ -34,6 +34,7 @@ export default function useCheckAutoApproval(isWalkIn = false, isVIP = false) {
   const schema = useTenantSchema();
 
   const [isAutoApproval, setIsAutoApproval] = useState(false);
+  const [isCheckingAutoApproval, setIsCheckingAutoApproval] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const throwError = (msg: string) => {
@@ -158,6 +159,7 @@ export default function useCheckAutoApproval(isWalkIn = false, isVIP = false) {
         setErrorMessage("Unable to determine auto-approval eligibility");
       }
 
+      setIsCheckingAutoApproval(false);
       return; // Exit early for ITP tenant
     }
 
@@ -182,6 +184,7 @@ export default function useCheckAutoApproval(isWalkIn = false, isVIP = false) {
       throwError(
         "Requests for multiple rooms (except for 2 ballrooms) will require full approval",
       );
+      setIsCheckingAutoApproval(false);
       return;
     }
 
@@ -223,6 +226,7 @@ export default function useCheckAutoApproval(isWalkIn = false, isVIP = false) {
       throwError(
         result.reason || "Booking does not meet auto-approval requirements",
       );
+      setIsCheckingAutoApproval(false);
       return;
     }
 
@@ -232,6 +236,7 @@ export default function useCheckAutoApproval(isWalkIn = false, isVIP = false) {
     );
     setIsAutoApproval(true);
     setErrorMessage(null);
+    setIsCheckingAutoApproval(false);
   }, [
     // WARNING WARNING make sure to update this dep list if relying on new props
     bookingCalendarInfo,
@@ -242,5 +247,5 @@ export default function useCheckAutoApproval(isWalkIn = false, isVIP = false) {
     isWalkIn, // Added isWalkIn to dependencies
   ]);
 
-  return { isAutoApproval, errorMessage };
+  return { isAutoApproval, isCheckingAutoApproval, errorMessage };
 }

--- a/booking-app/tests/unit/auto-approval-initial-state.unit.test.tsx
+++ b/booking-app/tests/unit/auto-approval-initial-state.unit.test.tsx
@@ -1,5 +1,5 @@
-import { renderHook } from "@testing-library/react";
-import { useParams, usePathname, useRouter } from "next/navigation";
+import { act, renderHook } from "@testing-library/react";
+import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("next/navigation", () => ({
@@ -7,22 +7,6 @@ vi.mock("next/navigation", () => ({
   useParams: vi.fn(() => ({ tenant: "mc" })),
   usePathname: vi.fn(() => "/mc/booking"),
 }));
-
-// Mock BookingContext with no rooms selected and no calendar info
-vi.mock(
-  "@/components/src/client/routes/booking/bookingProvider",
-  () => ({
-    BookingContext: {
-      _currentValue: {
-        bookingCalendarInfo: null,
-        selectedRooms: [],
-        formData: null,
-        role: undefined,
-      },
-      Provider: ({ children }: any) => children,
-    },
-  }),
-);
 
 // Mock SchemaProvider
 vi.mock("@/components/src/client/routes/components/SchemaProvider", () => ({
@@ -32,7 +16,7 @@ vi.mock("@/components/src/client/routes/components/SchemaProvider", () => ({
   })),
 }));
 
-// Mock XState to prevent actual machine execution
+// Mock XState - returns "Requested" (not "Approved") to reject auto-approval
 vi.mock("xstate", () => ({
   createActor: vi.fn(() => ({
     start: vi.fn(),
@@ -52,14 +36,45 @@ vi.mock("@/lib/stateMachines/mcBookingMachine", () => ({
   mcBookingMachine: {},
 }));
 
+import { BookingContext } from "@/components/src/client/routes/booking/bookingProvider";
 import useCheckAutoApproval from "@/components/src/client/routes/booking/hooks/useCheckAutoApproval";
 
+const mockBookingContext = {
+  bookingCalendarInfo: null,
+  selectedRooms: [],
+  formData: null,
+  role: undefined,
+  department: undefined,
+  setDepartment: vi.fn(),
+  setRole: vi.fn(),
+  setFormData: vi.fn(),
+};
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <BookingContext.Provider value={mockBookingContext as any}>
+      {children}
+    </BookingContext.Provider>
+  );
+}
+
 describe("useCheckAutoApproval – initial state", () => {
-  it("should default isAutoApproval to false before eligibility is determined", () => {
-    const { result } = renderHook(() => useCheckAutoApproval());
-    // The initial render should NOT show auto-approval banner.
-    // XState mock returns "Requested" (not "Approved"), so after effect
-    // runs it should still be false.
+  it("should default isAutoApproval to false before eligibility check", () => {
+    // Capture the value on every render to verify the initial state
+    const renderValues: boolean[] = [];
+
+    const { result } = renderHook(() => {
+      const hook = useCheckAutoApproval();
+      renderValues.push(hook.isAutoApproval);
+      return hook;
+    }, { wrapper });
+
+    // The very first render must be false — this is the regression test.
+    // Before the fix, useState(true) caused the first render to be true,
+    // which flashed the auto-approval banner before useEffect ran.
+    expect(renderValues[0]).toBe(false);
+
+    // Final state should also be false (XState mock returns "Requested")
     expect(result.current.isAutoApproval).toBe(false);
   });
 });

--- a/booking-app/tests/unit/auto-approval-initial-state.unit.test.tsx
+++ b/booking-app/tests/unit/auto-approval-initial-state.unit.test.tsx
@@ -1,6 +1,6 @@
-import { act, renderHook } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
 import React from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("next/navigation", () => ({
   useRouter: vi.fn(() => ({ push: vi.fn() })),
@@ -59,22 +59,27 @@ function wrapper({ children }: { children: React.ReactNode }) {
 }
 
 describe("useCheckAutoApproval – initial state", () => {
-  it("should default isAutoApproval to false before eligibility check", () => {
-    // Capture the value on every render to verify the initial state
-    const renderValues: boolean[] = [];
+  it("should default isAutoApproval to false and isCheckingAutoApproval to true before eligibility check", () => {
+    // Capture values on every render to verify the initial state
+    const renderValues: { isAutoApproval: boolean; isCheckingAutoApproval: boolean }[] = [];
 
     const { result } = renderHook(() => {
       const hook = useCheckAutoApproval();
-      renderValues.push(hook.isAutoApproval);
+      renderValues.push({
+        isAutoApproval: hook.isAutoApproval,
+        isCheckingAutoApproval: hook.isCheckingAutoApproval,
+      });
       return hook;
     }, { wrapper });
 
-    // The very first render must be false — this is the regression test.
-    // Before the fix, useState(true) caused the first render to be true,
-    // which flashed the auto-approval banner before useEffect ran.
-    expect(renderValues[0]).toBe(false);
+    // The very first render must have isAutoApproval=false and isCheckingAutoApproval=true.
+    // Before the fix, useState(true) caused the first render to flash the
+    // auto-approval banner before useEffect ran.
+    expect(renderValues[0].isAutoApproval).toBe(false);
+    expect(renderValues[0].isCheckingAutoApproval).toBe(true);
 
-    // Final state should also be false (XState mock returns "Requested")
+    // Final state: check complete, auto-approval rejected (XState mock returns "Requested")
     expect(result.current.isAutoApproval).toBe(false);
+    expect(result.current.isCheckingAutoApproval).toBe(false);
   });
 });

--- a/booking-app/tests/unit/auto-approval-initial-state.unit.test.tsx
+++ b/booking-app/tests/unit/auto-approval-initial-state.unit.test.tsx
@@ -1,0 +1,65 @@
+import { renderHook } from "@testing-library/react";
+import { useParams, usePathname, useRouter } from "next/navigation";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
+  useParams: vi.fn(() => ({ tenant: "mc" })),
+  usePathname: vi.fn(() => "/mc/booking"),
+}));
+
+// Mock BookingContext with no rooms selected and no calendar info
+vi.mock(
+  "@/components/src/client/routes/booking/bookingProvider",
+  () => ({
+    BookingContext: {
+      _currentValue: {
+        bookingCalendarInfo: null,
+        selectedRooms: [],
+        formData: null,
+        role: undefined,
+      },
+      Provider: ({ children }: any) => children,
+    },
+  }),
+);
+
+// Mock SchemaProvider
+vi.mock("@/components/src/client/routes/components/SchemaProvider", () => ({
+  useTenantSchema: vi.fn(() => ({
+    tenant: "mc",
+    resources: [],
+  })),
+}));
+
+// Mock XState to prevent actual machine execution
+vi.mock("xstate", () => ({
+  createActor: vi.fn(() => ({
+    start: vi.fn(),
+    getSnapshot: vi.fn(() => ({
+      value: "Requested",
+      context: { tenant: "mc", selectedRooms: [] },
+    })),
+    stop: vi.fn(),
+  })),
+}));
+
+vi.mock("@/lib/stateMachines/itpBookingMachine", () => ({
+  itpBookingMachine: {},
+}));
+
+vi.mock("@/lib/stateMachines/mcBookingMachine", () => ({
+  mcBookingMachine: {},
+}));
+
+import useCheckAutoApproval from "@/components/src/client/routes/booking/hooks/useCheckAutoApproval";
+
+describe("useCheckAutoApproval – initial state", () => {
+  it("should default isAutoApproval to false before eligibility is determined", () => {
+    const { result } = renderHook(() => useCheckAutoApproval());
+    // The initial render should NOT show auto-approval banner.
+    // XState mock returns "Requested" (not "Approved"), so after effect
+    // runs it should still be false.
+    expect(result.current.isAutoApproval).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary of Changes

The "Yay! This request is eligible for automatic approval" banner was briefly shown for all rooms regardless of auto-approval eligibility. The root cause was `useState(true)` as the initial value for `isAutoApproval` in `useCheckAutoApproval`. This meant the banner displayed immediately on render, before the `useEffect` could check actual room eligibility.

Changed the initial state to `useState(false)` so the banner only appears after the eligibility check confirms auto-approval.

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [x] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video

N/A — One-line state initialization fix. Before: banner flashes on load for all rooms. After: banner only appears when eligibility is confirmed.