### PR TITLE
fix: delete Google Calendar event when booking is marked no-show (#1367)

### DIFF
--- a/booking-app/components/src/server/db.ts
+++ b/booking-app/components/src/server/db.ts
@@ -1106,6 +1106,33 @@ export const noShow = async (
         await executeTraditionalNoShow(id, email, netId, tenant);
       }
 
+      // #1367: noShow transitions through Canceled via always; cancel-processing
+      // must run so the Google Calendar event gets deleted.
+      try {
+        const cancelResponse = await fetch(
+          `${process.env.NEXT_PUBLIC_BASE_URL}/api/cancel-processing`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "x-tenant": tenant || DEFAULT_TENANT,
+            },
+            body: JSON.stringify({ calendarEventId: id, email, netId, tenant }),
+          },
+        );
+        if (!cancelResponse.ok) {
+          console.error(
+            `🚨 NO SHOW CANCEL-PROCESSING FAILED [${tenant?.toUpperCase()}]:`,
+            { calendarEventId: id, status: cancelResponse.status },
+          );
+        }
+      } catch (error: any) {
+        console.error(
+          `🚨 NO SHOW CANCEL-PROCESSING ERROR [${tenant?.toUpperCase()}]:`,
+          { calendarEventId: id, error: error.message },
+        );
+      }
+
       // When noShow transitions directly to Closed
       if (xstateResult.newState === "Closed") {
         try {

--- a/booking-app/tests/unit/no-show-system-attribution.unit.test.ts
+++ b/booking-app/tests/unit/no-show-system-attribution.unit.test.ts
@@ -705,7 +705,7 @@ describe("noShow function XState flow", () => {
 
     await dbModule.noShow("cal-event-456", "staff@nyu.edu", "staff456", "mc");
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Traditional NoShow flow is skipped when XState doesn't reach "No Show"
     expect(mockClientUpdateDataByCalendarEventId).not.toHaveBeenCalled();
     expect(mockClientSaveDataToFirestore).not.toHaveBeenCalled();
     expect(mockClientGetDataByCalendarEventId).not.toHaveBeenCalled();
@@ -714,6 +714,13 @@ describe("noShow function XState flow", () => {
         ([url]) => typeof url === "string" && url.includes("/api/sendEmail"),
       ),
     ).toBe(false);
+    // #1367: cancel-processing must still run so Google Calendar event is deleted
+    expect(
+      fetchMock.mock.calls.some(
+        ([url]) =>
+          typeof url === "string" && url.includes("/api/cancel-processing"),
+      ),
+    ).toBe(true);
   });
 
   it("falls back to traditional flow when XState API fails", async () => {

--- a/booking-app/tests/unit/server-db.unit.test.ts
+++ b/booking-app/tests/unit/server-db.unit.test.ts
@@ -422,6 +422,98 @@ describe("server/db", () => {
     });
   });
 
+  describe("noShow", () => {
+    const makeResponse = (data: any, ok = true) =>
+      ({
+        ok,
+        json: async () => data,
+        text: async () => JSON.stringify(data),
+      }) as Response;
+
+    it("calls /api/cancel-processing after successful XState transition so calendar event is deleted (MC tenant, #1367)", async () => {
+      mockShouldUseXState.mockReturnValue(true);
+
+      const fetchCalls: Array<{ href: string; options?: RequestInit }> = [];
+      mockFetch.mockImplementation((url: any, options: any) => {
+        const href = typeof url === "string" ? url : url.toString();
+        fetchCalls.push({ href, options });
+
+        if (href.includes("/api/xstate-transition")) {
+          // noShow → No Show → (always) → Canceled → Service Closeout (with services)
+          return makeResponse({ newState: "Service Closeout" });
+        }
+        return makeResponse({});
+      });
+
+      const { noShow } = await import("@/components/src/server/db");
+      await noShow("cal-ns-1", "admin@nyu.edu", "admin", "media_commons");
+
+      const cancelProcessingCall = fetchCalls.find((c) =>
+        c.href.includes("/api/cancel-processing"),
+      );
+      expect(cancelProcessingCall).toBeDefined();
+      const payload = JSON.parse(String(cancelProcessingCall?.options?.body));
+      expect(payload).toMatchObject({
+        calendarEventId: "cal-ns-1",
+        email: "admin@nyu.edu",
+        netId: "admin",
+        tenant: "media_commons",
+      });
+    });
+
+    it("calls /api/cancel-processing after successful XState transition (ITP tenant, #1367)", async () => {
+      mockShouldUseXState.mockReturnValue(true);
+
+      const fetchCalls: Array<{ href: string; options?: RequestInit }> = [];
+      mockFetch.mockImplementation((url: any, options: any) => {
+        const href = typeof url === "string" ? url : url.toString();
+        fetchCalls.push({ href, options });
+
+        if (href.includes("/api/xstate-transition")) {
+          // ITP: noShow → No Show → Canceled → Closed (no services in ITP)
+          return makeResponse({ newState: "Closed" });
+        }
+        return makeResponse({});
+      });
+
+      const { noShow } = await import("@/components/src/server/db");
+      await noShow("cal-ns-2", "admin@nyu.edu", "admin", "itp");
+
+      const cancelProcessingCall = fetchCalls.find((c) =>
+        c.href.includes("/api/cancel-processing"),
+      );
+      expect(cancelProcessingCall).toBeDefined();
+      const payload = JSON.parse(String(cancelProcessingCall?.options?.body));
+      expect(payload).toMatchObject({
+        calendarEventId: "cal-ns-2",
+        tenant: "itp",
+      });
+    });
+
+    it("does NOT call cancel-processing when XState transition fails", async () => {
+      mockShouldUseXState.mockReturnValue(true);
+
+      const fetchCalls: Array<{ href: string }> = [];
+      mockFetch.mockImplementation((url: any) => {
+        const href = typeof url === "string" ? url : url.toString();
+        fetchCalls.push({ href });
+
+        if (href.includes("/api/xstate-transition")) {
+          return makeResponse({ error: "boom" }, false);
+        }
+        return makeResponse({});
+      });
+
+      const { noShow } = await import("@/components/src/server/db");
+      await noShow("cal-ns-3", "admin@nyu.edu", "admin", "media_commons");
+
+      const cancelProcessingCall = fetchCalls.find((c) =>
+        c.href.includes("/api/cancel-processing"),
+      );
+      expect(cancelProcessingCall).toBeUndefined();
+    });
+  });
+
   describe("checkin", () => {
     const makeResponse = (data: any, ok = true) =>
       ({


### PR DESCRIPTION
## Summary of Changes

Fixes #1367. When a booking is marked No Show, the corresponding Google Calendar event stayed on the room calendar and blocked walk-in reservations.

**Root cause**: The XState machine auto-transitions `No Show → Canceled` (via `always`), so logically the cancel-processing side effects (including `deleteEvent`) should fire. However, commit `8567a452` (2026-03-13) moved `handleCancelProcessing` out of `mcBookingMachine` into `db.ts` to unify the MC/ITP code paths. `db.ts cancel()` was updated to fetch `/api/cancel-processing`, but `db.ts noShow()` was missed. So when a PA marked a booking as No Show, the XState snapshot reached Canceled but the calendar event was never deleted.

**Fix**: Add a `/api/cancel-processing` fetch in `db.ts noShow()` after the XState transition succeeds, mirroring the `auto-cancel-declined` cron pattern. This ensures the calendar delete runs regardless of final state (No Show / Canceled / Service Closeout / Closed).

Verified via GCP logs: 191/192 `deleteEvent` calls in the last 30 days already succeed for the user-cancel path; no-show was the only orphaned entry point.

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

Screenshots/video N/A: this is a backend-only side-effect fix with no UI surface. Manual verification path on staging: mark any Approved booking as No Show from the admin dashboard, then confirm the event disappears from the room's Google Calendar within seconds.

Unit tests added:
- `server-db.unit.test.ts > noShow > calls /api/cancel-processing after successful XState transition (MC tenant, #1367)`
- `server-db.unit.test.ts > noShow > calls /api/cancel-processing after successful XState transition (ITP tenant, #1367)`
- `server-db.unit.test.ts > noShow > does NOT call cancel-processing when XState transition fails`
- Updated `no-show-system-attribution.unit.test.ts` "skips traditional flow when XState does not reach 'No Show'" to assert cancel-processing still runs

All 1411 unit tests pass.

## Screenshots / Video

N/A (backend fix, no UI change).