### PR TITLE
test: lock side-effect behavior of xstateEffects per-state handlers

### DIFF
--- a/booking-app/tests/unit/xstate-effects-handlers.unit.test.ts
+++ b/booking-app/tests/unit/xstate-effects-handlers.unit.test.ts
@@ -1,0 +1,377 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// -------------------------------------------------------------------------
+// Shared test scaffolding
+//
+// These tests exercise `handleStateTransitions` directly (not via XState) to
+// lock the side-effect behavior of each per-state handler in
+// `booking-app/lib/stateMachines/effects/*`. A regression in any handler
+// should make one of these tests fail loudly.
+//
+// Each test synthesizes a minimal `{ currentSnapshot, newSnapshot }` pair
+// with only the fields the dispatcher and the targeted handler read, and
+// asserts on:
+//   - mutations to the `firestoreUpdates` object the dispatcher mutates
+//   - calls to `global.fetch` (for calendar API PUTs)
+//   - calls to the mocked `serverSendBookingDetailEmail` /
+//     `serverUpdateDataByCalendarEventId` / `serverGetDocumentById` helpers
+// -------------------------------------------------------------------------
+
+process.env.NEXT_PUBLIC_BASE_URL = "http://localhost:3000";
+
+const testCalendarEventId = "test-cal-event-xyz";
+const testEmail = "actor@nyu.edu";
+const testGuestEmail = "guest@nyu.edu";
+const testTenant = "mc";
+
+// --- Firebase admin mocks ------------------------------------------------
+
+const mockServerGetDataByCalendarEventId = vi.fn();
+const mockServerGetDocumentById = vi.fn();
+
+vi.mock("@/lib/firebase/server/adminDb", () => ({
+  serverGetDataByCalendarEventId: mockServerGetDataByCalendarEventId,
+  serverGetDocumentById: mockServerGetDocumentById,
+  logServerBookingChange: vi.fn(),
+}));
+
+// --- Server admin mocks --------------------------------------------------
+
+const mockServerSendBookingDetailEmail = vi.fn();
+const mockServerUpdateDataByCalendarEventId = vi.fn();
+
+vi.mock("@/components/src/server/admin", () => ({
+  serverSendBookingDetailEmail: mockServerSendBookingDetailEmail,
+  serverUpdateDataByCalendarEventId: mockServerUpdateDataByCalendarEventId,
+}));
+
+// --- Email config mock ---------------------------------------------------
+
+const mockGetTenantEmailConfig = vi.fn();
+
+vi.mock("@/components/src/server/emails", () => ({
+  getTenantEmailConfig: mockGetTenantEmailConfig,
+}));
+
+// --- Global fetch mock (calendar API) ------------------------------------
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch as any;
+
+// --- Helpers -------------------------------------------------------------
+
+const buildBookingDoc = (overrides: Record<string, any> = {}) => ({
+  id: "booking-123",
+  requestNumber: 42,
+  email: testGuestEmail,
+  ...overrides,
+});
+
+const buildSnapshot = (
+  value: string,
+  context: Record<string, any> = {},
+) => ({
+  value,
+  context,
+  machine: { id: "MC Booking Request" },
+});
+
+const buildActor = (persistedValue: string = "Checked In") => ({
+  getPersistedSnapshot: vi.fn(() => ({
+    value: persistedValue,
+    context: {},
+    status: "active",
+  })),
+});
+
+const callHandleStateTransitions = async (args: {
+  previous: string;
+  next: string;
+  nextContext?: Record<string, any>;
+  actor?: any;
+  reason?: string;
+}) => {
+  const { handleStateTransitions } = await import(
+    "@/lib/stateMachines/xstateEffects"
+  );
+  const firestoreUpdates: Record<string, any> = {};
+  await handleStateTransitions(
+    buildSnapshot(args.previous),
+    buildSnapshot(args.next, args.nextContext || {}),
+    testCalendarEventId,
+    testEmail,
+    testTenant,
+    firestoreUpdates,
+    args.actor ?? buildActor(),
+    false,
+    false,
+    args.reason,
+  );
+  return firestoreUpdates;
+};
+
+const findCalendarPutCall = () =>
+  mockFetch.mock.calls.find(([url, init]) => {
+    return (
+      typeof url === "string" &&
+      url.includes("/api/calendarEvents") &&
+      init?.method === "PUT"
+    );
+  });
+
+// --- Default mock setup --------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mockServerGetDataByCalendarEventId.mockResolvedValue(buildBookingDoc());
+  mockServerGetDocumentById.mockResolvedValue(null);
+  mockServerSendBookingDetailEmail.mockResolvedValue(undefined);
+  mockServerUpdateDataByCalendarEventId.mockResolvedValue(undefined);
+  mockGetTenantEmailConfig.mockResolvedValue({
+    schemaName: "mc",
+    emailMessages: {
+      declined: "Your booking has been declined.",
+      approvalNotice: "Approval notice.",
+      checkoutConfirmation: "Checkout confirmation.",
+      canceled: "Canceled.",
+    },
+  });
+  mockFetch.mockResolvedValue({
+    ok: true,
+    status: 200,
+    statusText: "OK",
+    json: () => Promise.resolve({ success: true }),
+    text: () => Promise.resolve("OK"),
+  });
+});
+
+// -------------------------------------------------------------------------
+// Tests
+// -------------------------------------------------------------------------
+
+describe("handleStateTransitions — per-state handler side effects", () => {
+  describe("Approved", () => {
+    it("stamps finalApprovedAt / finalApprovedBy and makes no outbound side effects", async () => {
+      const firestoreUpdates = await callHandleStateTransitions({
+        previous: "Pre-approved",
+        next: "Approved",
+      });
+
+      expect(firestoreUpdates.finalApprovedAt).toBeDefined();
+      expect(firestoreUpdates.finalApprovedBy).toBe(testEmail);
+
+      // Approved handler intentionally delegates email/calendar/invite to
+      // `/api/approve` → `finalApprove()`, so it should make zero outbound calls
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(mockServerSendBookingDetailEmail).not.toHaveBeenCalled();
+      expect(mockServerUpdateDataByCalendarEventId).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Canceled", () => {
+    it("stamps canceledAt / canceledBy and makes no outbound side effects", async () => {
+      const firestoreUpdates = await callHandleStateTransitions({
+        previous: "Approved",
+        next: "Canceled",
+      });
+
+      expect(firestoreUpdates.canceledAt).toBeDefined();
+      expect(firestoreUpdates.canceledBy).toBe(testEmail);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(mockServerSendBookingDetailEmail).not.toHaveBeenCalled();
+      expect(mockServerUpdateDataByCalendarEventId).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("No Show", () => {
+    it("stamps noShowedAt / noShowedBy and makes no outbound side effects", async () => {
+      const firestoreUpdates = await callHandleStateTransitions({
+        previous: "Approved",
+        next: "No Show",
+      });
+
+      expect(firestoreUpdates.noShowedAt).toBeDefined();
+      expect(firestoreUpdates.noShowedBy).toBe(testEmail);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(mockServerSendBookingDetailEmail).not.toHaveBeenCalled();
+      expect(mockServerUpdateDataByCalendarEventId).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Pre-approved", () => {
+    it("stamps firstApprovedAt / firstApprovedBy, pre-saves to Firestore, and updates calendar prefix", async () => {
+      const firestoreUpdates = await callHandleStateTransitions({
+        previous: "Requested",
+        next: "Pre-approved",
+      });
+
+      // Firestore stamping
+      expect(firestoreUpdates.firstApprovedAt).toBeDefined();
+      expect(firestoreUpdates.firstApprovedBy).toBe(testEmail);
+
+      // Pre-save write (dedicated Firestore update BEFORE calendar update)
+      expect(mockServerUpdateDataByCalendarEventId).toHaveBeenCalledTimes(1);
+      const [, calendarEventIdArg, preApprovalUpdateArg] =
+        mockServerUpdateDataByCalendarEventId.mock.calls[0];
+      expect(calendarEventIdArg).toBe(testCalendarEventId);
+      expect(preApprovalUpdateArg.firstApprovedAt).toBeDefined();
+      expect(preApprovalUpdateArg.firstApprovedBy).toBe(testEmail);
+
+      // Calendar API called with PRE_APPROVED status prefix
+      const calendarCall = findCalendarPutCall();
+      expect(calendarCall).toBeDefined();
+      const [, init] = calendarCall!;
+      const body = JSON.parse((init as any).body);
+      expect(body.calendarEventId).toBe(testCalendarEventId);
+      expect(body.newValues.statusPrefix).toBe("PRE-APPROVED");
+    });
+  });
+
+  describe("Checked In", () => {
+    it("stamps checkedInAt / checkedInBy and persists XState snapshot to Firestore", async () => {
+      const actor = buildActor("Checked In");
+      const firestoreUpdates = await callHandleStateTransitions({
+        previous: "Approved",
+        next: "Checked In",
+        actor,
+      });
+
+      expect(firestoreUpdates.checkedInAt).toBeDefined();
+      expect(firestoreUpdates.checkedInBy).toBe(testEmail);
+
+      // Actor.getPersistedSnapshot() called to build xstateData
+      expect(actor.getPersistedSnapshot).toHaveBeenCalled();
+
+      // Snapshot persisted via Firestore update with xstateData field
+      expect(mockServerUpdateDataByCalendarEventId).toHaveBeenCalledTimes(1);
+      const [, calendarEventIdArg, updateArg] =
+        mockServerUpdateDataByCalendarEventId.mock.calls[0];
+      expect(calendarEventIdArg).toBe(testCalendarEventId);
+      expect(updateArg).toHaveProperty("xstateData");
+      expect(updateArg.xstateData).toHaveProperty("snapshot");
+      expect(updateArg.xstateData).toHaveProperty("machineId");
+      expect(updateArg.xstateData).toHaveProperty("lastTransition");
+
+      // No calendar API call (checkin-processing handles that separately)
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Declined", () => {
+    it("stamps declinedAt / declinedBy, sends decline email with grace period + decline reason, and updates calendar prefix", async () => {
+      // Tenant schema overrides the default 24h grace period to 48h
+      mockServerGetDocumentById.mockResolvedValue({ declinedGracePeriod: 48 });
+
+      const firestoreUpdates = await callHandleStateTransitions({
+        previous: "Pre-approved",
+        next: "Declined",
+        nextContext: {
+          declineReason: "Testing decline path",
+        },
+      });
+
+      // Firestore stamping
+      expect(firestoreUpdates.declinedAt).toBeDefined();
+      expect(firestoreUpdates.declinedBy).toBe(testEmail);
+
+      // Decline email sent with grace period + decline reason in header
+      expect(mockServerSendBookingDetailEmail).toHaveBeenCalledTimes(1);
+      const emailCall = mockServerSendBookingDetailEmail.mock.calls[0][0];
+      expect(emailCall.calendarEventId).toBe(testCalendarEventId);
+      expect(emailCall.targetEmail).toBe(testGuestEmail);
+      expect(emailCall.status).toBe("DECLINED");
+      expect(emailCall.headerMessage).toContain("Testing decline path");
+      expect(emailCall.headerMessage).toContain("48 hours");
+
+      // Calendar API called with DECLINED status prefix
+      const calendarCall = findCalendarPutCall();
+      expect(calendarCall).toBeDefined();
+      const body = JSON.parse((calendarCall![1] as any).body);
+      expect(body.newValues.statusPrefix).toBe("DECLINED");
+    });
+
+    it("composes per-service decline reason when servicesApproved contains declined entries", async () => {
+      await callHandleStateTransitions({
+        previous: "Services Request",
+        next: "Declined",
+        nextContext: {
+          servicesRequested: {
+            staff: true,
+            catering: true,
+            cleaning: false,
+          },
+          servicesApproved: {
+            staff: false,
+            catering: false,
+            cleaning: false,
+          },
+        },
+      });
+
+      expect(mockServerSendBookingDetailEmail).toHaveBeenCalledTimes(1);
+      const emailCall = mockServerSendBookingDetailEmail.mock.calls[0][0];
+
+      // Only the requested + declined services should appear in the reason.
+      // `cleaning` wasn't requested, so it's excluded.
+      expect(emailCall.headerMessage).toContain("Staff");
+      expect(emailCall.headerMessage).toContain("Catering");
+      expect(emailCall.headerMessage).not.toContain("Cleaning");
+      expect(emailCall.headerMessage).toContain("could not be fulfilled");
+    });
+
+    it("skips decline email when booking document has no email", async () => {
+      mockServerGetDataByCalendarEventId.mockResolvedValue(
+        buildBookingDoc({ email: undefined }),
+      );
+
+      await callHandleStateTransitions({
+        previous: "Pre-approved",
+        next: "Declined",
+      });
+
+      expect(mockServerSendBookingDetailEmail).not.toHaveBeenCalled();
+
+      // Calendar update still runs even without guest email
+      const calendarCall = findCalendarPutCall();
+      expect(calendarCall).toBeDefined();
+    });
+  });
+
+  describe("Dispatcher fall-through", () => {
+    it("returns without side effects when newState has no registered handler (e.g. parallel state JSON)", async () => {
+      // Simulate an XState parallel state value, which the dispatcher
+      // normalizes to a JSON-stringified string before handler lookup.
+      const parallelSnapshot = {
+        value: { "Services Request": { "Staff Request": "Staff Requested" } },
+        context: {},
+        machine: { id: "MC Booking Request" },
+      };
+
+      const { handleStateTransitions } = await import(
+        "@/lib/stateMachines/xstateEffects"
+      );
+      const firestoreUpdates: Record<string, any> = {};
+      await handleStateTransitions(
+        buildSnapshot("Requested"),
+        parallelSnapshot,
+        testCalendarEventId,
+        testEmail,
+        testTenant,
+        firestoreUpdates,
+        buildActor(),
+        false,
+        false,
+        undefined,
+      );
+
+      // No handler matched → no firestoreUpdates mutations, no side effects
+      expect(firestoreUpdates).toEqual({});
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(mockServerSendBookingDetailEmail).not.toHaveBeenCalled();
+      expect(mockServerUpdateDataByCalendarEventId).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/booking-app/tests/unit/xstate-effects-handlers.unit.test.ts
+++ b/booking-app/tests/unit/xstate-effects-handlers.unit.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // -------------------------------------------------------------------------
 // Shared test scaffolding
@@ -17,7 +17,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 //     `serverUpdateDataByCalendarEventId` / `serverGetDocumentById` helpers
 // -------------------------------------------------------------------------
 
-process.env.NEXT_PUBLIC_BASE_URL = "http://localhost:3000";
+// Save original values so we can restore them in `afterEach` — avoids
+// leaking `process.env.NEXT_PUBLIC_BASE_URL` and `global.fetch` into
+// other test files that share the same Vitest worker.
+const originalBaseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+const originalFetch = global.fetch;
 
 const testCalendarEventId = "test-cal-event-xyz";
 const testEmail = "actor@nyu.edu";
@@ -54,9 +58,11 @@ vi.mock("@/components/src/server/emails", () => ({
 }));
 
 // --- Global fetch mock (calendar API) ------------------------------------
+// `global.fetch` is assigned/restored per-test in beforeEach/afterEach so
+// neither the override nor accumulated mock state leaks into sibling
+// test files running in the same Vitest worker.
 
 const mockFetch = vi.fn();
-global.fetch = mockFetch as any;
 
 // --- Helpers -------------------------------------------------------------
 
@@ -124,6 +130,9 @@ const findCalendarPutCall = () =>
 beforeEach(() => {
   vi.clearAllMocks();
 
+  process.env.NEXT_PUBLIC_BASE_URL = "http://localhost:3000";
+  global.fetch = mockFetch as any;
+
   mockServerGetDataByCalendarEventId.mockResolvedValue(buildBookingDoc());
   mockServerGetDocumentById.mockResolvedValue(null);
   mockServerSendBookingDetailEmail.mockResolvedValue(undefined);
@@ -144,6 +153,15 @@ beforeEach(() => {
     json: () => Promise.resolve({ success: true }),
     text: () => Promise.resolve("OK"),
   });
+});
+
+afterEach(() => {
+  if (originalBaseUrl === undefined) {
+    delete process.env.NEXT_PUBLIC_BASE_URL;
+  } else {
+    process.env.NEXT_PUBLIC_BASE_URL = originalBaseUrl;
+  }
+  global.fetch = originalFetch;
 });
 
 // -------------------------------------------------------------------------
@@ -367,7 +385,10 @@ describe("handleStateTransitions — per-state handler side effects", () => {
         undefined,
       );
 
-      // No handler matched → no firestoreUpdates mutations, no side effects
+      // No handler matched → no handler-level side effects. The dispatcher
+      // itself still runs its transition log and fetches the booking doc
+      // via `serverGetDataByCalendarEventId`; that dispatcher-level work
+      // is expected and intentionally not asserted against here.
       expect(firestoreUpdates).toEqual({});
       expect(mockFetch).not.toHaveBeenCalled();
       expect(mockServerSendBookingDetailEmail).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary of Changes

Adds a new unit test suite `tests/unit/xstate-effects-handlers.unit.test.ts` that exercises `handleStateTransitions` directly to pin down the observable side effects of each per-state handler in `booking-app/lib/stateMachines/effects/*`.

### Why

The existing integration tests (`tests/unit/xstate-approval-real-integration.unit.test.ts`, `tests/unit/mc-booking-machine.*.unit.test.ts`) operate on the XState machine itself and don't cover the dispatcher → handler path. Recent refactors (#1345, #1398, #1405, #1406, #1412) split what was a 781-line god function into a dispatcher + 8 per-state handler files, and the test suite lacked anything that directly asserts on the side effects each handler is supposed to produce. A regression in a handler (forgotten `await`, dropped Firestore field, wrong email body) could therefore slip past CI.

This PR adds targeted integration tests that call `handleStateTransitions` with synthetic snapshot pairs and assert on:

- mutations to the shared `firestoreUpdates` object
- calls to `global.fetch` (for calendar API PUTs)
- calls to the mocked `serverSendBookingDetailEmail`, `serverUpdateDataByCalendarEventId`, `serverGetDocumentById` helpers
- calls to `actor.getPersistedSnapshot()` (Checked In)

### Coverage (9 tests)

| Handler | Assertions |
|---|---|
| `Approved` | `finalApprovedAt` / `finalApprovedBy` stamping + **zero** outbound side effects (delegated to `/api/approve`) |
| `Canceled` | `canceledAt` / `canceledBy` stamping + zero outbound side effects |
| `No Show` | `noShowedAt` / `noShowedBy` stamping + zero outbound side effects |
| `Pre-approved` | timestamp stamping + dedicated Firestore pre-save + calendar `[PRE-APPROVED]` prefix PUT |
| `Checked In` | timestamp stamping + `actor.getPersistedSnapshot()` call + Firestore write of `xstateData` snapshot |
| `Declined` (happy path) | timestamp stamping + decline email containing grace-period + decline reason + calendar `[DECLINED]` prefix PUT |
| `Declined` (per-service) | email header includes only the requested-AND-declined services, not non-requested ones |
| `Declined` (no guest email) | decline email is skipped but calendar prefix update still runs |
| Dispatcher fall-through | parallel-state snapshot (value normalized to JSON string) with no registered handler produces zero side effects — locks the behavior after #1412's dead-code removal |

### Design notes

- Tests drive `handleStateTransitions` via minimal synthetic `{ currentSnapshot, newSnapshot }` pairs with only the fields the dispatcher and targeted handler actually read. No real XState actor is needed — for Checked In the test provides a stub `actor.getPersistedSnapshot()`.
- All downstream dependencies are mocked at module level: `@/lib/firebase/server/adminDb`, `@/components/src/server/admin`, `@/components/src/server/emails`, and `global.fetch`.
- The suite adds **0 new runtime code paths**. It's a pure additive test file.

### Scope of testing

- `tsc --noEmit -p .` clean
- Full `vitest run`: **1382 / 1382 pass** (was 1373 + 9 new tests)

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description) — this PR IS the unit tests
- [x] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description) — test-only PR, no UI
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video

N/A — test-only PR.
