### PR TITLE
Unified dashboard style for users

### DIFF
--- a/booking-app/components/src/client/routes/myBookings/myBookingsPage.tsx
+++ b/booking-app/components/src/client/routes/myBookings/myBookingsPage.tsx
@@ -1,27 +1,30 @@
-import { Box, Typography } from "@mui/material";
+import { Box, Tab, Tabs } from "@mui/material";
+import { useContext, useState } from "react";
 
 import { PageContextLevel } from "@/components/src/types";
-import { styled } from "@mui/system";
-import { useTenantSchema } from "../components/SchemaProvider";
 import { Bookings } from "../components/bookingTable/Bookings";
-
-const Center = styled(Box)`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`;
+import { CenterLoading } from "../components/Loading";
+import { DatabaseContext } from "../components/Provider";
 
 export default function MyBookingsPage() {
-  const schema = useTenantSchema();
+  const { userEmail } = useContext(DatabaseContext);
+  const [tab, setTab] = useState("bookings");
+
+  if (userEmail === undefined) {
+    return <CenterLoading />;
+  }
 
   return (
-    <Center>
-      <Box width={{ xs: "90%", md: "65%" }} margin={6}>
-        <Typography variant="h6">
-          Welcome to the {schema.name} booking tool!
-        </Typography>
-        <Bookings pageContext={PageContextLevel.USER} />
-      </Box>
-    </Center>
+    <Box margin={3}>
+      <Tabs
+        value={tab}
+        onChange={(_, newVal) => setTab(newVal)}
+        textColor="primary"
+        indicatorColor="primary"
+      >
+        <Tab value="bookings" label="Bookings" />
+      </Tabs>
+      {tab === "bookings" && <Bookings pageContext={PageContextLevel.USER} />}
+    </Box>
   );
 }

--- a/booking-app/tests/unit/MyBookingsPage.unit.test.tsx
+++ b/booking-app/tests/unit/MyBookingsPage.unit.test.tsx
@@ -1,0 +1,122 @@
+import MyBookingsPage from "@/components/src/client/routes/myBookings/myBookingsPage";
+import { DatabaseContext } from "@/components/src/client/routes/components/Provider";
+import { SchemaContext } from "@/components/src/client/routes/components/SchemaProvider";
+import { PageContextLevel, PagePermission } from "@/components/src/types";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+// Capture the pageContext passed to <Bookings> so we can assert on it
+const mockBookings = vi.fn();
+vi.mock(
+  "@/components/src/client/routes/components/bookingTable/Bookings",
+  () => ({
+    Bookings: (props: { pageContext: PageContextLevel }) => {
+      mockBookings(props);
+      return (
+        <div
+          data-testid="bookings"
+          data-page-context={props.pageContext}
+        />
+      );
+    },
+  })
+);
+
+vi.mock("@/components/src/client/routes/components/Loading", () => ({
+  CenterLoading: () => <div data-testid="center-loading" />,
+}));
+
+const theme = createTheme();
+
+const mockSchemaContext = {
+  resourceName: "Room",
+  schema: { name: "Media Commons" } as any,
+};
+
+function buildDatabaseContext(overrides: Partial<{ userEmail: string | undefined }> = {}) {
+  return {
+    userEmail: "user@nyu.edu",
+    pagePermission: PagePermission.BOOKING,
+    adminUsers: [],
+    paUsers: [],
+    liaisonUsers: [],
+    equipmentUsers: [],
+    superAdminUsers: [],
+    bannedUsers: [],
+    allBookings: [],
+    bookingsLoading: false,
+    settings: { bookingTypes: [] },
+    roomSettings: [],
+    setFilters: vi.fn(),
+    setLoadMoreEnabled: vi.fn(),
+    fetchAllBookings: vi.fn(),
+    setLastItem: vi.fn(),
+    ...overrides,
+  } as any;
+}
+
+function renderPage(dbCtx: ReturnType<typeof buildDatabaseContext>) {
+  return render(
+    <ThemeProvider theme={theme}>
+      <DatabaseContext.Provider value={dbCtx}>
+        <SchemaContext.Provider value={mockSchemaContext as any}>
+          <MyBookingsPage />
+        </SchemaContext.Provider>
+      </DatabaseContext.Provider>
+    </ThemeProvider>
+  );
+}
+
+describe("MyBookingsPage", () => {
+  it("shows loading spinner while userEmail is undefined", () => {
+    renderPage(buildDatabaseContext({ userEmail: undefined }));
+    expect(screen.getByTestId("center-loading")).toBeInTheDocument();
+    expect(screen.queryByTestId("bookings")).not.toBeInTheDocument();
+  });
+
+  it("renders the Bookings tab once userEmail is resolved", () => {
+    renderPage(buildDatabaseContext());
+    expect(screen.queryByTestId("center-loading")).not.toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Bookings" })).toBeInTheDocument();
+    expect(screen.getByTestId("bookings")).toBeInTheDocument();
+  });
+
+  it("passes PageContextLevel.USER to <Bookings> — never a privileged level", () => {
+    renderPage(buildDatabaseContext());
+    expect(mockBookings).toHaveBeenCalledWith(
+      expect.objectContaining({ pageContext: PageContextLevel.USER })
+    );
+    // Explicitly assert none of the privileged levels are passed
+    const calledWith: PageContextLevel = mockBookings.mock.calls[0][0].pageContext;
+    expect(calledWith).not.toBe(PageContextLevel.PA);
+    expect(calledWith).not.toBe(PageContextLevel.LIAISON);
+    expect(calledWith).not.toBe(PageContextLevel.ADMIN);
+  });
+
+  it("exposes only a single Bookings tab — no Settings or admin-only tabs", () => {
+    renderPage(buildDatabaseContext());
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(1);
+    expect(tabs[0]).toHaveTextContent("Bookings");
+  });
+
+  it("Bookings panel is visible by default without any tab interaction", () => {
+    renderPage(buildDatabaseContext());
+    expect(screen.getByTestId("bookings")).toBeInTheDocument();
+  });
+
+  it("does not expose settings or admin controls even if the user has a higher permission stored", () => {
+    // A user whose permission was resolved to ADMIN should still see only
+    // the USER-level bookings view on the my-bookings page.
+    renderPage(buildDatabaseContext({ userEmail: "admin@nyu.edu" }));
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(1);
+    expect(screen.queryByRole("tab", { name: /settings/i })).not.toBeInTheDocument();
+    expect(mockBookings).toHaveBeenCalledWith(
+      expect.objectContaining({ pageContext: PageContextLevel.USER })
+    );
+  });
+});


### PR DESCRIPTION
## Summary of Changes

https://github.com/ITPNYU/booking-app/issues/716

- Box margin={3} same wrapper as PA/Liaison/Admin
- Full width consistent layout
- Tabs + <Tab value="bookings" label="Bookings" /> structure
- CenterLoading while userEmail is not yet resolved

The page still uses PageContextLevel.USER, which scopes what <Bookings> renders (no approve/decline/admin actions).
There is no permission check that could accidentally escalate, unlike Admin/PA/Liaison, there's no pagePermission gate here since any authenticated user can view their own bookings.
The only guard is userEmail === undefined (loading state), so a plain user will never see content intended for privileged roles.

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [x] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [x] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [x] I requested a code review from at least one other teammate

## Screenshots / Video

<img width="1506" height="704" alt="image" src="https://github.com/user-attachments/assets/b3af3c6f-a5f0-45cb-b07d-1ba7f2597f81" />

