### PR TITLE
refactor: split handleStateTransitions into per-state handlers

### DIFF
--- a/booking-app/lib/stateMachines/effects/approvedEffects.ts
+++ b/booking-app/lib/stateMachines/effects/approvedEffects.ts
@@ -1,0 +1,43 @@
+import * as admin from "firebase-admin";
+import type { HandlerContext, StateHandler } from "./types";
+
+/**
+ * Handler for the `Approved` state entry.
+ *
+ * Side-effect footprint is intentionally minimal: the real approval
+ * side effects (emails, calendar status update, user invite) are handled
+ * by `/api/approve` → `finalApprove()` → `serverApproveEvent()` in the
+ * endpoint layer, not here. This handler only stamps the final-approval
+ * timestamps onto `firestoreUpdates` so the dispatcher persists them.
+ */
+export const handleApprovedEntry: StateHandler = async (
+  ctx: HandlerContext,
+) => {
+  const { calendarEventId, email, tenant, previousState, newState, firestoreUpdates } = ctx;
+
+  firestoreUpdates.finalApprovedAt = admin.firestore.Timestamp.now();
+  if (email) {
+    firestoreUpdates.finalApprovedBy = email;
+  }
+
+  console.log(
+    `🎉 XSTATE REACHED APPROVED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+    {
+      calendarEventId,
+      previousState,
+      newState,
+      finalApprovedAt: firestoreUpdates.finalApprovedAt,
+      finalApprovedBy: firestoreUpdates.finalApprovedBy,
+    },
+  );
+
+  console.log(
+    `📝 XSTATE APPROVED STATE REACHED - SIDE EFFECTS HANDLED EXTERNALLY [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+    {
+      calendarEventId,
+      email,
+      tenant,
+      note: "Approval side effects handled by /api/services or /api/approve",
+    },
+  );
+};

--- a/booking-app/lib/stateMachines/effects/canceledEffects.ts
+++ b/booking-app/lib/stateMachines/effects/canceledEffects.ts
@@ -1,0 +1,31 @@
+import * as admin from "firebase-admin";
+import type { HandlerContext, StateHandler } from "./types";
+
+/**
+ * Handler for the `Canceled` state entry.
+ *
+ * Stamps `canceledAt` / `canceledBy` onto `firestoreUpdates`. Calendar
+ * deletion and cancel emails are handled by the calling API layer or
+ * by downstream actors; this handler only records the audit fields.
+ */
+export const handleCanceledEntry: StateHandler = async (
+  ctx: HandlerContext,
+) => {
+  const { calendarEventId, email, tenant, previousState, newState, firestoreUpdates } = ctx;
+
+  firestoreUpdates.canceledAt = admin.firestore.Timestamp.now();
+  if (email) {
+    firestoreUpdates.canceledBy = email;
+  }
+
+  console.log(
+    `🔄 XSTATE REACHED CANCELED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+    {
+      calendarEventId,
+      previousState,
+      newState,
+      canceledAt: firestoreUpdates.canceledAt,
+      canceledBy: firestoreUpdates.canceledBy,
+    },
+  );
+};

--- a/booking-app/lib/stateMachines/effects/checkedInEffects.ts
+++ b/booking-app/lib/stateMachines/effects/checkedInEffects.ts
@@ -1,0 +1,78 @@
+import * as admin from "firebase-admin";
+import { cleanObjectForFirestore } from "../xstatePersistence";
+import type { HandlerContext, StateHandler } from "./types";
+
+/**
+ * Handler for the `Checked In` state entry.
+ *
+ * Stamps check-in timestamps and persists the XState snapshot into
+ * Firestore so that `statusFromXState` resolves correctly after reload.
+ * All other check-in processing (emails, calendar update, history log)
+ * is handled by `/api/checkin-processing`, called by the client after
+ * this dispatcher returns.
+ */
+export const handleCheckedInEntry: StateHandler = async (
+  ctx: HandlerContext,
+) => {
+  const {
+    calendarEventId,
+    email,
+    tenant,
+    previousState,
+    newState,
+    firestoreUpdates,
+    actor,
+    currentSnapshot,
+    newSnapshot,
+  } = ctx;
+
+  firestoreUpdates.checkedInAt = admin.firestore.Timestamp.now();
+  if (email) {
+    firestoreUpdates.checkedInBy = email;
+  }
+
+  console.log(
+    `📥 XSTATE REACHED CHECKED IN [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+    {
+      calendarEventId,
+      previousState,
+      newState,
+      note: "checkin-processing will be called by client",
+    },
+  );
+
+  // Persist XState snapshot so statusFromXState works correctly
+  try {
+    const { serverUpdateDataByCalendarEventId } =
+      await import("@/components/src/server/admin");
+    const { TableNames } = await import("@/components/src/policy");
+
+    const persistedSnapshot = actor.getPersistedSnapshot();
+    const cleanedSnapshot = cleanObjectForFirestore(persistedSnapshot);
+
+    const xstateDataToPersist = {
+      snapshot: cleanedSnapshot,
+      machineId: newSnapshot?.machine?.id || currentSnapshot?.machine?.id,
+      lastTransition: new Date().toISOString(),
+    };
+
+    await serverUpdateDataByCalendarEventId(
+      TableNames.BOOKING,
+      calendarEventId,
+      {
+        xstateData: xstateDataToPersist,
+      },
+      tenant,
+    );
+
+    console.log(
+      `💾 XSTATE CHECK-IN: SNAPSHOT PERSISTED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+      { calendarEventId, savedState: "Checked In" },
+    );
+  } catch (error) {
+    console.error(
+      `🚨 XSTATE CHECK-IN: FAILED TO PERSIST SNAPSHOT [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+      { calendarEventId, error: error instanceof Error ? error.message : String(error) },
+    );
+  }
+};

--- a/booking-app/lib/stateMachines/effects/closedEffects.ts
+++ b/booking-app/lib/stateMachines/effects/closedEffects.ts
@@ -1,0 +1,33 @@
+import type { HandlerContext, StateHandler } from "./types";
+
+/**
+ * Handler for the `Closed` state entry.
+ *
+ * Close-processing (emails, final calendar state, etc.) is triggered by
+ * the XState machine via `/api/close-processing`, not by this dispatcher.
+ * For the ITP auto-close path (Checked In → Checked Out → Closed via
+ * `always` transition), checkout-processing runs from `db.ts` checkOut()
+ * after this dispatcher returns; the special-case log below documents
+ * that flow.
+ */
+export const handleClosedEntry: StateHandler = async (
+  ctx: HandlerContext,
+) => {
+  const { calendarEventId, tenant, previousState, newState } = ctx;
+
+  console.log(
+    `🎯 XSTATE REACHED CLOSED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+    {
+      calendarEventId,
+      previousState,
+      newState,
+    },
+  );
+
+  if (previousState === "Checked In") {
+    console.log(
+      `📤 XSTATE CHECKOUT VIA AUTO-CLOSE [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+      { calendarEventId, previousState, newState, note: "checkout-processing will be called by client" },
+    );
+  }
+};

--- a/booking-app/lib/stateMachines/effects/declinedEffects.ts
+++ b/booking-app/lib/stateMachines/effects/declinedEffects.ts
@@ -1,0 +1,199 @@
+import type { SchemaContextType } from "@/components/src/client/routes/components/SchemaProvider";
+import { DEFAULT_TENANT } from "@/components/src/constants/tenants";
+import { TableNames } from "@/components/src/policy";
+import { getTenantEmailConfig } from "@/components/src/server/emails";
+import { BookingStatusLabel } from "@/components/src/types";
+import { serverGetDocumentById } from "@/lib/firebase/server/adminDb";
+import * as admin from "firebase-admin";
+import type { HandlerContext, StateHandler } from "./types";
+
+/**
+ * Handler for the `Declined` state entry.
+ *
+ * Most substantial side-effect handler in the dispatcher:
+ * 1. Stamps declinedAt / declinedBy onto firestoreUpdates
+ * 2. Composes and sends a decline email to the guest, including the
+ *    tenant-specific grace period and — for parallel state declines —
+ *    the list of specific services that were declined
+ * 3. PUTs /api/calendarEvents to prefix the Google Calendar event title
+ *    with `[DECLINED]`
+ */
+export const handleDeclinedEntry: StateHandler = async (
+  ctx: HandlerContext,
+) => {
+  const {
+    calendarEventId,
+    email,
+    tenant,
+    previousState,
+    newState,
+    firestoreUpdates,
+    bookingDoc,
+    newSnapshot,
+    reason,
+  } = ctx;
+
+  firestoreUpdates.declinedAt = admin.firestore.Timestamp.now();
+  if (email) {
+    firestoreUpdates.declinedBy = email;
+  }
+
+  console.log(
+    `❌ XSTATE REACHED DECLINED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+    {
+      calendarEventId,
+      previousState,
+      newState,
+      declinedAt: firestoreUpdates.declinedAt,
+      declinedBy: firestoreUpdates.declinedBy,
+      reason: "Service(s) declined",
+      servicesApproved: newSnapshot.context?.servicesApproved,
+    },
+  );
+
+  // Send decline email to guest using booking document email
+  try {
+    const guestEmail = bookingDoc?.email;
+
+    console.log(
+      `🔍 XSTATE DECLINE EMAIL DEBUG [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+      {
+        calendarEventId,
+        hasNewSnapshot: !!newSnapshot,
+        hasContext: !!newSnapshot.context,
+        contextKeys: newSnapshot.context
+          ? Object.keys(newSnapshot.context)
+          : [],
+        guestEmail,
+        contextEmail: bookingDoc?.email,
+      },
+    );
+
+    if (guestEmail) {
+      const { serverSendBookingDetailEmail } =
+        await import("@/components/src/server/admin");
+      const emailConfig = await getTenantEmailConfig(tenant);
+      let headerMessage = emailConfig.emailMessages.declined;
+
+      // Fetch tenant schema to get declinedGracePeriod (default: 24 hours)
+      const schema = tenant
+        ? await serverGetDocumentById<SchemaContextType>(
+            TableNames.TENANT_SCHEMA,
+            tenant,
+          )
+        : null;
+      const gracePeriodHours = schema?.declinedGracePeriod ?? 24;
+
+      // Check which services were declined and include them in the message
+      const declinedServices: string[] = [];
+      if (newSnapshot.context?.servicesApproved) {
+        const { servicesApproved } = newSnapshot.context;
+        const servicesRequested = newSnapshot.context.servicesRequested || {};
+
+        Object.entries(servicesApproved).forEach(([service, approved]) => {
+          if (servicesRequested[service] && approved === false) {
+            const serviceName =
+              service.charAt(0).toUpperCase() + service.slice(1);
+            declinedServices.push(serviceName);
+          }
+        });
+      }
+
+      // Use decline reason from XState context if available, fallback to reason parameter
+      let declineReason =
+        newSnapshot.context?.declineReason ||
+        reason ||
+        "Service requirements could not be fulfilled";
+
+      // If specific services were declined, include them in the reason
+      if (declinedServices.length > 0) {
+        const servicesList = declinedServices.join(", ");
+        declineReason = `The following service(s) could not be fulfilled: ${servicesList}`;
+      }
+
+      headerMessage += ` Reason: ${declineReason}. <br /><br />You have ${gracePeriodHours} hours to edit your request if you'd like to make changes. After ${gracePeriodHours} hours, your request will be automatically canceled. <br /><br />If you have any questions or need further assistance, please don't hesitate to reach out.`;
+
+      await serverSendBookingDetailEmail({
+        calendarEventId,
+        targetEmail: guestEmail,
+        headerMessage,
+        status: BookingStatusLabel.DECLINED,
+        tenant,
+      });
+
+      console.log(
+        `📧 XSTATE DECLINE EMAIL SENT [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+        {
+          calendarEventId,
+          guestEmail,
+          reason: declineReason,
+        },
+      );
+    } else {
+      console.warn(
+        `⚠️ XSTATE DECLINE EMAIL SKIPPED - NO EMAIL IN CONTEXT [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+        {
+          calendarEventId,
+          contextKeys: newSnapshot.context
+            ? Object.keys(newSnapshot.context)
+            : [],
+        },
+      );
+    }
+  } catch (error) {
+    console.error(
+      `🚨 XSTATE DECLINE EMAIL FAILED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+      {
+        calendarEventId,
+        email,
+        tenant,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+
+  // Update calendar event with DECLINED status
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_BASE_URL}/api/calendarEvents`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          "x-tenant": tenant || DEFAULT_TENANT,
+        },
+        body: JSON.stringify({
+          calendarEventId,
+          newValues: { statusPrefix: BookingStatusLabel.DECLINED },
+        }),
+      },
+    );
+
+    if (response.ok) {
+      console.log(
+        `📅 XSTATE DECLINE CALENDAR UPDATED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+        {
+          calendarEventId,
+          statusPrefix: BookingStatusLabel.DECLINED,
+        },
+      );
+    } else {
+      console.error(
+        `🚨 XSTATE DECLINE CALENDAR UPDATE FAILED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+        {
+          calendarEventId,
+          status: response.status,
+          statusText: response.statusText,
+        },
+      );
+    }
+  } catch (error) {
+    console.error(
+      `🚨 XSTATE DECLINE CALENDAR UPDATE ERROR [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+      {
+        calendarEventId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+};

--- a/booking-app/lib/stateMachines/effects/fallbackEffects.ts
+++ b/booking-app/lib/stateMachines/effects/fallbackEffects.ts
@@ -1,0 +1,221 @@
+import { DEFAULT_TENANT } from "@/components/src/constants/tenants";
+import { getTenantEmailConfig } from "@/components/src/server/emails";
+import { BookingStatusLabel } from "@/components/src/types";
+import { BookingLogger } from "@/lib/logger/bookingLogger";
+import * as admin from "firebase-admin";
+import type { HandlerContext, StateHandler } from "./types";
+
+/**
+ * Fallback handler invoked when no per-state handler matches the new
+ * state. Primarily handles XState parallel states (`Services Request`,
+ * `Service Closeout`) and generic status-label mapping for string states
+ * that aren't covered by a dedicated handler.
+ *
+ * For `Service Closeout` transitioned from `Checked In` (Media Commons),
+ * this also sends the check-out email and updates the Google Calendar
+ * event with the `[CHECKED_OUT]` prefix.
+ */
+export const handleFallbackEntry: StateHandler = async (
+  ctx: HandlerContext,
+) => {
+  const {
+    calendarEventId,
+    email,
+    tenant,
+    previousState,
+    newState,
+    firestoreUpdates,
+    bookingDoc,
+    skipCalendarForServiceCloseout,
+  } = ctx;
+
+  console.log(
+    `🔄 XSTATE GENERIC STATE CHANGE [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+    {
+      calendarEventId,
+      previousState,
+      newState,
+      email,
+    },
+  );
+
+  // Try to map XState to BookingStatusLabel for generic states
+  let statusLabel: BookingStatusLabel | null | undefined;
+  if (typeof newState === "string") {
+    switch (newState) {
+      case "Requested":
+        statusLabel = BookingStatusLabel.REQUESTED;
+        break;
+      case "No Show":
+        statusLabel = BookingStatusLabel.NO_SHOW;
+        break;
+      default:
+        break;
+    }
+  } else if (typeof newState === "object" && newState) {
+    // Handle parallel states
+    if ((newState as any)["Services Request"]) {
+      statusLabel = BookingStatusLabel.PRE_APPROVED;
+      console.log(
+        `🔀 XSTATE PARALLEL STATE: Services Request [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+        {
+          calendarEventId,
+          previousState,
+          newState,
+          statusLabel,
+        },
+      );
+    } else if ((newState as any)["Service Closeout"]) {
+      statusLabel = BookingStatusLabel.CHECKED_OUT;
+      console.log(
+        `🔀 XSTATE PARALLEL STATE: Service Closeout [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+        {
+          calendarEventId,
+          previousState,
+          newState,
+          statusLabel,
+          skipCalendarUpdate: skipCalendarForServiceCloseout,
+        },
+      );
+
+      // Handle check-out email for Service Closeout state (Media Commons)
+      if (previousState === "Checked In" && !skipCalendarForServiceCloseout) {
+        console.log(
+          `📧 SENDING CHECK-OUT EMAIL FOR SERVICE CLOSEOUT [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+          {
+            calendarEventId,
+            previousState,
+            newState: "Service Closeout",
+          },
+        );
+
+        // Set check-out timestamps for Firestore
+        firestoreUpdates.checkedOutAt = admin.firestore.Timestamp.now();
+        if (email) {
+          firestoreUpdates.checkedOutBy = email;
+        }
+
+        // Send check-out email to guest
+        try {
+          const guestEmail = bookingDoc?.email;
+
+          console.log(
+            `🔍 XSTATE SERVICE CLOSEOUT EMAIL DEBUG [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+            {
+              calendarEventId,
+              hasBookingDoc: !!bookingDoc,
+              bookingDocKeys: bookingDoc ? Object.keys(bookingDoc) : [],
+              guestEmail,
+              guestEmailType: typeof guestEmail,
+              bookingDocEmail: bookingDoc?.email,
+            },
+          );
+
+          if (guestEmail) {
+            const { serverSendBookingDetailEmail } =
+              await import("@/components/src/server/admin");
+            const emailConfig = await getTenantEmailConfig(tenant);
+            const headerMessage =
+              emailConfig.emailMessages.checkoutConfirmation;
+
+            await serverSendBookingDetailEmail({
+              calendarEventId,
+              targetEmail: guestEmail,
+              headerMessage,
+              status: BookingStatusLabel.CHECKED_OUT,
+              tenant,
+            });
+
+            console.log(
+              `📧 XSTATE SERVICE CLOSEOUT EMAIL SENT [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+              {
+                calendarEventId,
+                guestEmail,
+              },
+            );
+          } else {
+            console.warn(
+              `⚠️ XSTATE SERVICE CLOSEOUT EMAIL SKIPPED - NO EMAIL [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+              {
+                calendarEventId,
+                hasBookingDoc: !!bookingDoc,
+                bookingDocKeys: bookingDoc ? Object.keys(bookingDoc) : [],
+              },
+            );
+          }
+        } catch (error) {
+          console.error(
+            `🚨 XSTATE SERVICE CLOSEOUT EMAIL FAILED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+            {
+              calendarEventId,
+              email,
+              tenant,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+        }
+
+        // Update calendar event with CHECKED_OUT status
+        try {
+          const response = await fetch(
+            `${process.env.NEXT_PUBLIC_BASE_URL}/api/calendarEvents`,
+            {
+              method: "PUT",
+              headers: {
+                "Content-Type": "application/json",
+                "x-tenant": tenant || DEFAULT_TENANT,
+              },
+              body: JSON.stringify({
+                calendarEventId,
+                newValues: {
+                  statusPrefix: BookingStatusLabel.CHECKED_OUT,
+                },
+              }),
+            },
+          );
+
+          if (response.ok) {
+            BookingLogger.calendarUpdate(
+              "Service Closeout status update",
+              { calendarEventId, tenant },
+              { statusPrefix: BookingStatusLabel.CHECKED_OUT },
+            );
+          }
+        } catch (error) {
+          BookingLogger.calendarError(
+            "Service Closeout calendar update",
+            { calendarEventId, tenant },
+            error,
+          );
+        }
+      }
+
+      // Skip calendar update if this Service Closeout was triggered by No Show
+      if (skipCalendarForServiceCloseout) {
+        console.log(
+          `⏭️ SKIPPING SERVICE CLOSEOUT CALENDAR UPDATE - HANDLED BY NO SHOW [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+          {
+            calendarEventId,
+            reason: "No Show processing already updated calendar",
+          },
+        );
+        statusLabel = null; // Prevent generic history logging too
+      }
+    }
+  }
+
+  // Apply status label to Firestore updates if determined
+  if (statusLabel) {
+    firestoreUpdates.status = statusLabel;
+    console.log(
+      `📋 XSTATE STATUS UPDATE [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+      {
+        calendarEventId,
+        previousState,
+        newState,
+        statusLabel,
+        willUpdateDatabaseStatus: true,
+      },
+    );
+  }
+};

--- a/booking-app/lib/stateMachines/effects/noShowEffects.ts
+++ b/booking-app/lib/stateMachines/effects/noShowEffects.ts
@@ -1,0 +1,31 @@
+import * as admin from "firebase-admin";
+import type { HandlerContext, StateHandler } from "./types";
+
+/**
+ * Handler for the `No Show` state entry.
+ *
+ * Stamps `noShowedAt` / `noShowedBy` onto `firestoreUpdates`. Calendar
+ * updates and emails for no-show are handled by the calling API layer;
+ * this handler only persists the audit fields.
+ */
+export const handleNoShowEntry: StateHandler = async (
+  ctx: HandlerContext,
+) => {
+  const { calendarEventId, email, tenant, previousState, newState, firestoreUpdates } = ctx;
+
+  firestoreUpdates.noShowedAt = admin.firestore.Timestamp.now();
+  if (email) {
+    firestoreUpdates.noShowedBy = email;
+  }
+
+  console.log(
+    `🚫 XSTATE REACHED NO SHOW [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+    {
+      calendarEventId,
+      previousState,
+      newState,
+      noShowedAt: firestoreUpdates.noShowedAt,
+      noShowedBy: firestoreUpdates.noShowedBy,
+    },
+  );
+};

--- a/booking-app/lib/stateMachines/effects/preApprovedEffects.ts
+++ b/booking-app/lib/stateMachines/effects/preApprovedEffects.ts
@@ -1,0 +1,130 @@
+import { DEFAULT_TENANT } from "@/components/src/constants/tenants";
+import { BookingStatusLabel } from "@/components/src/types";
+import * as admin from "firebase-admin";
+import type { PersistedXStateData, PreApprovalUpdateData } from "../xstateTypes";
+import type { HandlerContext, StateHandler } from "./types";
+
+/**
+ * Handler for the `Pre-approved` state entry.
+ *
+ * Heavy branch: stamps `firstApprovedAt` / `firstApprovedBy`, pre-saves
+ * the pre-approval fields and persisted XState snapshot to Firestore
+ * via a dedicated write, then updates the Google Calendar event title
+ * with the `[PRE-APPROVED]` prefix.
+ */
+export const handlePreApprovedEntry: StateHandler = async (
+  ctx: HandlerContext,
+) => {
+  const {
+    calendarEventId,
+    email,
+    tenant,
+    previousState,
+    newState,
+    firestoreUpdates,
+  } = ctx;
+
+  firestoreUpdates.firstApprovedAt = admin.firestore.Timestamp.now();
+  if (email) {
+    firestoreUpdates.firstApprovedBy = email;
+  }
+
+  console.log(
+    `⏳ XSTATE REACHED PRE-APPROVED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+    {
+      calendarEventId,
+      previousState,
+      newState,
+      firstApprovedAt: firestoreUpdates.firstApprovedAt,
+      firstApprovedBy: firestoreUpdates.firstApprovedBy,
+    },
+  );
+
+  try {
+    const { serverUpdateDataByCalendarEventId } =
+      await import("@/components/src/server/admin");
+    const { TableNames } = await import("@/components/src/policy");
+    const preApprovalUpdateData: PreApprovalUpdateData = {
+      firstApprovedAt:
+        firestoreUpdates.firstApprovedAt as admin.firestore.Timestamp,
+      ...(firestoreUpdates.firstApprovedBy
+        ? { firstApprovedBy: firestoreUpdates.firstApprovedBy as string }
+        : {}),
+    };
+
+    if (firestoreUpdates.xstateData) {
+      preApprovalUpdateData.xstateData =
+        firestoreUpdates.xstateData as PersistedXStateData;
+    }
+
+    await serverUpdateDataByCalendarEventId(
+      TableNames.BOOKING,
+      calendarEventId,
+      preApprovalUpdateData,
+      tenant,
+    );
+
+    console.log(
+      `💾 PRE-APPROVED DATA SAVED TO DB BEFORE CALENDAR UPDATE [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+      {
+        calendarEventId,
+        savedFields: Object.keys(preApprovalUpdateData),
+        hasXStateData: !!preApprovalUpdateData.xstateData,
+      },
+    );
+  } catch (error) {
+    console.error(
+      `🚨 FAILED TO PRE-SAVE PRE-APPROVED DATA [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+      {
+        calendarEventId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    // Don't throw - continue with calendar update even if DB save failed
+  }
+
+  // Update calendar event with PRE_APPROVED status
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_BASE_URL}/api/calendarEvents`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          "x-tenant": tenant || DEFAULT_TENANT,
+        },
+        body: JSON.stringify({
+          calendarEventId,
+          newValues: { statusPrefix: BookingStatusLabel.PRE_APPROVED },
+        }),
+      },
+    );
+
+    if (response.ok) {
+      console.log(
+        `📅 XSTATE PRE-APPROVED CALENDAR UPDATED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+        {
+          calendarEventId,
+          statusPrefix: BookingStatusLabel.PRE_APPROVED,
+        },
+      );
+    } else {
+      console.error(
+        `🚨 XSTATE PRE-APPROVED CALENDAR UPDATE FAILED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+        {
+          calendarEventId,
+          status: response.status,
+          statusText: response.statusText,
+        },
+      );
+    }
+  } catch (error) {
+    console.error(
+      `🚨 XSTATE PRE-APPROVED CALENDAR UPDATE ERROR [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+      {
+        calendarEventId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+};

--- a/booking-app/lib/stateMachines/effects/requestedEffects.ts
+++ b/booking-app/lib/stateMachines/effects/requestedEffects.ts
@@ -1,0 +1,24 @@
+import type { HandlerContext, StateHandler } from "./types";
+
+/**
+ * Handler for the `Requested` state entry.
+ *
+ * Decline field cleanup, history logging, and calendar updates for
+ * re-requested bookings are handled by the calling API layer, not here.
+ * This handler only logs the transition for observability.
+ */
+export const handleRequestedEntry: StateHandler = async (
+  ctx: HandlerContext,
+) => {
+  const { calendarEventId, tenant, previousState, newState } = ctx;
+
+  console.log(
+    `🔄 XSTATE REACHED REQUESTED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+    {
+      calendarEventId,
+      previousState,
+      newState,
+      note: "Decline field cleanup handled by calling API",
+    },
+  );
+};

--- a/booking-app/lib/stateMachines/effects/types.ts
+++ b/booking-app/lib/stateMachines/effects/types.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared types for per-state effect handlers in `handleStateTransitions`.
+ *
+ * Each handler receives a single `HandlerContext` bundling everything it
+ * might need — the state transition metadata, the booking document already
+ * fetched from Firestore, and the mutable `firestoreUpdates` object that
+ * the dispatcher will persist after handlers run.
+ *
+ * The dispatcher builds the context once per transition; handlers read
+ * from it freely and mutate `firestoreUpdates` to queue field updates.
+ */
+export interface HandlerContext {
+  previousState: string;
+  newState: string | object;
+  calendarEventId: string;
+  email: string;
+  tenant: string;
+  firestoreUpdates: any;
+  bookingDoc: any;
+  skipCalendarForServiceCloseout: boolean;
+  isXStateCreation: boolean;
+  reason?: string;
+}
+
+export type StateHandler = (ctx: HandlerContext) => Promise<void>;

--- a/booking-app/lib/stateMachines/effects/types.ts
+++ b/booking-app/lib/stateMachines/effects/types.ts
@@ -14,6 +14,7 @@ export interface HandlerContext {
   newState: string | object;
   currentSnapshot: any;
   newSnapshot: any;
+  actor: any;
   calendarEventId: string;
   email: string;
   tenant: string;

--- a/booking-app/lib/stateMachines/effects/types.ts
+++ b/booking-app/lib/stateMachines/effects/types.ts
@@ -12,6 +12,8 @@
 export interface HandlerContext {
   previousState: string;
   newState: string | object;
+  currentSnapshot: any;
+  newSnapshot: any;
   calendarEventId: string;
   email: string;
   tenant: string;

--- a/booking-app/lib/stateMachines/effects/types.ts
+++ b/booking-app/lib/stateMachines/effects/types.ts
@@ -16,8 +16,8 @@ export interface HandlerContext {
   newSnapshot: any;
   actor: any;
   calendarEventId: string;
-  email: string;
-  tenant: string;
+  email?: string;
+  tenant?: string;
   firestoreUpdates: any;
   bookingDoc: any;
   skipCalendarForServiceCloseout: boolean;

--- a/booking-app/lib/stateMachines/xstateEffects.ts
+++ b/booking-app/lib/stateMachines/xstateEffects.ts
@@ -16,6 +16,7 @@ import { handleCheckedInEntry } from "./effects/checkedInEffects";
 import { handleClosedEntry } from "./effects/closedEffects";
 import { handleDeclinedEntry } from "./effects/declinedEffects";
 import { handleNoShowEntry } from "./effects/noShowEffects";
+import { handlePreApprovedEntry } from "./effects/preApprovedEffects";
 import { handleRequestedEntry } from "./effects/requestedEffects";
 import type { HandlerContext, StateHandler } from "./effects/types";
 
@@ -30,6 +31,7 @@ const stateHandlers: Partial<Record<string, StateHandler>> = {
   "Closed": handleClosedEntry,
   "Declined": handleDeclinedEntry,
   "Checked In": handleCheckedInEntry,
+  "Pre-approved": handlePreApprovedEntry,
 };
 
 // Note: History logging is now handled by traditional functions only
@@ -137,111 +139,6 @@ export async function handleStateTransitions(
       reason,
     };
     await extractedHandler(handlerCtx);
-  } else if (newState === "Pre-approved" && previousState !== "Pre-approved") {
-    // Pre-approved state handling
-    firestoreUpdates.firstApprovedAt = admin.firestore.Timestamp.now();
-    if (email) {
-      firestoreUpdates.firstApprovedBy = email;
-    }
-
-    console.log(
-      `⏳ XSTATE REACHED PRE-APPROVED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-      {
-        calendarEventId,
-        previousState,
-        newState,
-        firstApprovedAt: firestoreUpdates.firstApprovedAt,
-        firstApprovedBy: firestoreUpdates.firstApprovedBy,
-      },
-    );
-
-    try {
-      const { serverUpdateDataByCalendarEventId } =
-        await import("@/components/src/server/admin");
-      const { TableNames } = await import("@/components/src/policy");
-      const preApprovalUpdateData: PreApprovalUpdateData = {
-        firstApprovedAt:
-          firestoreUpdates.firstApprovedAt as admin.firestore.Timestamp,
-        ...(firestoreUpdates.firstApprovedBy
-          ? { firstApprovedBy: firestoreUpdates.firstApprovedBy as string }
-          : {}),
-      };
-
-      if (firestoreUpdates.xstateData) {
-        preApprovalUpdateData.xstateData =
-          firestoreUpdates.xstateData as PersistedXStateData;
-      }
-
-      await serverUpdateDataByCalendarEventId(
-        TableNames.BOOKING,
-        calendarEventId,
-        preApprovalUpdateData,
-        tenant,
-      );
-
-      console.log(
-        `💾 PRE-APPROVED DATA SAVED TO DB BEFORE CALENDAR UPDATE [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-        {
-          calendarEventId,
-          savedFields: Object.keys(preApprovalUpdateData),
-          hasXStateData: !!preApprovalUpdateData.xstateData,
-        },
-      );
-    } catch (error) {
-      console.error(
-        `🚨 FAILED TO PRE-SAVE PRE-APPROVED DATA [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-        {
-          calendarEventId,
-          error: error instanceof Error ? error.message : String(error),
-        },
-      );
-      // Don't throw - continue with calendar update even if DB save failed
-    }
-
-    // Update calendar event with PRE_APPROVED status
-    try {
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BASE_URL}/api/calendarEvents`,
-        {
-          method: "PUT",
-          headers: {
-            "Content-Type": "application/json",
-            "x-tenant": tenant || DEFAULT_TENANT,
-          },
-          body: JSON.stringify({
-            calendarEventId,
-            newValues: { statusPrefix: BookingStatusLabel.PRE_APPROVED },
-          }),
-        },
-      );
-
-      if (response.ok) {
-        console.log(
-          `📅 XSTATE PRE-APPROVED CALENDAR UPDATED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-          {
-            calendarEventId,
-            statusPrefix: BookingStatusLabel.PRE_APPROVED,
-          },
-        );
-      } else {
-        console.error(
-          `🚨 XSTATE PRE-APPROVED CALENDAR UPDATE FAILED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-          {
-            calendarEventId,
-            status: response.status,
-            statusText: response.statusText,
-          },
-        );
-      }
-    } catch (error) {
-      console.error(
-        `🚨 XSTATE PRE-APPROVED CALENDAR UPDATE ERROR [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-        {
-          calendarEventId,
-          error: error.message,
-        },
-      );
-    }
   } else {
     // Generic state change - still log to history for tracking
     console.log(

--- a/booking-app/lib/stateMachines/xstateEffects.ts
+++ b/booking-app/lib/stateMachines/xstateEffects.ts
@@ -13,6 +13,7 @@ import { cleanObjectForFirestore } from "./xstatePersistence";
 import { handleApprovedEntry } from "./effects/approvedEffects";
 import { handleCanceledEntry } from "./effects/canceledEffects";
 import { handleClosedEntry } from "./effects/closedEffects";
+import { handleDeclinedEntry } from "./effects/declinedEffects";
 import { handleNoShowEntry } from "./effects/noShowEffects";
 import { handleRequestedEntry } from "./effects/requestedEffects";
 import type { HandlerContext, StateHandler } from "./effects/types";
@@ -26,6 +27,7 @@ const stateHandlers: Partial<Record<string, StateHandler>> = {
   "No Show": handleNoShowEntry,
   "Canceled": handleCanceledEntry,
   "Closed": handleClosedEntry,
+  "Declined": handleDeclinedEntry,
 };
 
 // Note: History logging is now handled by traditional functions only
@@ -120,6 +122,8 @@ export async function handleStateTransitions(
     const handlerCtx: HandlerContext = {
       previousState,
       newState,
+      currentSnapshot,
+      newSnapshot,
       calendarEventId,
       email,
       tenant,
@@ -130,176 +134,6 @@ export async function handleStateTransitions(
       reason,
     };
     await extractedHandler(handlerCtx);
-  } else if (newState === "Declined" && previousState !== "Declined") {
-    // Declined state handling
-    firestoreUpdates.declinedAt = admin.firestore.Timestamp.now();
-    if (email) {
-      firestoreUpdates.declinedBy = email;
-    }
-
-    console.log(
-      `❌ XSTATE REACHED DECLINED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-      {
-        calendarEventId,
-        previousState,
-        newState,
-        declinedAt: firestoreUpdates.declinedAt,
-        declinedBy: firestoreUpdates.declinedBy,
-        reason: "Service(s) declined",
-        servicesApproved: newSnapshot.context?.servicesApproved,
-      },
-    );
-
-    // Note: History logging is now handled by traditional functions only
-    // XState only manages state transitions, not history logging
-
-    // Send decline email to guest using booking document email
-    try {
-      // Use email from booking document (not from XState context)
-      const guestEmail = bookingDoc?.email;
-
-      console.log(
-        `🔍 XSTATE DECLINE EMAIL DEBUG [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-        {
-          calendarEventId,
-          hasNewSnapshot: !!newSnapshot,
-          hasContext: !!newSnapshot.context,
-          contextKeys: newSnapshot.context
-            ? Object.keys(newSnapshot.context)
-            : [],
-          guestEmail,
-          contextEmail: bookingDoc?.email,
-        },
-      );
-
-      if (guestEmail) {
-        const { serverSendBookingDetailEmail } =
-          await import("@/components/src/server/admin");
-        const emailConfig = await getTenantEmailConfig(tenant);
-        let headerMessage = emailConfig.emailMessages.declined;
-
-        // Fetch tenant schema to get declinedGracePeriod (default: 24 hours)
-        const schema = tenant
-          ? await serverGetDocumentById<SchemaContextType>(
-              TableNames.TENANT_SCHEMA,
-              tenant,
-            )
-          : null;
-        const gracePeriodHours = schema?.declinedGracePeriod ?? 24;
-
-        // Check which services were declined and include them in the message
-        const declinedServices = [];
-        if (newSnapshot.context?.servicesApproved) {
-          const { servicesApproved } = newSnapshot.context;
-          const servicesRequested = newSnapshot.context.servicesRequested || {};
-
-          Object.entries(servicesApproved).forEach(([service, approved]) => {
-            if (servicesRequested[service] && approved === false) {
-              // Capitalize first letter of service name
-              const serviceName =
-                service.charAt(0).toUpperCase() + service.slice(1);
-              declinedServices.push(serviceName);
-            }
-          });
-        }
-
-        // Use decline reason from XState context if available, fallback to reason parameter
-        let declineReason =
-          newSnapshot.context?.declineReason ||
-          reason ||
-          "Service requirements could not be fulfilled";
-
-        // If specific services were declined, include them in the reason
-        if (declinedServices.length > 0) {
-          const servicesList = declinedServices.join(", ");
-          declineReason = `The following service(s) could not be fulfilled: ${servicesList}`;
-        }
-
-        headerMessage += ` Reason: ${declineReason}. <br /><br />You have ${gracePeriodHours} hours to edit your request if you'd like to make changes. After ${gracePeriodHours} hours, your request will be automatically canceled. <br /><br />If you have any questions or need further assistance, please don't hesitate to reach out.`;
-
-        await serverSendBookingDetailEmail({
-          calendarEventId,
-          targetEmail: guestEmail,
-          headerMessage,
-          status: BookingStatusLabel.DECLINED,
-          tenant,
-        });
-
-        console.log(
-          `📧 XSTATE DECLINE EMAIL SENT [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-          {
-            calendarEventId,
-            guestEmail,
-            reason: declineReason,
-          },
-        );
-      } else {
-        console.warn(
-          `⚠️ XSTATE DECLINE EMAIL SKIPPED - NO EMAIL IN CONTEXT [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-          {
-            calendarEventId,
-            contextKeys: newSnapshot.context
-              ? Object.keys(newSnapshot.context)
-              : [],
-          },
-        );
-      }
-    } catch (error) {
-      console.error(
-        `🚨 XSTATE DECLINE EMAIL FAILED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-        {
-          calendarEventId,
-          email,
-          tenant,
-          error: error.message,
-        },
-      );
-    }
-
-    // Update calendar event with DECLINED status
-    try {
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BASE_URL}/api/calendarEvents`,
-        {
-          method: "PUT",
-          headers: {
-            "Content-Type": "application/json",
-            "x-tenant": tenant || DEFAULT_TENANT,
-          },
-          body: JSON.stringify({
-            calendarEventId,
-            newValues: { statusPrefix: BookingStatusLabel.DECLINED },
-          }),
-        },
-      );
-
-      if (response.ok) {
-        console.log(
-          `📅 XSTATE DECLINE CALENDAR UPDATED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-          {
-            calendarEventId,
-            statusPrefix: BookingStatusLabel.DECLINED,
-          },
-        );
-      } else {
-        console.error(
-          `🚨 XSTATE DECLINE CALENDAR UPDATE FAILED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-          {
-            calendarEventId,
-            status: response.status,
-            statusText: response.statusText,
-          },
-        );
-      }
-    } catch (error) {
-      console.error(
-        `🚨 XSTATE DECLINE CALENDAR UPDATE ERROR [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-        {
-          calendarEventId,
-          error: error.message,
-        },
-      );
-    }
   } else if (newState === "Checked In" && previousState !== "Checked In") {
     // Check-in state handling - persist XState snapshot only
     // All other processing (Firestore timestamps, email, calendar, history) is handled by /api/checkin-processing

--- a/booking-app/lib/stateMachines/xstateEffects.ts
+++ b/booking-app/lib/stateMachines/xstateEffects.ts
@@ -11,6 +11,7 @@ import * as admin from "firebase-admin";
 import type { PersistedXStateData, PreApprovalUpdateData } from "./xstateTypes";
 import { cleanObjectForFirestore } from "./xstatePersistence";
 import { handleApprovedEntry } from "./effects/approvedEffects";
+import { handleCanceledEntry } from "./effects/canceledEffects";
 import { handleNoShowEntry } from "./effects/noShowEffects";
 import { handleRequestedEntry } from "./effects/requestedEffects";
 import type { HandlerContext, StateHandler } from "./effects/types";
@@ -22,6 +23,7 @@ const stateHandlers: Partial<Record<string, StateHandler>> = {
   "Approved": handleApprovedEntry,
   "Requested": handleRequestedEntry,
   "No Show": handleNoShowEntry,
+  "Canceled": handleCanceledEntry,
 };
 
 // Note: History logging is now handled by traditional functions only
@@ -296,23 +298,6 @@ export async function handleStateTransitions(
         },
       );
     }
-  } else if (newState === "Canceled" && previousState !== "Canceled") {
-    // Canceled state handling - update Firestore fields
-    firestoreUpdates.canceledAt = admin.firestore.Timestamp.now();
-    if (email) {
-      firestoreUpdates.canceledBy = email;
-    }
-
-    console.log(
-      `🔄 XSTATE REACHED CANCELED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-      {
-        calendarEventId,
-        previousState,
-        newState,
-        canceledAt: firestoreUpdates.canceledAt,
-        canceledBy: firestoreUpdates.canceledBy,
-      },
-    );
   } else if (newState === "Closed" && previousState !== "Closed") {
     console.log(
       `🎯 XSTATE REACHED CLOSED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,

--- a/booking-app/lib/stateMachines/xstateEffects.ts
+++ b/booking-app/lib/stateMachines/xstateEffects.ts
@@ -11,11 +11,28 @@ import { handlePreApprovedEntry } from "./effects/preApprovedEffects";
 import { handleRequestedEntry } from "./effects/requestedEffects";
 import type { HandlerContext, StateHandler } from "./effects/types";
 
+// States that have a dedicated per-state handler. Any string state
+// not in this union falls through to `handleFallbackEntry`.
+type HandledState =
+  | "Approved"
+  | "Requested"
+  | "No Show"
+  | "Canceled"
+  | "Closed"
+  | "Declined"
+  | "Checked In"
+  | "Pre-approved";
+
 // Registry of per-state entry handlers. Dispatcher delegates to one of
 // these when `newState` is a string key present in the map. Otherwise
 // the fallback handler runs (for XState parallel states and the
 // catch-all generic status-label mapping).
-const stateHandlers: Partial<Record<string, StateHandler>> = {
+//
+// `satisfies` enforces that every key in HandledState is wired up —
+// adding a new state to HandledState without adding a handler is a
+// compile-time error. Keys must still be looked up with a string index
+// since `newState` is typed `string`.
+const stateHandlers = {
   "Approved": handleApprovedEntry,
   "Requested": handleRequestedEntry,
   "No Show": handleNoShowEntry,
@@ -24,7 +41,7 @@ const stateHandlers: Partial<Record<string, StateHandler>> = {
   "Declined": handleDeclinedEntry,
   "Checked In": handleCheckedInEntry,
   "Pre-approved": handlePreApprovedEntry,
-};
+} satisfies Record<HandledState, StateHandler>;
 
 // Note: History logging is now handled by traditional functions only
 // XState only manages state transitions, not history logging
@@ -107,11 +124,12 @@ export async function handleStateTransitions(
   );
 
   // Per-state dispatch: if an extracted handler exists for this string
-  // state and the previous state differs, delegate to it. Otherwise fall
-  // through to the inline branches still living in this function.
+  // state and the previous state differs, delegate to it. Otherwise the
+  // fallback handler runs (XState parallel states, generic status
+  // mapping, and Service Closeout check-out email/calendar path).
   const extractedHandler =
     typeof newState === "string" && newState !== previousState
-      ? stateHandlers[newState]
+      ? (stateHandlers as Record<string, StateHandler>)[newState]
       : undefined;
 
   const handlerCtx: HandlerContext = {

--- a/booking-app/lib/stateMachines/xstateEffects.ts
+++ b/booking-app/lib/stateMachines/xstateEffects.ts
@@ -12,6 +12,7 @@ import type { PersistedXStateData, PreApprovalUpdateData } from "./xstateTypes";
 import { cleanObjectForFirestore } from "./xstatePersistence";
 import { handleApprovedEntry } from "./effects/approvedEffects";
 import { handleCanceledEntry } from "./effects/canceledEffects";
+import { handleClosedEntry } from "./effects/closedEffects";
 import { handleNoShowEntry } from "./effects/noShowEffects";
 import { handleRequestedEntry } from "./effects/requestedEffects";
 import type { HandlerContext, StateHandler } from "./effects/types";
@@ -24,6 +25,7 @@ const stateHandlers: Partial<Record<string, StateHandler>> = {
   "Requested": handleRequestedEntry,
   "No Show": handleNoShowEntry,
   "Canceled": handleCanceledEntry,
+  "Closed": handleClosedEntry,
 };
 
 // Note: History logging is now handled by traditional functions only
@@ -298,27 +300,6 @@ export async function handleStateTransitions(
         },
       );
     }
-  } else if (newState === "Closed" && previousState !== "Closed") {
-    console.log(
-      `🎯 XSTATE REACHED CLOSED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-      {
-        calendarEventId,
-        previousState,
-        newState,
-      },
-    );
-
-    // ITP: checkout auto-closes via always transition (Checked In → Checked Out → Closed)
-    // When previousState is "Checked In", checkout-processing is called from db.ts checkOut()
-    // after this API returns (to avoid self-referencing fetch deadlock)
-    if (previousState === "Checked In") {
-      console.log(
-        `📤 XSTATE CHECKOUT VIA AUTO-CLOSE [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-        { calendarEventId, previousState, newState, note: "checkout-processing will be called by client" },
-      );
-    }
-
-    // Close processing for other cases is handled by XState machine action calling /api/close-processing
   } else if (newState === "Checked In" && previousState !== "Checked In") {
     // Check-in state handling - persist XState snapshot only
     // All other processing (Firestore timestamps, email, calendar, history) is handled by /api/checkin-processing

--- a/booking-app/lib/stateMachines/xstateEffects.ts
+++ b/booking-app/lib/stateMachines/xstateEffects.ts
@@ -12,6 +12,7 @@ import type { PersistedXStateData, PreApprovalUpdateData } from "./xstateTypes";
 import { cleanObjectForFirestore } from "./xstatePersistence";
 import { handleApprovedEntry } from "./effects/approvedEffects";
 import { handleCanceledEntry } from "./effects/canceledEffects";
+import { handleCheckedInEntry } from "./effects/checkedInEffects";
 import { handleClosedEntry } from "./effects/closedEffects";
 import { handleDeclinedEntry } from "./effects/declinedEffects";
 import { handleNoShowEntry } from "./effects/noShowEffects";
@@ -28,6 +29,7 @@ const stateHandlers: Partial<Record<string, StateHandler>> = {
   "Canceled": handleCanceledEntry,
   "Closed": handleClosedEntry,
   "Declined": handleDeclinedEntry,
+  "Checked In": handleCheckedInEntry,
 };
 
 // Note: History logging is now handled by traditional functions only
@@ -124,6 +126,7 @@ export async function handleStateTransitions(
       newState,
       currentSnapshot,
       newSnapshot,
+      actor,
       calendarEventId,
       email,
       tenant,
@@ -134,58 +137,6 @@ export async function handleStateTransitions(
       reason,
     };
     await extractedHandler(handlerCtx);
-  } else if (newState === "Checked In" && previousState !== "Checked In") {
-    // Check-in state handling - persist XState snapshot only
-    // All other processing (Firestore timestamps, email, calendar, history) is handled by /api/checkin-processing
-    firestoreUpdates.checkedInAt = admin.firestore.Timestamp.now();
-    if (email) {
-      firestoreUpdates.checkedInBy = email;
-    }
-
-    console.log(
-      `📥 XSTATE REACHED CHECKED IN [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-      {
-        calendarEventId,
-        previousState,
-        newState,
-        note: "checkin-processing will be called by client",
-      },
-    );
-
-    // Persist XState snapshot so statusFromXState works correctly
-    try {
-      const { serverUpdateDataByCalendarEventId } =
-        await import("@/components/src/server/admin");
-      const { TableNames } = await import("@/components/src/policy");
-
-      const persistedSnapshot = actor.getPersistedSnapshot();
-      const cleanedSnapshot = cleanObjectForFirestore(persistedSnapshot);
-
-      const xstateDataToPersist = {
-        snapshot: cleanedSnapshot,
-        machineId: newSnapshot?.machine?.id || currentSnapshot?.machine?.id,
-        lastTransition: new Date().toISOString(),
-      };
-
-      await serverUpdateDataByCalendarEventId(
-        TableNames.BOOKING,
-        calendarEventId,
-        {
-          xstateData: xstateDataToPersist,
-        },
-        tenant,
-      );
-
-      console.log(
-        `💾 XSTATE CHECK-IN: SNAPSHOT PERSISTED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-        { calendarEventId, savedState: "Checked In" },
-      );
-    } catch (error) {
-      console.error(
-        `🚨 XSTATE CHECK-IN: FAILED TO PERSIST SNAPSHOT [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-        { calendarEventId, error: error?.message },
-      );
-    }
   } else if (newState === "Pre-approved" && previousState !== "Pre-approved") {
     // Pre-approved state handling
     firestoreUpdates.firstApprovedAt = admin.firestore.Timestamp.now();

--- a/booking-app/lib/stateMachines/xstateEffects.ts
+++ b/booking-app/lib/stateMachines/xstateEffects.ts
@@ -10,6 +10,15 @@ import { BookingLogger } from "@/lib/logger/bookingLogger";
 import * as admin from "firebase-admin";
 import type { PersistedXStateData, PreApprovalUpdateData } from "./xstateTypes";
 import { cleanObjectForFirestore } from "./xstatePersistence";
+import { handleApprovedEntry } from "./effects/approvedEffects";
+import type { HandlerContext, StateHandler } from "./effects/types";
+
+// Registry of per-state entry handlers. As branches are extracted from
+// the inline if-else chain in `handleStateTransitions`, their handlers
+// land here and the corresponding branch is removed from the function.
+const stateHandlers: Partial<Record<string, StateHandler>> = {
+  "Approved": handleApprovedEntry,
+};
 
 // Note: History logging is now handled by traditional functions only
 // XState only manages state transitions, not history logging
@@ -91,39 +100,28 @@ export async function handleStateTransitions(
     },
   );
 
-  // Handle specific state transitions
-  if (newState === "Approved" && previousState !== "Approved") {
-    // Approved state handling
-    firestoreUpdates.finalApprovedAt = admin.firestore.Timestamp.now();
-    if (email) {
-      firestoreUpdates.finalApprovedBy = email;
-    }
+  // Per-state dispatch: if an extracted handler exists for this string
+  // state and the previous state differs, delegate to it. Otherwise fall
+  // through to the inline branches still living in this function.
+  const extractedHandler =
+    typeof newState === "string" && newState !== previousState
+      ? stateHandlers[newState]
+      : undefined;
 
-    console.log(
-      `🎉 XSTATE REACHED APPROVED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-      {
-        calendarEventId,
-        previousState,
-        newState,
-        finalApprovedAt: firestoreUpdates.finalApprovedAt,
-        finalApprovedBy: firestoreUpdates.finalApprovedBy,
-      },
-    );
-
-    // Note: History logging is now handled by traditional functions only
-    // XState only manages state transitions, not history logging
-
-    // Note: Side effects (emails, calendar updates, history logging) are now handled
-    // by traditional processing after XState transitions to maintain separation of concerns
-    console.log(
-      `📝 XSTATE APPROVED STATE REACHED - SIDE EFFECTS HANDLED EXTERNALLY [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-      {
-        calendarEventId,
-        email,
-        tenant,
-        note: "Approval side effects handled by /api/services or /api/approve",
-      },
-    );
+  if (extractedHandler) {
+    const handlerCtx: HandlerContext = {
+      previousState,
+      newState,
+      calendarEventId,
+      email,
+      tenant,
+      firestoreUpdates,
+      bookingDoc,
+      skipCalendarForServiceCloseout,
+      isXStateCreation,
+      reason,
+    };
+    await extractedHandler(handlerCtx);
   } else if (newState === "Declined" && previousState !== "Declined") {
     // Declined state handling
     firestoreUpdates.declinedAt = admin.firestore.Timestamp.now();

--- a/booking-app/lib/stateMachines/xstateEffects.ts
+++ b/booking-app/lib/stateMachines/xstateEffects.ts
@@ -1,28 +1,20 @@
-import type { SchemaContextType } from "@/components/src/client/routes/components/SchemaProvider";
-import { DEFAULT_TENANT } from "@/components/src/constants/tenants";
-import { TableNames } from "@/components/src/policy";
 import { getTenantEmailConfig } from "@/components/src/server/emails";
 import { BookingStatusLabel } from "@/components/src/types";
-import {
-  serverGetDocumentById,
-} from "@/lib/firebase/server/adminDb";
-import { BookingLogger } from "@/lib/logger/bookingLogger";
-import * as admin from "firebase-admin";
-import type { PersistedXStateData, PreApprovalUpdateData } from "./xstateTypes";
-import { cleanObjectForFirestore } from "./xstatePersistence";
 import { handleApprovedEntry } from "./effects/approvedEffects";
 import { handleCanceledEntry } from "./effects/canceledEffects";
 import { handleCheckedInEntry } from "./effects/checkedInEffects";
 import { handleClosedEntry } from "./effects/closedEffects";
 import { handleDeclinedEntry } from "./effects/declinedEffects";
+import { handleFallbackEntry } from "./effects/fallbackEffects";
 import { handleNoShowEntry } from "./effects/noShowEffects";
 import { handlePreApprovedEntry } from "./effects/preApprovedEffects";
 import { handleRequestedEntry } from "./effects/requestedEffects";
 import type { HandlerContext, StateHandler } from "./effects/types";
 
-// Registry of per-state entry handlers. As branches are extracted from
-// the inline if-else chain in `handleStateTransitions`, their handlers
-// land here and the corresponding branch is removed from the function.
+// Registry of per-state entry handlers. Dispatcher delegates to one of
+// these when `newState` is a string key present in the map. Otherwise
+// the fallback handler runs (for XState parallel states and the
+// catch-all generic status-label mapping).
 const stateHandlers: Partial<Record<string, StateHandler>> = {
   "Approved": handleApprovedEntry,
   "Requested": handleRequestedEntry,
@@ -122,218 +114,26 @@ export async function handleStateTransitions(
       ? stateHandlers[newState]
       : undefined;
 
+  const handlerCtx: HandlerContext = {
+    previousState,
+    newState,
+    currentSnapshot,
+    newSnapshot,
+    actor,
+    calendarEventId,
+    email,
+    tenant,
+    firestoreUpdates,
+    bookingDoc,
+    skipCalendarForServiceCloseout,
+    isXStateCreation,
+    reason,
+  };
+
   if (extractedHandler) {
-    const handlerCtx: HandlerContext = {
-      previousState,
-      newState,
-      currentSnapshot,
-      newSnapshot,
-      actor,
-      calendarEventId,
-      email,
-      tenant,
-      firestoreUpdates,
-      bookingDoc,
-      skipCalendarForServiceCloseout,
-      isXStateCreation,
-      reason,
-    };
     await extractedHandler(handlerCtx);
   } else {
-    // Generic state change - still log to history for tracking
-    console.log(
-      `🔄 XSTATE GENERIC STATE CHANGE [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-      {
-        calendarEventId,
-        previousState,
-        newState,
-        email,
-      },
-    );
-
-    // Try to map XState to BookingStatusLabel for generic states
-    let statusLabel: BookingStatusLabel | undefined;
-    if (typeof newState === "string") {
-      switch (newState) {
-        case "Requested":
-          statusLabel = BookingStatusLabel.REQUESTED;
-          break;
-        case "No Show":
-          statusLabel = BookingStatusLabel.NO_SHOW;
-          break;
-        default:
-          break;
-      }
-    } else if (typeof newState === "object" && newState) {
-      // Handle parallel states
-      if (newState["Services Request"]) {
-        statusLabel = BookingStatusLabel.PRE_APPROVED;
-        console.log(
-          `🔀 XSTATE PARALLEL STATE: Services Request [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-          {
-            calendarEventId,
-            previousState,
-            newState,
-            statusLabel,
-          },
-        );
-      } else if (newState["Service Closeout"]) {
-        statusLabel = BookingStatusLabel.CHECKED_OUT;
-        console.log(
-          `🔀 XSTATE PARALLEL STATE: Service Closeout [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-          {
-            calendarEventId,
-            previousState,
-            newState,
-            statusLabel,
-            skipCalendarUpdate: skipCalendarForServiceCloseout,
-          },
-        );
-
-        // Handle check-out email for Service Closeout state (Media Commons)
-        if (previousState === "Checked In" && !skipCalendarForServiceCloseout) {
-          console.log(
-            `📧 SENDING CHECK-OUT EMAIL FOR SERVICE CLOSEOUT [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-            {
-              calendarEventId,
-              previousState,
-              newState: "Service Closeout",
-            },
-          );
-
-          // Set check-out timestamps for Firestore
-          firestoreUpdates.checkedOutAt = admin.firestore.Timestamp.now();
-          if (email) {
-            firestoreUpdates.checkedOutBy = email;
-          }
-
-          // Send check-out email to guest
-          try {
-            // Use email from booking document (not from XState context)
-            const guestEmail = bookingDoc?.email;
-
-            console.log(
-              `🔍 XSTATE SERVICE CLOSEOUT EMAIL DEBUG [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-              {
-                calendarEventId,
-                hasBookingDoc: !!bookingDoc,
-                bookingDocKeys: bookingDoc ? Object.keys(bookingDoc) : [],
-                guestEmail,
-                guestEmailType: typeof guestEmail,
-                bookingDocEmail: bookingDoc?.email,
-              },
-            );
-
-            if (guestEmail) {
-              const { serverSendBookingDetailEmail } =
-                await import("@/components/src/server/admin");
-              const emailConfig = await getTenantEmailConfig(tenant);
-              const headerMessage =
-                emailConfig.emailMessages.checkoutConfirmation;
-
-              await serverSendBookingDetailEmail({
-                calendarEventId,
-                targetEmail: guestEmail,
-                headerMessage,
-                status: BookingStatusLabel.CHECKED_OUT,
-                tenant,
-              });
-
-              console.log(
-                `📧 XSTATE SERVICE CLOSEOUT EMAIL SENT [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-                {
-                  calendarEventId,
-                  guestEmail,
-                },
-              );
-            } else {
-              console.warn(
-                `⚠️ XSTATE SERVICE CLOSEOUT EMAIL SKIPPED - NO EMAIL [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-                {
-                  calendarEventId,
-                  hasBookingDoc: !!bookingDoc,
-                  bookingDocKeys: bookingDoc ? Object.keys(bookingDoc) : [],
-                },
-              );
-            }
-          } catch (error) {
-            console.error(
-              `🚨 XSTATE SERVICE CLOSEOUT EMAIL FAILED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-              {
-                calendarEventId,
-                email,
-                tenant,
-                error: error.message,
-              },
-            );
-          }
-
-          // Update calendar event with CHECKED_OUT status
-          try {
-            const response = await fetch(
-              `${process.env.NEXT_PUBLIC_BASE_URL}/api/calendarEvents`,
-              {
-                method: "PUT",
-                headers: {
-                  "Content-Type": "application/json",
-                  "x-tenant": tenant || DEFAULT_TENANT,
-                },
-                body: JSON.stringify({
-                  calendarEventId,
-                  newValues: {
-                    statusPrefix: BookingStatusLabel.CHECKED_OUT,
-                  },
-                }),
-              },
-            );
-
-            if (response.ok) {
-              BookingLogger.calendarUpdate(
-                "Service Closeout status update",
-                { calendarEventId, tenant },
-                { statusPrefix: BookingStatusLabel.CHECKED_OUT },
-              );
-            }
-          } catch (error) {
-            BookingLogger.calendarError(
-              "Service Closeout calendar update",
-              { calendarEventId, tenant },
-              error,
-            );
-          }
-        }
-
-        // Skip calendar update if this Service Closeout was triggered by No Show
-        if (skipCalendarForServiceCloseout) {
-          console.log(
-            `⏭️ SKIPPING SERVICE CLOSEOUT CALENDAR UPDATE - HANDLED BY NO SHOW [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-            {
-              calendarEventId,
-              reason: "No Show processing already updated calendar",
-            },
-          );
-          statusLabel = null; // Prevent generic history logging too
-        }
-      }
-    }
-
-    // Apply status label to Firestore updates if determined
-    if (statusLabel) {
-      firestoreUpdates.status = statusLabel;
-      console.log(
-        `📋 XSTATE STATUS UPDATE [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-        {
-          calendarEventId,
-          previousState,
-          newState,
-          statusLabel,
-          willUpdateDatabaseStatus: true,
-        },
-      );
-    }
-
-    // Note: History logging is now handled by traditional functions only
-    // XState only manages state transitions, not history logging
+    await handleFallbackEntry(handlerCtx);
   }
 }
 

--- a/booking-app/lib/stateMachines/xstateEffects.ts
+++ b/booking-app/lib/stateMachines/xstateEffects.ts
@@ -11,6 +11,7 @@ import * as admin from "firebase-admin";
 import type { PersistedXStateData, PreApprovalUpdateData } from "./xstateTypes";
 import { cleanObjectForFirestore } from "./xstatePersistence";
 import { handleApprovedEntry } from "./effects/approvedEffects";
+import { handleNoShowEntry } from "./effects/noShowEffects";
 import { handleRequestedEntry } from "./effects/requestedEffects";
 import type { HandlerContext, StateHandler } from "./effects/types";
 
@@ -20,6 +21,7 @@ import type { HandlerContext, StateHandler } from "./effects/types";
 const stateHandlers: Partial<Record<string, StateHandler>> = {
   "Approved": handleApprovedEntry,
   "Requested": handleRequestedEntry,
+  "No Show": handleNoShowEntry,
 };
 
 // Note: History logging is now handled by traditional functions only
@@ -294,23 +296,6 @@ export async function handleStateTransitions(
         },
       );
     }
-  } else if (newState === "No Show" && previousState !== "No Show") {
-    // No Show state handling - update Firestore fields
-    firestoreUpdates.noShowedAt = admin.firestore.Timestamp.now();
-    if (email) {
-      firestoreUpdates.noShowedBy = email;
-    }
-
-    console.log(
-      `🚫 XSTATE REACHED NO SHOW [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-      {
-        calendarEventId,
-        previousState,
-        newState,
-        noShowedAt: firestoreUpdates.noShowedAt,
-        noShowedBy: firestoreUpdates.noShowedBy,
-      },
-    );
   } else if (newState === "Canceled" && previousState !== "Canceled") {
     // Canceled state handling - update Firestore fields
     firestoreUpdates.canceledAt = admin.firestore.Timestamp.now();

--- a/booking-app/lib/stateMachines/xstateEffects.ts
+++ b/booking-app/lib/stateMachines/xstateEffects.ts
@@ -11,6 +11,7 @@ import * as admin from "firebase-admin";
 import type { PersistedXStateData, PreApprovalUpdateData } from "./xstateTypes";
 import { cleanObjectForFirestore } from "./xstatePersistence";
 import { handleApprovedEntry } from "./effects/approvedEffects";
+import { handleRequestedEntry } from "./effects/requestedEffects";
 import type { HandlerContext, StateHandler } from "./effects/types";
 
 // Registry of per-state entry handlers. As branches are extracted from
@@ -18,6 +19,7 @@ import type { HandlerContext, StateHandler } from "./effects/types";
 // land here and the corresponding branch is removed from the function.
 const stateHandlers: Partial<Record<string, StateHandler>> = {
   "Approved": handleApprovedEntry,
+  "Requested": handleRequestedEntry,
 };
 
 // Note: History logging is now handled by traditional functions only
@@ -292,20 +294,6 @@ export async function handleStateTransitions(
         },
       );
     }
-  } else if (newState === "Requested" && previousState !== "Requested") {
-    // Requested state handling
-    console.log(
-      `🔄 XSTATE REACHED REQUESTED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
-      {
-        calendarEventId,
-        previousState,
-        newState,
-        note: "Decline field cleanup handled by calling API",
-      },
-    );
-
-    // Note: History logging, calendar updates, and field cleanup are now handled by traditional functions only
-    // XState only manages state transitions, not side effects
   } else if (newState === "No Show" && previousState !== "No Show") {
     // No Show state handling - update Firestore fields
     firestoreUpdates.noShowedAt = admin.firestore.Timestamp.now();


### PR DESCRIPTION
## Summary of Changes

Splits the 781-line `handleStateTransitions()` god function in `booking-app/lib/stateMachines/xstateEffects.ts` into per-state handlers living under a new `effects/` subdirectory. Dispatcher becomes a thin router; each state's side-effect logic is now isolated, independently readable, and independently testable.

**Before**: 781 lines, single function, 9-branch if-else chain with heterogeneous logic per branch (timestamps, emails, calendar API calls, Firestore writes, parallel-state handling — all interleaved).

**After**:
| File | Lines | Purpose |
|---|---|---|
| `xstateEffects.ts` | 218 | Dispatcher + `sendCanceledEmail` helper (unchanged) |
| `effects/types.ts` | 28 | `HandlerContext`, `StateHandler` |
| `effects/approvedEffects.ts` | 43 | Final approval timestamp |
| `effects/requestedEffects.ts` | 24 | Observability log only |
| `effects/noShowEffects.ts` | 31 | No-show timestamps |
| `effects/canceledEffects.ts` | 31 | Cancellation timestamps |
| `effects/closedEffects.ts` | 33 | Closed log + ITP auto-close note |
| `effects/declinedEffects.ts` | 199 | Decline email + calendar `[DECLINED]` update |
| `effects/checkedInEffects.ts` | 78 | Check-in timestamp + snapshot persist |
| `effects/preApprovedEffects.ts` | 130 | First-approval pre-save + calendar `[PRE-APPROVED]` update |
| `effects/fallbackEffects.ts` | 221 | Parallel states + generic status mapping + Service Closeout check-out email/calendar path |

### Dispatcher shape

```typescript
type HandledState =
  | "Approved" | "Requested" | "No Show" | "Canceled"
  | "Closed" | "Declined" | "Checked In" | "Pre-approved";

const stateHandlers = {
  "Approved": handleApprovedEntry,
  "Requested": handleRequestedEntry,
  "No Show": handleNoShowEntry,
  "Canceled": handleCanceledEntry,
  "Closed": handleClosedEntry,
  "Declined": handleDeclinedEntry,
  "Checked In": handleCheckedInEntry,
  "Pre-approved": handlePreApprovedEntry,
} satisfies Record<HandledState, StateHandler>;

// inside handleStateTransitions(...):
const extractedHandler =
  typeof newState === "string" && newState !== previousState
    ? (stateHandlers as Record<string, StateHandler>)[newState]
    : undefined;

const handlerCtx: HandlerContext = { /* ... bundled inputs ... */ };

if (extractedHandler) {
  await extractedHandler(handlerCtx);
} else {
  await handleFallbackEntry(handlerCtx);
}
```

Each handler takes a single `HandlerContext` that the dispatcher builds once per transition (snapshots, `bookingDoc`, `firestoreUpdates`, `actor`, flags, etc.). `satisfies Record<HandledState, StateHandler>` guarantees at compile time that every state in the `HandledState` union has a wired handler.

### Why

- `handleStateTransitions` is touched every time a new transition is added, a new service is introduced, or side-effect behavior changes. A 781-line function with 9 intertwined branches makes each of those changes risky to read and hard to test in isolation.
- With per-state handlers, each branch is independently testable and independently readable.
- Sets up a clean structure for future work (e.g. admin-undo transitions) that needs to add new dispatch branches.

### What this PR does NOT change

- Zero runtime behavior change. Every console log, every Firestore field, every fetch call, every email, every error branch is preserved 1:1 from the original if-else chain. The commits are small per-branch moves so each one can be diffed against the deleted inline code.
- The pre-existing duplicated `🔄 XSTATE STATE TRANSITION DETECTED` log inside `handleStateTransitions` is kept as-is — not cleaned up in this PR to keep the diff purely behavior-preserving.
- No tests added or modified. The existing 44 MC-machine / XState-integration tests plus the wider test suite exercise these branches; they all pass.

### Known pre-existing dead code preserved as-is

Code review surfaced that the parallel-state handling block inside the fallback handler (Services Request → `PRE_APPROVED` mapping, Service Closeout → `CHECKED_OUT` mapping, and the MC check-out email / calendar update for Service Closeout from Checked In) is **dead code both in this PR and on `main`**. The reason: at the top of `handleStateTransitions` the function normalizes `newSnapshot.value` into a string via `JSON.stringify` for object values, so the later `typeof newState === "object"` check is never true.

This is a pre-existing condition — not a regression introduced by this refactor. To keep this PR strictly behavior-preserving, the dead block is preserved exactly as it was. Whether the Service Closeout flow actually needs this code path (or whether the real functionality is wired up elsewhere) should be investigated separately.

### Commits (per branch, for easy review)

1. Approved
2. Requested
3. No Show
4. Canceled
5. Closed
6. Declined
7. Checked In
8. Pre-approved
9. Fallback / parallel state + dispatcher thinning + unused-import cleanup
10. Type fixes from code review (HandlerContext optional fields, `satisfies Record<HandledState, StateHandler>`, stale comment)

Each of the first 9 commits is independently buildable and independently passes `tsc --noEmit` + the MC-machine tests.

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description) — pure move, existing tests cover the branches
- [x] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description) — no UI / runtime behavior change
- [x] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved — addressed Codex review feedback in the final commit; parallel-state dead-code concern preserved as-is because fixing it would violate the behavior-preserving scope of this PR
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests — 1372 / 1373 pass; the 1 failure is a pre-existing leap day / timezone bug in `tests/unit/server-admin.unit.test.ts` that reproduces on main and is unrelated to this refactor
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video

N/A — pure refactor, no UI or runtime behavior change.
