### PR TITLE
ci: add PR prod schema diff workflow

### DIFF
--- a/.github/workflows/pr-prod-schema-check.yml
+++ b/.github/workflows/pr-prod-schema-check.yml
@@ -9,12 +9,11 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - prod
-      - main # TEMP: remove before merge
 
 jobs:
   schema-diff:
     name: Dry Run - development vs production tenantSchema
-    if: (github.base_ref == 'prod' && github.head_ref == 'main') || github.head_ref == 'worktree-pr-prod-schema-check'
+    if: github.base_ref == 'prod' && github.head_ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-prod-schema-check.yml
+++ b/.github/workflows/pr-prod-schema-check.yml
@@ -1,0 +1,91 @@
+name: PR Prod Schema Diff
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - prod
+      - main # TEMP: remove before merge
+
+jobs:
+  schema-diff:
+    name: Dry Run - development vs production tenantSchema
+    if: (github.base_ref == 'prod' && github.head_ref == 'main') || github.head_ref == 'worktree-pr-prod-schema-check'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: booking-app/package-lock.json
+
+      - name: Install dependencies
+        working-directory: ./booking-app
+        run: npm ci
+
+      - name: Create .env.local file
+        working-directory: ./booking-app
+        run: |
+          cat > .env.local << EOF
+          FIREBASE_PROJECT_ID=${{ secrets.FIREBASE_PROJECT_ID }}
+          FIREBASE_CLIENT_EMAIL=${{ secrets.FIREBASE_CLIENT_EMAIL }}
+          FIREBASE_PRIVATE_KEY="${{ secrets.FIREBASE_PRIVATE_KEY }}"
+          EOF
+
+      - name: Dry Run - development → production
+        working-directory: ./booking-app
+        run: |
+          node scripts/copyCollection.js \
+            --source-database development \
+            --target-database production \
+            --source-collection tenantSchema \
+            --target-collection tenantSchema \
+            --report-file dry-run-pr-production-details.json \
+            --dry-run > dry-run-pr-production-output.txt 2>&1 || true
+        continue-on-error: true
+
+      - name: Build diff comment
+        working-directory: ./booking-app
+        run: |
+          {
+            echo "## Tenant Schema Diff (development → production)"
+            echo ""
+            echo "This PR targets \`prod\`. Review the diff below and confirm every change is acceptable before merging."
+            echo ""
+            echo "### Key Differences by Document"
+            echo '```'
+            awk '/^📄 Document:|^   Added keys|^     \+ |^   Deleted keys|^     - |^   Updated keys|^     ~ /{print}' dry-run-pr-production-output.txt || true
+            echo '```'
+            echo ""
+            echo "<details><summary>Full dry-run output</summary>"
+            echo ""
+            echo '```'
+            cat dry-run-pr-production-output.txt
+            echo '```'
+            echo ""
+            echo "</details>"
+          } > dry-run-pr-production-comment.md
+
+      - name: Post or update PR comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: tenant-schema-prod-diff
+          path: booking-app/dry-run-pr-production-comment.md
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tenant-schema-dry-run-pr-production
+          path: |
+            booking-app/dry-run-pr-production-*.txt
+            booking-app/dry-run-pr-production-*.md
+            booking-app/dry-run-pr-production-*.json
+          retention-days: 30


### PR DESCRIPTION
## Summary of Changes

Adds a GitHub Actions workflow that runs on `pull_request` when a PR targets `prod` from `main` (our production release PRs). It executes the existing `copyCollection.js --dry-run` to compare the `tenantSchema` collection between `development` and `production`, then posts the result as a sticky PR comment so reviewers can confirm every schema change is acceptable before merging.

**Note:** the trigger is temporarily relaxed (also fires on this branch into `main`) so we can verify the workflow runs and produces a comment on this PR itself. Before merge, I'll revert the trigger to `base=prod && head=main` only.

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [ ] I added or updated unit tests (or explained why not in the PR description) — N/A: CI workflow only
- [x] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description) — N/A: CI workflow, verification happens via the PR comment posted by the workflow itself
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [ ] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video

N/A — the workflow will post its dry-run diff as a comment on this PR, which serves as the verification.