### PR TITLE
refactor: Phase 3 — type safety improvements for MC booking machine

### DIFF
--- a/booking-app/lib/stateMachines/mcBookingMachine.ts
+++ b/booking-app/lib/stateMachines/mcBookingMachine.ts
@@ -1,6 +1,7 @@
 import { getBookingHourLimits } from "@/components/src/client/routes/booking/utils/bookingHourLimits";
 import { TENANTS } from "@/components/src/constants/tenants";
-import { BookingOrigin, Role } from "@/components/src/types";
+import { BookingOrigin, Inputs, Role, RoomSetting } from "@/components/src/types";
+import type { DateSelectArg } from "fullcalendar";
 import { BookingLogger } from "@/lib/logger/bookingLogger";
 import { logAutomaticCancellationTransition, type AutomaticCancellationReason } from "@/lib/stateMachines/logAutomaticCancellationTransition";
 import { and, assign, setup } from "xstate";
@@ -181,9 +182,9 @@ function createServiceGuards(configs: readonly ServiceConfig[]) {
 // Define context type for type safety
 interface MediaCommonsBookingContext {
   tenant?: string;
-  selectedRooms?: any[];
-  formData?: any;
-  bookingCalendarInfo?: any;
+  selectedRooms?: RoomSetting[];
+  formData?: Inputs;
+  bookingCalendarInfo?: DateSelectArg;
   isWalkIn?: boolean;
   calendarEventId?: string | null;
   email?: string;

--- a/booking-app/lib/stateMachines/mcBookingMachine.ts
+++ b/booking-app/lib/stateMachines/mcBookingMachine.ts
@@ -22,14 +22,21 @@ interface ServiceConfig {
   declineAction: string;
 }
 
-const SERVICE_CONFIGS: ServiceConfig[] = [
+const SERVICE_CONFIGS = [
   { name: "Staff",     contextKey: "staff",     requestGuard: "staffRequested",    approvedGuard: "staffApproved",    approveEvent: "approveStaff",     declineEvent: "declineStaff",     closeoutEvent: "closeoutStaff",     approveAction: "approveStaffService",     declineAction: "declineStaffService" },
   { name: "Catering",  contextKey: "catering",  requestGuard: "caterRequested",    approvedGuard: "cateringApproved", approveEvent: "approveCatering",  declineEvent: "declineCatering",  closeoutEvent: "closeoutCatering",  approveAction: "approveCateringService",  declineAction: "declineCateringService" },
   { name: "Setup",     contextKey: "setup",     requestGuard: "setupRequested",    approvedGuard: "setupApproved",    approveEvent: "approveSetup",     declineEvent: "declineSetup",     closeoutEvent: "closeoutSetup",     approveAction: "approveSetupService",     declineAction: "declineSetupService" },
   { name: "Cleaning",  contextKey: "cleaning",  requestGuard: "cleanRequested",    approvedGuard: "cleanApproved",    approveEvent: "approveCleaning",  declineEvent: "declineCleaning",  closeoutEvent: "closeoutCleaning",  approveAction: "approveCleaningService",  declineAction: "declineCleaningService" },
   { name: "Security",  contextKey: "security",  requestGuard: "securityRequested", approvedGuard: "securityApproved", approveEvent: "approveSecurity",  declineEvent: "declineSecurity",  closeoutEvent: "closeoutSecurity",  approveAction: "approveSecurityService",  declineAction: "declineSecurityService" },
   { name: "Equipment", contextKey: "equipment", requestGuard: "equipRequested",    approvedGuard: "equipApproved",    approveEvent: "approveEquipment", declineEvent: "declineEquipment", closeoutEvent: "closeoutEquipment", approveAction: "approveEquipmentService", declineAction: "declineEquipmentService" },
-];
+] as const satisfies readonly ServiceConfig[];
+
+// Derived event union — single source of truth is SERVICE_CONFIGS above.
+// Adding a service to SERVICE_CONFIGS automatically extends the event types.
+type ServiceEvent =
+  | { type: (typeof SERVICE_CONFIGS)[number]["approveEvent"] }
+  | { type: (typeof SERVICE_CONFIGS)[number]["declineEvent"] }
+  | { type: (typeof SERVICE_CONFIGS)[number]["closeoutEvent"] };
 
 function createServiceRequestState(config: ServiceConfig) {
   return {
@@ -135,7 +142,7 @@ function createServiceCloseoutState(config: ServiceConfig) {
   };
 }
 
-function createServiceActions(configs: ServiceConfig[]) {
+function createServiceActions(configs: readonly ServiceConfig[]) {
   const actions: Record<string, ReturnType<typeof assign>> = {};
   for (const config of configs) {
     actions[config.approveAction] = assign({
@@ -154,7 +161,7 @@ function createServiceActions(configs: ServiceConfig[]) {
   return actions;
 }
 
-function createServiceGuards(configs: ServiceConfig[]) {
+function createServiceGuards(configs: readonly ServiceConfig[]) {
   const guards: Record<string, (args: { context: MediaCommonsBookingContext }) => boolean> = {};
   for (const config of configs) {
     guards[config.requestGuard] = ({ context }: { context: MediaCommonsBookingContext }) => {
@@ -226,25 +233,8 @@ export const mcBookingMachine = setup({
       | { type: "checkIn" }
       | { type: "decline"; reason?: string }
       | { type: "checkOut" }
-      | { type: "approveSetup" }
-      | { type: "approveStaff" }
-      | { type: "declineSetup" }
-      | { type: "declineStaff" }
-      | { type: "closeoutSetup" }
-      | { type: "closeoutStaff" }
-      | { type: "approveCatering" }
-      | { type: "approveCleaning" }
-      | { type: "approveSecurity" }
-      | { type: "declineCatering" }
-      | { type: "declineCleaning" }
-      | { type: "declineSecurity" }
-      | { type: "approveEquipment" }
-      | { type: "closeoutCatering" }
-      | { type: "closeoutCleaning" }
-      | { type: "closeoutSecurity" }
-      | { type: "declineEquipment" }
-      | { type: "closeoutEquipment" }
-      | { type: "autoCloseScript" },
+      | { type: "autoCloseScript" }
+      | ServiceEvent,
   },
   actors: {},
   actions: {


### PR DESCRIPTION
## Summary of Changes

Phase 3 of the XState refactoring plan. Two small, safe type-only improvements to `mcBookingMachine.ts` — no runtime behavior changes.

**1. Derive event union from `SERVICE_CONFIGS`** (commit 55f410e2)

`SERVICE_CONFIGS` is now `as const satisfies readonly ServiceConfig[]`, preserving literal types. The hand-written union of 18 service event variants (`approveStaff`, `declineStaff`, `closeoutStaff`, …) is replaced with a single `ServiceEvent` type derived via indexed access on the const tuple. Adding a new service to the table now automatically extends the event types — no parallel list to keep in sync.

**2. Replace `any` in `MediaCommonsBookingContext`** (commit 24165fe2)

The three remaining `any` fields are now properly typed:

| Field | Before | After |
|---|---|---|
| `selectedRooms` | `any[]` | `RoomSetting[]` (from `components/src/types`) |
| `formData` | `any` | `Inputs` (from `components/src/types`) |
| `bookingCalendarInfo` | `any` | `DateSelectArg` (from `fullcalendar`) |

These match the types already used by the call sites in `app/api/bookings/route.ts` and `app/api/bookings/modification/route.ts`, so this is purely a documentation/safety improvement.

### Not in this PR

Tightening the `Object.fromEntries(...) as any` casts on the parallel `Services Request` / `Service Closeout` state objects was attempted and reverted: XState's `StatesConfig` generic widens factory-derived guard/event names to `string`, so a narrow cast target fails to type-check. The existing documented `as any` remains the safest escape hatch.

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description) — type-only refactor, existing 44 tests (mc-booking-machine.unit + .xstate.unit + xstate-approval-real-integration) cover the changes
- [x] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description) — type-only refactor, no UI changes
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video

N/A — type-only refactor with no UI or runtime behavior changes.