### PR TITLE
fix(export): timezone and missing-origin bugs in booking CSV export

### DIFF
--- a/booking-app/app/api/bookings/export/route.ts
+++ b/booking-app/app/api/bookings/export/route.ts
@@ -9,7 +9,10 @@ import {
 } from "@/lib/firebase/server/adminDb";
 import { applyEnvironmentCalendarIds } from "@/lib/utils/calendarEnvironment";
 import { format } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 import { parse } from "json2csv";
+
+const EXPORT_TIME_ZONE = "America/New_York";
 
 export async function GET(request: NextRequest) {
   // Get tenant from request headers or default to 'mc'
@@ -99,10 +102,10 @@ export async function GET(request: NextRequest) {
             : booking.department,
         "Role (Affiliation)": booking.role,
         "Room(s)": booking.roomId,
-        "Booking Start Date": format(startDate, "M/d/yyyy"),
-        "Booking End Date": format(endDate, "M/d/yyyy"),
-        "Booking Start Time": format(startDate, "h:mm a"),
-        "Booking End Time": format(endDate, "h:mm a"),
+        "Booking Start Date": formatInTimeZone(startDate, EXPORT_TIME_ZONE, "M/d/yyyy"),
+        "Booking End Date": formatInTimeZone(endDate, EXPORT_TIME_ZONE, "M/d/yyyy"),
+        "Booking Start Time": formatInTimeZone(startDate, EXPORT_TIME_ZONE, "h:mm a"),
+        "Booking End Time": formatInTimeZone(endDate, EXPORT_TIME_ZONE, "h:mm a"),
         "Time In Use, Hours": timeInUse,
         "# rooms used": roomCount,
         "ACTUAL hours": timeInUse * roomCount,

--- a/booking-app/app/api/bookings/export/route.ts
+++ b/booking-app/app/api/bookings/export/route.ts
@@ -8,11 +8,10 @@ import {
   serverGetDocumentById,
 } from "@/lib/firebase/server/adminDb";
 import { applyEnvironmentCalendarIds } from "@/lib/utils/calendarEnvironment";
-import { format } from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";
 import { parse } from "json2csv";
 
-const EXPORT_TIME_ZONE = "America/New_York";
+import { TIMEZONE } from "../shared";
 
 export async function GET(request: NextRequest) {
   // Get tenant from request headers or default to 'mc'
@@ -102,10 +101,10 @@ export async function GET(request: NextRequest) {
             : booking.department,
         "Role (Affiliation)": booking.role,
         "Room(s)": booking.roomId,
-        "Booking Start Date": formatInTimeZone(startDate, EXPORT_TIME_ZONE, "M/d/yyyy"),
-        "Booking End Date": formatInTimeZone(endDate, EXPORT_TIME_ZONE, "M/d/yyyy"),
-        "Booking Start Time": formatInTimeZone(startDate, EXPORT_TIME_ZONE, "h:mm a"),
-        "Booking End Time": formatInTimeZone(endDate, EXPORT_TIME_ZONE, "h:mm a"),
+        "Booking Start Date": formatInTimeZone(startDate, TIMEZONE, "M/d/yyyy"),
+        "Booking End Date": formatInTimeZone(endDate, TIMEZONE, "M/d/yyyy"),
+        "Booking Start Time": formatInTimeZone(startDate, TIMEZONE, "h:mm a"),
+        "Booking End Time": formatInTimeZone(endDate, TIMEZONE, "h:mm a"),
         "Time In Use, Hours": timeInUse,
         "# rooms used": roomCount,
         "ACTUAL hours": timeInUse * roomCount,
@@ -137,7 +136,7 @@ export async function GET(request: NextRequest) {
 
   try {
     const csv = parse(csvData);
-    const currentDate = format(new Date(), "yyyy-MM-dd");
+    const currentDate = formatInTimeZone(new Date(), TIMEZONE, "yyyy-MM-dd");
     return new NextResponse(csv, {
       status: 200,
       headers: {

--- a/booking-app/app/api/bookings/export/route.ts
+++ b/booking-app/app/api/bookings/export/route.ts
@@ -2,7 +2,7 @@ import { DEFAULT_TENANT } from "@/components/src/constants/tenants";
 import { NextRequest, NextResponse } from "next/server";
 
 import { TableNames } from "@/components/src/policy";
-import { Booking, BookingOrigin, RoomSetting } from "@/components/src/types";
+import { Booking, RoomSetting, formatOrigin } from "@/components/src/types";
 import {
   serverFetchAllDataFromCollection,
   serverGetDocumentById,
@@ -112,11 +112,7 @@ export async function GET(request: NextRequest) {
         "Reservation Title": booking.title,
         "Reservation Description": booking.description,
         "Expected Attendance": booking.expectedAttendance,
-        "Reservation Origin":
-          booking.origin ||
-          (!booking.department && !booking.role
-            ? BookingOrigin.PREGAME
-            : BookingOrigin.USER),
+        "Reservation Origin": booking.origin ? formatOrigin(booking.origin) : "",
         "Booking Type": booking.bookingType,
         "Attendee Affiliation(s)": booking.attendeeAffiliation,
         "End Event Status": getBookingStatus(booking),


### PR DESCRIPTION
## Summary of Changes

Two bugs in `GET /api/bookings/export`, both affecting the CSV that admins download.

### 1. Start/End Date & Time printed in UTC

The four Booking Start/End Date/Time columns were formatted with `date-fns` `format` and no timezone, so on the UTC production runtime every row was emitted in UTC instead of NY wall-clock time.

For most records the shift was "only" 4–5 hours so it looked plausible, but bookings that end near midnight NY (e.g. all-day reservations ending at 23:59) had both the date and time flip to the next UTC day — a 23:59 NY end time printed as `3:59 AM` on the following date.

Switched the four columns to `formatInTimeZone(..., "America/New_York", ...)` from `date-fns-tz` (already a dependency, and already the pattern used in `app/api/bookings/shared.ts`).

DB values themselves are correct Firestore `Timestamp`s — verified across a 69-record sample spanning requestNumber 1–4005. The bug was purely in the export's formatting layer.

### 2. Missing `origin` mis-classified as Pre-game

The `Reservation Origin` column fell back to `!department && !role ? PREGAME : USER` when `origin` was missing. That heuristic predates the current pregame import flow (`app/api/syncSemesterPregameBookings/route.ts` now sets `origin: BookingOrigin.PREGAME` explicitly), so it only mis-labels pre-refactor records — old user bookings were showing up as "Pre-game" in the export.

Now the column emits an empty string when `origin` is missing, and uses `formatOrigin` for the label when it is present.

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [ ] I thoroughly tested this feature locally
- [ ] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [ ] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video

N/A — CSV column output change.