### PR TITLE
fix: make Canceled state entry trigger cancel-processing (#1367)

### DIFF
--- a/booking-app/app/api/bookings/auto-cancel-declined/route.ts
+++ b/booking-app/app/api/bookings/auto-cancel-declined/route.ts
@@ -193,6 +193,7 @@ export async function GET(request: NextRequest) {
             "system", // System identifier for automated actions
             tenant,
             `Auto-canceled after ${gracePeriodHours}-hour grace period expired`,
+            "system", // netId
           );
 
           if (xstateResult.success) {

--- a/booking-app/app/api/bookings/auto-cancel-declined/route.ts
+++ b/booking-app/app/api/bookings/auto-cancel-declined/route.ts
@@ -207,30 +207,8 @@ export async function GET(request: NextRequest) {
               `Auto-canceled after ${gracePeriodHours}-hour grace period`,
             );
 
-            // Call cancel-processing API for side effects (email, calendar, history)
-            // Machine actions are no-ops; processing is delegated to APIs
-            try {
-              await fetch(
-                `${process.env.NEXT_PUBLIC_BASE_URL}/api/cancel-processing`,
-                {
-                  method: "POST",
-                  headers: { "Content-Type": "application/json" },
-                  body: JSON.stringify({
-                    calendarEventId: booking.calendarEventId,
-                    email: "system",
-                    netId: "system",
-                    tenant,
-                  }),
-                },
-              );
-            } catch (procError) {
-              BookingLogger.apiError(
-                "POST",
-                "/api/cancel-processing",
-                { calendarEventId: booking.calendarEventId, tenant },
-                procError,
-              );
-            }
+            // cancel-processing is triggered by the machine's Canceled state
+            // entry via queueCancelProcessing. No manual fetch here.
 
             // If cancel transitions directly to Closed, call close-processing
             if (xstateResult.newState === "Closed") {

--- a/booking-app/app/api/bookings/auto-cancel-unapproved/route.ts
+++ b/booking-app/app/api/bookings/auto-cancel-unapproved/route.ts
@@ -197,26 +197,8 @@ export async function GET(request: NextRequest) {
           continue;
         }
 
-        // Side effects are processed via APIs (matches existing cron patterns)
-        try {
-          await fetch(`${process.env.NEXT_PUBLIC_BASE_URL}/api/cancel-processing`, {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              calendarEventId: booking.calendarEventId,
-              email: "system",
-              netId: "system",
-              tenant,
-            }),
-          });
-        } catch (procError) {
-          BookingLogger.apiError(
-            "POST",
-            "/api/cancel-processing",
-            { calendarEventId: booking.calendarEventId, tenant },
-            procError,
-          );
-        }
+        // cancel-processing is triggered by the machine's Canceled state
+        // entry via queueCancelProcessing. No manual fetch here.
 
         if (xstateResult.newState === "Closed") {
           try {

--- a/booking-app/app/api/bookings/auto-cancel-unapproved/route.ts
+++ b/booking-app/app/api/bookings/auto-cancel-unapproved/route.ts
@@ -186,6 +186,7 @@ export async function GET(request: NextRequest) {
           "system",
           tenant,
           reason,
+          "system", // netId
         );
 
         if (!xstateResult.success) {

--- a/booking-app/app/api/xstate-transition/route.ts
+++ b/booking-app/app/api/xstate-transition/route.ts
@@ -9,10 +9,14 @@ import {
 /**
  * Execute XState transition for ITP bookings
  * POST /api/xstate-transition
- * Body: { calendarEventId: string, eventType: string, email?: string }
+ * Body: { calendarEventId: string, eventType: string, email?: string, netId?: string, reason?: string }
+ *
+ * netId is the authoritative user id from the caller's session — needed because
+ * some queued side effects (pre-ban logging inside /api/cancel-processing) key
+ * off it. Reconstructing from email.split("@")[0] is wrong for aliases.
  */
 export async function POST(req: NextRequest) {
-  const { calendarEventId, eventType, email, reason } = await req.json();
+  const { calendarEventId, eventType, email, netId, reason } = await req.json();
 
   // Get tenant from x-tenant header, fallback to default tenant
   const tenant = req.headers.get("x-tenant") || DEFAULT_TENANT;
@@ -90,6 +94,7 @@ export async function POST(req: NextRequest) {
       tenant,
       email, // Pass email for finalApprovedBy
       reason, // Pass reason for decline actions
+      netId, // Pass authoritative netId for side effects (pre-ban logging)
     );
 
     if (!result.success) {

--- a/booking-app/components/src/server/db.ts
+++ b/booking-app/components/src/server/db.ts
@@ -738,40 +738,9 @@ export const cancel = async (
       newState: xstateResult.newState,
     });
 
-    // Delegate cancel processing to /api/cancel-processing for all tenants
-    try {
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_BASE_URL}/api/cancel-processing`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            calendarEventId: id,
-            email,
-            netId,
-            tenant,
-          }),
-        },
-      );
-
-      if (response.ok) {
-        console.log(
-          `✅ CANCEL-PROCESSING API SUCCESS [${tenant?.toUpperCase()}]:`,
-          { calendarEventId: id },
-        );
-      } else {
-        const errorData = await response.json();
-        console.error(
-          `🚨 CANCEL-PROCESSING API FAILED [${tenant?.toUpperCase()}]:`,
-          { calendarEventId: id, error: errorData },
-        );
-      }
-    } catch (error: any) {
-      console.error(
-        `🚨 CANCEL-PROCESSING API ERROR [${tenant?.toUpperCase()}]:`,
-        { calendarEventId: id, error: error.message },
-      );
-    }
+    // cancel-processing is now triggered by the machine's Canceled state entry
+    // via queueCancelProcessing → xstate-transition executor. No manual fetch
+    // here — see lib/stateMachines/xstateTransitions.ts::executeSideEffect.
 
     // When cancel transitions directly to Closed (e.g., cancel without services)
     if (xstateResult.newState === "Closed") {

--- a/booking-app/components/src/server/db.ts
+++ b/booking-app/components/src/server/db.ts
@@ -33,12 +33,17 @@ import {
 import { getBookingToolDeployUrl } from "./ui";
 
 // Helper function to call XState transition API
+//
+// netId is threaded through to the xstate-transition route because side effects
+// queued by state entry actions (e.g., /api/cancel-processing for pre-ban
+// logging) need the authoritative netId, not one guessed from email local-part.
 export async function callXStateTransitionAPI(
   calendarEventId: string,
   eventType: string,
   email: string,
   tenant?: string,
   reason?: string,
+  netId?: string,
 ): Promise<{ success: boolean; newState?: string; error?: string }> {
   try {
     const response = await fetch(
@@ -53,6 +58,7 @@ export async function callXStateTransitionAPI(
           calendarEventId,
           eventType,
           email,
+          netId,
           reason,
         }),
       },
@@ -714,6 +720,8 @@ export const cancel = async (
     "cancel",
     email,
     tenant,
+    undefined, // reason
+    netId,
   );
 
   if (!xstateResult.success) {
@@ -1036,6 +1044,8 @@ export const noShow = async (
       "noShow",
       email,
       tenant,
+      undefined, // reason
+      netId,
     );
 
     if (!xstateResult.success) {

--- a/booking-app/lib/stateMachines/itpBookingMachine.ts
+++ b/booking-app/lib/stateMachines/itpBookingMachine.ts
@@ -18,6 +18,10 @@ interface BookingContext {
   calendarEventId?: string | null;
   email?: string;
   automationReason?: AutomaticCancellationReason; // Tracks automatic transitions
+  // Queue of side effects declared by state entry actions. Machine stays pure
+  // (assign only); xstate-transition route drains and executes the list after
+  // the transition, then clears it before persisting the snapshot.
+  pendingSideEffects?: string[];
 }
 
 export const itpBookingMachine = setup({
@@ -135,6 +139,15 @@ export const itpBookingMachine = setup({
         calendarEventId: context.calendarEventId,
       });
     },
+    // Queue a side effect for the xstate-transition route to execute after
+    // the machine finishes transitioning. Pure assign — safe on both server
+    // and client.
+    queueCancelProcessing: assign({
+      pendingSideEffects: ({ context }) => [
+        ...(context.pendingSideEffects ?? []),
+        "cancelProcessing",
+      ],
+    }),
     logCanceledAfterAutomaticTransition: async (
       { context },
     ): Promise<void> => {
@@ -206,13 +219,7 @@ export const itpBookingMachine = setup({
           });
         },
         {
-          type: "sendHTMLEmail",
-        },
-        {
-          type: "updateCalendarEvent",
-        },
-        {
-          type: "deleteCalendarEvent",
+          type: "queueCancelProcessing",
         },
         {
           type: "logCanceledAfterAutomaticTransition",

--- a/booking-app/lib/stateMachines/mcBookingMachine.ts
+++ b/booking-app/lib/stateMachines/mcBookingMachine.ts
@@ -211,6 +211,10 @@ interface MediaCommonsBookingContext {
   };
   // Flag to indicate this XState was created from existing booking without prior xstateData
   _restoredFromStatus?: boolean;
+  // Queue of side effects declared by state entry actions. Machine stays pure
+  // (assign only); xstate-transition route drains and executes the list after
+  // the transition, then clears it before persisting the snapshot.
+  pendingSideEffects?: string[];
 }
 
 // ⚠️ XSTATE PURITY CONSTRAINT:
@@ -239,14 +243,15 @@ export const mcBookingMachine = setup({
   },
   actors: {},
   actions: {
-    // Cancel processing is now handled by db.ts after XState transition
-    // to keep the same pattern across all tenants (MC, ITP, etc.)
-    handleCancelProcessing: ({ context }) => {
-      console.log("🎬 XSTATE ACTION: handleCancelProcessing (no-op, handled by db.ts)", {
-        calendarEventId: context.calendarEventId,
-        tenant: context.tenant,
-      });
-    },
+    // Queue a side effect for the xstate-transition route to execute after
+    // the machine finishes transitioning. Pure assign — safe on both server
+    // and client.
+    queueCancelProcessing: assign({
+      pendingSideEffects: ({ context }) => [
+        ...(context.pendingSideEffects ?? []),
+        "cancelProcessing",
+      ],
+    }),
 
     sendHTMLEmail: ({ context, event }) => {
       // NOTE: This is a placeholder action for state machine logic only
@@ -806,7 +811,7 @@ export const mcBookingMachine = setup({
           );
         },
         {
-          type: "handleCancelProcessing",
+          type: "queueCancelProcessing",
         },
         {
           type: "logCanceledAfterAutomaticTransition",

--- a/booking-app/lib/stateMachines/xstateTransitions.ts
+++ b/booking-app/lib/stateMachines/xstateTransitions.ts
@@ -25,13 +25,25 @@ import type { PersistedXStateData } from "./xstateTypes";
  * Drain and execute a single side effect declared by a state entry action
  * (via `queueCancelProcessing` or similar assign). Keeps the machine pure
  * while still making state entry the trigger for real-world work.
+ *
+ * netId is passed through from the caller (authoritative from session) rather
+ * than reconstructed from email, because some effects (pre-ban logging inside
+ * /api/cancel-processing) key off it — alias emails where the local-part !=
+ * netId would otherwise penalize the wrong user.
  */
 async function executeSideEffect(
   effect: string,
-  ctx: { calendarEventId: string; tenant?: string; email?: string },
+  ctx: {
+    calendarEventId: string;
+    tenant?: string;
+    email?: string;
+    netId?: string;
+  },
 ): Promise<void> {
-  const { calendarEventId, tenant, email } = ctx;
-  const netId = email && email.includes("@") ? email.split("@")[0] : "system";
+  const { calendarEventId, tenant, email, netId: passedNetId } = ctx;
+  const netId =
+    passedNetId ||
+    (email && email.includes("@") ? email.split("@")[0] : "system");
 
   if (effect === "cancelProcessing") {
     try {
@@ -81,6 +93,7 @@ export async function executeXStateTransition(
   tenant?: string,
   email?: string,
   reason?: string,
+  netId?: string,
 ): Promise<{ success: boolean; newState?: string; error?: string }> {
   try {
     console.log(
@@ -576,7 +589,7 @@ export async function executeXStateTransition(
     // the snapshot so we can clear the queue — otherwise a restore would re-fire.
     const pendingEffects = (newSnapshot.context as any)?.pendingSideEffects ?? [];
     for (const effect of pendingEffects) {
-      await executeSideEffect(effect, { calendarEventId, tenant, email });
+      await executeSideEffect(effect, { calendarEventId, tenant, email, netId });
     }
     if (pendingEffects.length > 0 && firestoreUpdates.xstateData?.snapshot?.context) {
       (firestoreUpdates.xstateData.snapshot.context as any).pendingSideEffects = [];

--- a/booking-app/lib/stateMachines/xstateTransitions.ts
+++ b/booking-app/lib/stateMachines/xstateTransitions.ts
@@ -22,6 +22,57 @@ import {
 import type { PersistedXStateData } from "./xstateTypes";
 
 /**
+ * Drain and execute a single side effect declared by a state entry action
+ * (via `queueCancelProcessing` or similar assign). Keeps the machine pure
+ * while still making state entry the trigger for real-world work.
+ */
+async function executeSideEffect(
+  effect: string,
+  ctx: { calendarEventId: string; tenant?: string; email?: string },
+): Promise<void> {
+  const { calendarEventId, tenant, email } = ctx;
+  const netId = email && email.includes("@") ? email.split("@")[0] : "system";
+
+  if (effect === "cancelProcessing") {
+    try {
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_BASE_URL}/api/cancel-processing`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "x-tenant": tenant || DEFAULT_TENANT,
+          },
+          body: JSON.stringify({
+            calendarEventId,
+            email: email || "system",
+            netId,
+            tenant,
+          }),
+        },
+      );
+      if (!response.ok) {
+        console.error(
+          `🚨 SIDE EFFECT FAILED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+          { effect, calendarEventId, status: response.status },
+        );
+      }
+    } catch (error: any) {
+      console.error(
+        `🚨 SIDE EFFECT ERROR [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+        { effect, calendarEventId, error: error.message },
+      );
+    }
+    return;
+  }
+
+  console.warn(
+    `⚠️ UNKNOWN SIDE EFFECT [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+    { effect, calendarEventId },
+  );
+}
+
+/**
  * Execute XState transition and save updated state to Firestore
  */
 export async function executeXStateTransition(
@@ -517,6 +568,18 @@ export async function executeXStateTransition(
           },
         },
       );
+    }
+
+    // Drain side effects queued by state entry actions (see `queueCancelProcessing`
+     // etc. in machine definitions). Runs after handleStateTransitions so any
+    // firestoreUpdates they rely on are in the same save, and BEFORE persisting
+    // the snapshot so we can clear the queue — otherwise a restore would re-fire.
+    const pendingEffects = (newSnapshot.context as any)?.pendingSideEffects ?? [];
+    for (const effect of pendingEffects) {
+      await executeSideEffect(effect, { calendarEventId, tenant, email });
+    }
+    if (pendingEffects.length > 0 && firestoreUpdates.xstateData?.snapshot?.context) {
+      (firestoreUpdates.xstateData.snapshot.context as any).pendingSideEffects = [];
     }
 
     // Save updated state to Firestore

--- a/booking-app/tests/unit/itp-booking-machine.xstate.unit.test.ts
+++ b/booking-app/tests/unit/itp-booking-machine.xstate.unit.test.ts
@@ -419,6 +419,31 @@ describe("Cancellation", () => {
     actor.stop();
   });
 
+  it("Canceled entry queues cancelProcessing side effect (user cancel)", () => {
+    const { machine } = createSpiedMachine();
+    const actor = createActor(machine, { input: manualInput });
+    actor.start();
+    actor.send({ type: "cancel" });
+    expect(
+      actor.getSnapshot().context.pendingSideEffects,
+    ).toContain("cancelProcessing");
+    actor.stop();
+  });
+
+  it("noShow → Canceled via always also queues cancelProcessing (#1367 structural fix)", () => {
+    const { machine } = createSpiedMachine();
+    const actor = createActor(machine, { input: manualInput });
+    actor.start();
+    actor.send({ type: "approve" });
+    actor.send({ type: "noShow" });
+    // noShow → No Show → (always) → Canceled → (always) → Closed
+    // Canceled entry must still fire and queue cancelProcessing
+    expect(
+      actor.getSnapshot().context.pendingSideEffects,
+    ).toContain("cancelProcessing");
+    actor.stop();
+  });
+
 });
 
 // ===== 5. Decline =====
@@ -519,8 +544,8 @@ describe("No Show", () => {
     actor.stop();
   });
 
-  it("deleteCalendarEvent fires during No Show → Canceled transition", () => {
-    const { machine, spies } = createSpiedMachine();
+  it("cancelProcessing is queued during No Show → Canceled transition (#1367)", () => {
+    const { machine } = createSpiedMachine();
     const actor = createActor(machine, {
       input: {
         tenant: "itp",
@@ -530,11 +555,16 @@ describe("No Show", () => {
       },
     });
     actor.start();
-    spies.deleteCalendarEvent.mockClear();
     actor.send({ type: "approve" });
     actor.send({ type: "noShow" });
-    // deleteCalendarEvent fires as part of Canceled entry actions
-    expect(spies.deleteCalendarEvent).toHaveBeenCalled();
+    // Canceled entry queues cancelProcessing; the xstate-transition route
+    // executor then fetches /api/cancel-processing which deletes the calendar
+    // event. This closes #1367 structurally — every path that traverses
+    // Canceled (user cancel, noShow, decline-24h, auto-cancel-unapproved)
+    // triggers the same side effect.
+    expect(
+      actor.getSnapshot().context.pendingSideEffects,
+    ).toContain("cancelProcessing");
     actor.stop();
   });
 });
@@ -715,18 +745,18 @@ describe("Entry Actions Verification", () => {
     actor.stop();
   });
 
-  it("Canceled: sendHTMLEmail + updateCalendarEvent + deleteCalendarEvent", () => {
-    const { machine, spies } = createSpiedMachine();
+  it("Canceled: queues cancelProcessing side effect (machine-driven)", () => {
+    const { machine } = createSpiedMachine();
     const actor = createActor(machine, { input: manualInput });
     actor.start();
-    spies.sendHTMLEmail.mockClear();
-    spies.updateCalendarEvent.mockClear();
-    spies.deleteCalendarEvent.mockClear();
     actor.send({ type: "cancel" });
-    // Canceled entry runs before transient → Closed
-    expect(spies.sendHTMLEmail).toHaveBeenCalled();
-    expect(spies.updateCalendarEvent).toHaveBeenCalled();
-    expect(spies.deleteCalendarEvent).toHaveBeenCalled();
+    // Canceled entry runs before transient → Closed and queues the effect.
+    // The xstate-transition route executor drains the queue after the
+    // transition completes; cancelProcessing → /api/cancel-processing
+    // which handles email + calendar delete + Firestore updates.
+    expect(
+      actor.getSnapshot().context.pendingSideEffects,
+    ).toContain("cancelProcessing");
     actor.stop();
   });
 
@@ -771,17 +801,18 @@ describe("Entry Actions Verification", () => {
     const emailCallsBefore = spies.sendHTMLEmail.mock.calls.length;
     actor.send({ type: "noShow" });
 
-    // updateCalendarEvent is called in No Show entry, Canceled entry, and Closed entry
-    expect(spies.updateCalendarEvent).toHaveBeenCalled();
-    // sendHTMLEmail is NOT called in No Show entry, but IS called in Canceled and Closed
-    // We verify No Show state's own entry only has updateCalendarEvent
-    // (The total calls include Canceled + Closed transient entries too)
+    // updateCalendarEvent is called in No Show and Closed entries.
+    // Canceled entry no longer has sendHTMLEmail/updateCalendarEvent/deleteCalendarEvent —
+    // it queues cancelProcessing instead (handled by the xstate-transition
+    // route executor, not via the machine action spies).
     const totalUpdateCalls = spies.updateCalendarEvent.mock.calls.length - updateCallsBefore;
     const totalEmailCalls = spies.sendHTMLEmail.mock.calls.length - emailCallsBefore;
-    // No Show(1 update) + Canceled(1 update) + Closed(1 update) = 3 updates
-    expect(totalUpdateCalls).toBe(3);
-    // Canceled(1 email) + Closed(1 email) = 2 emails (No Show has none)
-    expect(totalEmailCalls).toBe(2);
+    expect(totalUpdateCalls).toBe(2); // No Show(1) + Closed(1)
+    expect(totalEmailCalls).toBe(1); // Closed(1); No Show and Canceled have none
+    // Canceled side effect is queued instead of fired as a machine action
+    expect(
+      actor.getSnapshot().context.pendingSideEffects,
+    ).toContain("cancelProcessing");
     actor.stop();
   });
 

--- a/booking-app/tests/unit/no-show-system-attribution.unit.test.ts
+++ b/booking-app/tests/unit/no-show-system-attribution.unit.test.ts
@@ -606,6 +606,7 @@ describe("noShow function XState flow", () => {
           calendarEventId: "cal-event-123",
           eventType: "noShow",
           email: "staff@nyu.edu",
+          netId: "staff123",
           reason: undefined,
         }),
       }),

--- a/booking-app/tests/unit/server-db.unit.test.ts
+++ b/booking-app/tests/unit/server-db.unit.test.ts
@@ -353,7 +353,7 @@ describe("server/db", () => {
         text: async () => JSON.stringify(data),
       }) as Response;
 
-    it("calls /api/cancel-processing after successful XState transition (MC tenant)", async () => {
+    it("triggers XState cancel transition and does NOT fetch /api/cancel-processing directly (machine-driven via queueCancelProcessing)", async () => {
       const fetchCalls: Array<{ href: string; options?: RequestInit }> = [];
       mockFetch.mockImplementation((url: any, options: any) => {
         const href = typeof url === "string" ? url : url.toString();
@@ -368,46 +368,48 @@ describe("server/db", () => {
       const { cancel } = await import("@/components/src/server/db");
       await cancel("cal-1", "user@nyu.edu", "net123", "media_commons");
 
+      const xstateCall = fetchCalls.find((c) =>
+        c.href.includes("/api/xstate-transition"),
+      );
+      expect(xstateCall).toBeDefined();
+      const xstatePayload = JSON.parse(String(xstateCall?.options?.body));
+      expect(xstatePayload).toMatchObject({
+        calendarEventId: "cal-1",
+        eventType: "cancel",
+        email: "user@nyu.edu",
+      });
+
+      // db.ts cancel() no longer fetches cancel-processing directly.
+      // The Canceled state entry queues cancelProcessing; the xstate-transition
+      // route's executor drains the queue and calls /api/cancel-processing
+      // inside the same request (not visible at this layer).
       const cancelProcessingCall = fetchCalls.find((c) =>
         c.href.includes("/api/cancel-processing"),
       );
-      expect(cancelProcessingCall).toBeDefined();
-      const payload = JSON.parse(String(cancelProcessingCall?.options?.body));
-      expect(payload).toMatchObject({
-        calendarEventId: "cal-1",
-        email: "user@nyu.edu",
-        netId: "net123",
-        tenant: "media_commons",
-      });
+      expect(cancelProcessingCall).toBeUndefined();
     });
 
-    it("calls /api/cancel-processing after successful XState transition (ITP tenant)", async () => {
-      const fetchCalls: Array<{ href: string; options?: RequestInit }> = [];
-      mockFetch.mockImplementation((url: any, options: any) => {
+    it("still calls /api/close-processing when XState cancel transitions directly to Closed", async () => {
+      const fetchCalls: Array<{ href: string }> = [];
+      mockFetch.mockImplementation((url: any) => {
         const href = typeof url === "string" ? url : url.toString();
-        fetchCalls.push({ href, options });
+        fetchCalls.push({ href });
 
         if (href.includes("/api/xstate-transition")) {
-          return makeResponse({ newState: "Canceled" });
+          return makeResponse({ newState: "Closed" });
         }
         return makeResponse({});
       });
 
       const { cancel } = await import("@/components/src/server/db");
-      await cancel("cal-2", "user@nyu.edu", "net456", "itp");
+      await cancel("cal-2", "user@nyu.edu", "net456", "media_commons");
 
-      const cancelProcessingCall = fetchCalls.find((c) =>
-        c.href.includes("/api/cancel-processing"),
-      );
-      expect(cancelProcessingCall).toBeDefined();
-      const payload = JSON.parse(String(cancelProcessingCall?.options?.body));
-      expect(payload).toMatchObject({
-        calendarEventId: "cal-2",
-        tenant: "itp",
-      });
+      expect(
+        fetchCalls.some((c) => c.href.includes("/api/close-processing")),
+      ).toBe(true);
     });
 
-    it("does NOT call cancel-processing when XState transition fails (falls back)", async () => {
+    it("falls back to processCancelBooking when XState transition fails", async () => {
       const fetchCalls: Array<{ href: string }> = [];
       mockFetch.mockImplementation((url: any) => {
         const href = typeof url === "string" ? url : url.toString();
@@ -422,10 +424,12 @@ describe("server/db", () => {
       const { cancel } = await import("@/components/src/server/db");
       await cancel("cal-3", "user@nyu.edu", "net789", "media_commons");
 
-      const cancelProcessingCall = fetchCalls.find((c) =>
-        c.href.includes("/api/cancel-processing"),
-      );
-      expect(cancelProcessingCall).toBeUndefined();
+      // No fetch to /api/cancel-processing from db.ts itself.
+      // Fallback path calls processCancelBooking in-process which updates
+      // Firestore and sends emails directly (not via fetch).
+      expect(
+        fetchCalls.some((c) => c.href.includes("/api/cancel-processing")),
+      ).toBe(false);
     });
   });
 

--- a/booking-app/tests/unit/server-db.unit.test.ts
+++ b/booking-app/tests/unit/server-db.unit.test.ts
@@ -377,6 +377,10 @@ describe("server/db", () => {
         calendarEventId: "cal-1",
         eventType: "cancel",
         email: "user@nyu.edu",
+        // netId must be passed through so the executor's /api/cancel-processing
+        // call uses the authoritative value (not email.split("@")[0], which
+        // would misattribute pre-ban penalties for alias emails).
+        netId: "net123",
       });
 
       // db.ts cancel() no longer fetches cancel-processing directly.


### PR DESCRIPTION
## Summary of Changes

No Show bookings (and other Canceled paths) stopped having their Google Calendar events deleted because commit \`8567a452\` pulled \`handleCancelProcessing\` out of the machine into \`db.ts\` and the noShow caller wasn't updated. Rather than adding yet another manual \`/api/cancel-processing\` fetch to \`db.ts noShow()\` (same anti-pattern that caused the bug), this PR makes the Canceled state entry the trigger so every path reaches the same side effect structurally.

**Approach (memory: \`xstate-phase7-side-effects.md\` Plan B):**
- Both \`mcBookingMachine\` and \`itpBookingMachine\` gain \`pendingSideEffects?: string[]\` in their context and a pure \`queueCancelProcessing\` assign action
- Canceled state entry calls \`queueCancelProcessing\` which appends \`"cancelProcessing"\` to \`context.pendingSideEffects\`
- \`xstateTransitions.ts\` adds an \`executeSideEffect\` helper and a drain loop that runs after \`handleStateTransitions\` and before the Firestore save. The loop fetches \`/api/cancel-processing\` for each queued effect, then clears the queue on the snapshot being persisted so a restore can't re-fire
- \`db.ts cancel()\`, \`/api/bookings/auto-cancel-declined\`, and \`/api/bookings/auto-cancel-unapproved\` drop their own \`/api/cancel-processing\` fetches — the machine covers them now

The machine stays pure: \`queueCancelProcessing\` is just an \`assign\`, so \`useCheckAutoApproval\` (which runs the same machine client-side for auto-approval probing) doesn't misfire any server APIs.

**Paths verified to traverse the Canceled entry and queue cancelProcessing:**
1. user cancel from Requested / Pre-approved / Approved / Services Request
2. noShow → No Show → (always) → Canceled (#1367 fix)
3. decline → Declined → (after 24h cron) → Canceled
4. auto-cancel-unapproved cron → Canceled

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

Screenshots/video N/A: backend-only side-effect plumbing, no UI surface. Manual staging verification path: mark any Approved MC booking as No Show, confirm the Google Calendar event disappears from the room calendar within seconds and the booking tool reports the slot as available.

Full vitest suite: 1410 tests pass. \`tsc --noEmit\` passes.

Tests updated:
- \`server-db.unit.test.ts > cancel\` — asserts \`cancel()\` no longer fetches \`/api/cancel-processing\` directly; close-processing still fires on direct-to-Closed transitions; fallback path still works
- \`itp-booking-machine.xstate.unit.test.ts > Cancellation\` — new cases for \`queueCancelProcessing\` being appended on user cancel AND on noShow → Canceled auto-transition
- \`itp-booking-machine.xstate.unit.test.ts > Entry Actions Verification > Canceled\` — rewritten from sniffing \`sendHTMLEmail/updateCalendarEvent/deleteCalendarEvent\` spies to asserting the queued effect
- \`itp-booking-machine.xstate.unit.test.ts > No Show\` — updated expected updateCalendarEvent count (2: No Show + Closed; Canceled no longer fires its own)

## Screenshots / Video

N/A (backend fix, no UI change).