### PR TITLE
fix: use getFirestore(app, databaseId) for multi-database schema compare

### DIFF
--- a/booking-app/lib/firebase/server/multiDb.ts
+++ b/booking-app/lib/firebase/server/multiDb.ts
@@ -1,4 +1,5 @@
 import admin from "./firebaseAdmin";
+import { getFirestore } from "firebase-admin/firestore";
 import { DATABASES } from "./databases";
 import { TableNames } from "@/components/src/policy";
 
@@ -6,61 +7,19 @@ export type Environment = keyof typeof DATABASES;
 
 export const ENVIRONMENTS = Object.keys(DATABASES) as Environment[];
 
-// Cache Firestore instances so settings() is only called once per environment
-const firestoreCache = new Map<Environment, admin.firestore.Firestore>();
-
-/** @internal Exposed for testing only. */
-export function clearFirestoreCache() {
-  firestoreCache.clear();
-}
-
 /**
- * Get a Firestore instance for a specific environment.
- * Creates a named Firebase app per environment so multiple databases
- * can be accessed concurrently within the same request.
+ * Get a Firestore instance for a specific environment's database.
+ * Uses getFirestore(app, databaseId) so no named apps or settings() calls are needed.
  */
 export function getFirestoreForEnv(
   env: Environment,
 ): admin.firestore.Firestore {
-  const cached = firestoreCache.get(env);
-  if (cached) {
-    return cached;
-  }
-
   const databaseId = DATABASES[env];
   if (!databaseId) {
     throw new Error(`Unknown environment: ${env}`);
   }
 
-  const appName = `multi-db-${env}`;
-  let app: admin.app.App;
-
-  try {
-    app = admin.app(appName);
-  } catch {
-    try {
-      const defaultApp = admin.app();
-      app = admin.initializeApp(defaultApp.options, appName);
-    } catch (initError) {
-      // Handle race condition: another request may have initialized it
-      // between the first admin.app() check and initializeApp().
-      if (
-        initError instanceof Error &&
-        initError.message.includes("already exists")
-      ) {
-        app = admin.app(appName);
-      } else {
-        throw initError;
-      }
-    }
-  }
-
-  const db = app.firestore();
-  if (databaseId !== "(default)") {
-    db.settings({ databaseId });
-  }
-  firestoreCache.set(env, db);
-  return db;
+  return getFirestore(admin.app(), databaseId);
 }
 
 /**

--- a/booking-app/tests/unit/multiDb.unit.test.ts
+++ b/booking-app/tests/unit/multiDb.unit.test.ts
@@ -2,35 +2,28 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 
 vi.mock("@/lib/firebase/server/firebaseAdmin", () => ({
   default: {
-    app: vi.fn(),
-    initializeApp: vi.fn(),
+    app: vi.fn(() => ({ name: "[DEFAULT]" })),
     firestore: { Firestore: class {} },
   },
 }));
 
-import admin from "@/lib/firebase/server/firebaseAdmin";
+vi.mock("firebase-admin/firestore", () => ({
+  getFirestore: vi.fn(),
+}));
+
+import { getFirestore } from "firebase-admin/firestore";
 import {
   getFirestoreForEnv,
   getSchemaFromEnv,
-  clearFirestoreCache,
   ENVIRONMENTS,
   type Environment,
 } from "@/lib/firebase/server/multiDb";
 
-const mockApp = vi.mocked(admin.app);
-const mockInitializeApp = vi.mocked(admin.initializeApp);
-
-function createFakeApp(opts?: { settingsFn?: ReturnType<typeof vi.fn> }) {
-  const settingsFn = opts?.settingsFn ?? vi.fn();
-  return {
-    firestore: () => ({ settings: settingsFn }),
-  };
-}
+const mockGetFirestore = vi.mocked(getFirestore);
 
 describe("multiDb", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    clearFirestoreCache();
   });
 
   describe("ENVIRONMENTS", () => {
@@ -43,90 +36,43 @@ describe("multiDb", () => {
   });
 
   describe("getFirestoreForEnv", () => {
-    it("reuses an existing named app", () => {
-      const fakeApp = createFakeApp();
-      mockApp.mockReturnValue(fakeApp as any);
-
-      getFirestoreForEnv("development");
-
-      expect(mockApp).toHaveBeenCalledWith("multi-db-development");
-      expect(mockInitializeApp).not.toHaveBeenCalled();
-    });
-
-    it("creates a new named app when one does not exist", () => {
-      const fakeDefaultApp = { options: { projectId: "test" } };
-      const fakeNewApp = createFakeApp();
-
-      mockApp
-        .mockImplementationOnce(() => {
-          throw new Error("does not exist");
-        })
-        .mockReturnValueOnce(fakeDefaultApp as any);
-
-      mockInitializeApp.mockReturnValue(fakeNewApp as any);
-
-      getFirestoreForEnv("staging");
-
-      expect(mockInitializeApp).toHaveBeenCalledWith(
-        fakeDefaultApp.options,
-        "multi-db-staging",
-      );
-    });
-
-    it("applies databaseId settings for non-default databases", () => {
-      const settingsFn = vi.fn();
-      const fakeApp = createFakeApp({ settingsFn });
-      mockApp.mockReturnValue(fakeApp as any);
-
-      getFirestoreForEnv("production");
-
-      expect(settingsFn).toHaveBeenCalledWith({
-        databaseId: "booking-app-prod",
-      });
-    });
-
-    it("skips databaseId settings for the default database", () => {
-      const settingsFn = vi.fn();
-      const fakeApp = createFakeApp({ settingsFn });
-      mockApp.mockReturnValue(fakeApp as any);
-
-      getFirestoreForEnv("development");
-
-      expect(settingsFn).not.toHaveBeenCalled();
-    });
-
-    it("handles race condition when another request initializes the app concurrently", () => {
-      const fakeDefaultApp = { options: { projectId: "test" } };
-      const fakeApp = createFakeApp();
-
-      mockApp
-        .mockImplementationOnce(() => {
-          throw new Error("does not exist");
-        })
-        .mockReturnValueOnce(fakeDefaultApp as any)
-        .mockReturnValueOnce(fakeApp as any);
-
-      mockInitializeApp.mockImplementation(() => {
-        throw new Error('Firebase app named "multi-db-development" already exists');
-      });
+    it("calls getFirestore with (default) for development", () => {
+      const fakeDb = {};
+      mockGetFirestore.mockReturnValue(fakeDb as any);
 
       const result = getFirestoreForEnv("development");
 
-      expect(result).toBeDefined();
-      expect(mockApp).toHaveBeenCalledTimes(3);
+      expect(mockGetFirestore).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "[DEFAULT]" }),
+        "(default)",
+      );
+      expect(result).toBe(fakeDb);
     });
 
-    it("returns cached Firestore instance on subsequent calls", () => {
-      const settingsFn = vi.fn();
-      const fakeApp = createFakeApp({ settingsFn });
-      mockApp.mockReturnValue(fakeApp as any);
+    it("calls getFirestore with booking-app-prod for production", () => {
+      const fakeDb = {};
+      mockGetFirestore.mockReturnValue(fakeDb as any);
 
-      const first = getFirestoreForEnv("production");
-      const second = getFirestoreForEnv("production");
+      const result = getFirestoreForEnv("production");
 
-      expect(first).toBe(second);
-      // settings() should only be called once thanks to caching
-      expect(settingsFn).toHaveBeenCalledTimes(1);
+      expect(mockGetFirestore).toHaveBeenCalledWith(
+        expect.anything(),
+        "booking-app-prod",
+      );
+      expect(result).toBe(fakeDb);
+    });
+
+    it("calls getFirestore with booking-app-staging for staging", () => {
+      const fakeDb = {};
+      mockGetFirestore.mockReturnValue(fakeDb as any);
+
+      const result = getFirestoreForEnv("staging");
+
+      expect(mockGetFirestore).toHaveBeenCalledWith(
+        expect.anything(),
+        "booking-app-staging",
+      );
+      expect(result).toBe(fakeDb);
     });
 
     it("throws for unknown environments", () => {
@@ -145,10 +91,7 @@ describe("multiDb", () => {
       });
       const mockDoc = vi.fn(() => ({ get: mockGet }));
       const mockCollection = vi.fn(() => ({ doc: mockDoc }));
-      const fakeApp = {
-        firestore: () => ({ settings: vi.fn(), collection: mockCollection }),
-      };
-      mockApp.mockReturnValue(fakeApp as any);
+      mockGetFirestore.mockReturnValue({ collection: mockCollection } as any);
 
       const result = await getSchemaFromEnv("development", "mc");
 
@@ -161,10 +104,7 @@ describe("multiDb", () => {
       const mockGet = vi.fn().mockResolvedValue({ exists: false });
       const mockDoc = vi.fn(() => ({ get: mockGet }));
       const mockCollection = vi.fn(() => ({ doc: mockDoc }));
-      const fakeApp = {
-        firestore: () => ({ settings: vi.fn(), collection: mockCollection }),
-      };
-      mockApp.mockReturnValue(fakeApp as any);
+      mockGetFirestore.mockReturnValue({ collection: mockCollection } as any);
 
       const result = await getSchemaFromEnv("development", "nonexistent");
 


### PR DESCRIPTION
## Summary of Changes

- Replace the named-app + `db.settings({ databaseId })` approach in `multiDb.ts` with `getFirestore(app, databaseId)`, the proper Firebase Admin v12 API for multi-database access
- On GCP Production, `db.settings()` threw "Firestore has already been initialized" which was silently suppressed, causing all environments to read from `(default)` database — making schema compare show "No differences between development and production" even when differences existed
- The new approach requires no named apps, no settings() calls, and no caching — `getFirestore()` handles instance management internally

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video

N/A — Server-side fix. Verified locally by simulating Production environment (`NEXT_PUBLIC_DATABASE_NAME=booking-app-prod`) and confirming `getFirestore(app, databaseId)` correctly returns different data for development vs production databases.