### PR TITLE
fix: route client-side Firestore reads/writes through API + Admin SDK

### DIFF
--- a/booking-app/app/api/firestore/getDoc/route.ts
+++ b/booking-app/app/api/firestore/getDoc/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import admin from "@/lib/firebase/server/firebaseAdmin";
 import { requireSession } from "@/lib/api/requireSession";
+import { authorizeRead, isAccessDenied } from "@/lib/api/authz";
 import { resolveCollectionName } from "@/lib/api/firestoreServer";
 import type { GetDocRequest } from "@/lib/api/firestoreShared";
 
@@ -19,6 +20,13 @@ export async function POST(req: NextRequest) {
     return NextResponse.json(
       { error: "collection and docId required" },
       { status: 400 },
+    );
+  }
+  const decision = await authorizeRead(session, body.tenant, body.collection);
+  if (isAccessDenied(decision)) {
+    return NextResponse.json(
+      { error: decision.reason },
+      { status: decision.status },
     );
   }
   try {

--- a/booking-app/app/api/firestore/getDoc/route.ts
+++ b/booking-app/app/api/firestore/getDoc/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import admin from "@/lib/firebase/server/firebaseAdmin";
+import { requireSession } from "@/lib/api/requireSession";
+import { resolveCollectionName } from "@/lib/api/firestoreServer";
+import type { GetDocRequest } from "@/lib/api/firestoreShared";
+
+export async function POST(req: NextRequest) {
+  const session = await requireSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  let body: GetDocRequest;
+  try {
+    body = (await req.json()) as GetDocRequest;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  if (!body?.collection || !body?.docId) {
+    return NextResponse.json(
+      { error: "collection and docId required" },
+      { status: 400 },
+    );
+  }
+  try {
+    const collectionName = resolveCollectionName(body.collection, body.tenant);
+    const snap = await admin
+      .firestore()
+      .collection(collectionName)
+      .doc(body.docId)
+      .get();
+    if (!snap.exists) {
+      return NextResponse.json({ doc: null });
+    }
+    return NextResponse.json({ doc: { id: snap.id, ...snap.data() } });
+  } catch (error) {
+    console.error("[/api/firestore/getDoc] error:", error);
+    return NextResponse.json(
+      { error: (error as Error).message ?? "Internal error" },
+      { status: 500 },
+    );
+  }
+}

--- a/booking-app/app/api/firestore/list/route.ts
+++ b/booking-app/app/api/firestore/list/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireSession } from "@/lib/api/requireSession";
+import { authorizeRead, isAccessDenied } from "@/lib/api/authz";
 import { listDocs } from "@/lib/api/firestoreServer";
 import type { ListRequest } from "@/lib/api/firestoreShared";
 
@@ -18,6 +19,13 @@ export async function POST(req: NextRequest) {
     return NextResponse.json(
       { error: "collection required" },
       { status: 400 },
+    );
+  }
+  const decision = await authorizeRead(session, body.tenant, body.collection);
+  if (isAccessDenied(decision)) {
+    return NextResponse.json(
+      { error: decision.reason },
+      { status: decision.status },
     );
   }
   try {

--- a/booking-app/app/api/firestore/list/route.ts
+++ b/booking-app/app/api/firestore/list/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireSession } from "@/lib/api/requireSession";
+import { listDocs } from "@/lib/api/firestoreServer";
+import type { ListRequest } from "@/lib/api/firestoreShared";
+
+export async function POST(req: NextRequest) {
+  const session = await requireSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  let body: ListRequest;
+  try {
+    body = (await req.json()) as ListRequest;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  if (!body?.collection) {
+    return NextResponse.json(
+      { error: "collection required" },
+      { status: 400 },
+    );
+  }
+  try {
+    const docs = await listDocs(body.collection, body.tenant, {
+      where: body.where,
+      orderBy: body.orderBy,
+      limit: body.limit,
+    });
+    return NextResponse.json({ docs });
+  } catch (error) {
+    console.error("[/api/firestore/list] error:", error);
+    return NextResponse.json(
+      { error: (error as Error).message ?? "Internal error" },
+      { status: 500 },
+    );
+  }
+}

--- a/booking-app/app/api/firestore/mutate/route.ts
+++ b/booking-app/app/api/firestore/mutate/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import admin from "@/lib/firebase/server/firebaseAdmin";
 import { requireSession } from "@/lib/api/requireSession";
+import { authorizeWrite, isAccessDenied } from "@/lib/api/authz";
 import { resolveCollectionName, reviveValue } from "@/lib/api/firestoreServer";
 import type { MutateRequest } from "@/lib/api/firestoreShared";
 
@@ -19,6 +20,13 @@ export async function POST(req: NextRequest) {
     return NextResponse.json(
       { error: "op and collection required" },
       { status: 400 },
+    );
+  }
+  const decision = await authorizeWrite(session, body.tenant, body.collection);
+  if (isAccessDenied(decision)) {
+    return NextResponse.json(
+      { error: decision.reason },
+      { status: decision.status },
     );
   }
   const collectionName = resolveCollectionName(body.collection, body.tenant);

--- a/booking-app/app/api/firestore/mutate/route.ts
+++ b/booking-app/app/api/firestore/mutate/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import admin from "@/lib/firebase/server/firebaseAdmin";
+import { requireSession } from "@/lib/api/requireSession";
+import { resolveCollectionName, reviveValue } from "@/lib/api/firestoreServer";
+import type { MutateRequest } from "@/lib/api/firestoreShared";
+
+export async function POST(req: NextRequest) {
+  const session = await requireSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  let body: MutateRequest;
+  try {
+    body = (await req.json()) as MutateRequest;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  if (!body?.op || !body?.collection) {
+    return NextResponse.json(
+      { error: "op and collection required" },
+      { status: 400 },
+    );
+  }
+  const collectionName = resolveCollectionName(body.collection, body.tenant);
+  const colRef = admin.firestore().collection(collectionName);
+  try {
+    if (body.op === "create") {
+      const data = reviveValue(body.data) as FirebaseFirestore.DocumentData;
+      const docRef = await colRef.add(data);
+      return NextResponse.json({ id: docRef.id });
+    }
+    if (body.op === "update") {
+      if (!body.docId) {
+        return NextResponse.json(
+          { error: "docId required" },
+          { status: 400 },
+        );
+      }
+      const data = reviveValue(body.data) as FirebaseFirestore.DocumentData;
+      await colRef.doc(body.docId).update(data);
+      return NextResponse.json({ ok: true });
+    }
+    if (body.op === "delete") {
+      if (!body.docId) {
+        return NextResponse.json(
+          { error: "docId required" },
+          { status: 400 },
+        );
+      }
+      await colRef.doc(body.docId).delete();
+      return NextResponse.json({ ok: true });
+    }
+    return NextResponse.json({ error: "unknown op" }, { status: 400 });
+  } catch (error) {
+    console.error("[/api/firestore/mutate] error:", error);
+    return NextResponse.json(
+      { error: (error as Error).message ?? "Internal error" },
+      { status: 500 },
+    );
+  }
+}

--- a/booking-app/app/api/firestore/paginated/route.ts
+++ b/booking-app/app/api/firestore/paginated/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import admin from "@/lib/firebase/server/firebaseAdmin";
 import { requireSession } from "@/lib/api/requireSession";
+import { authorizeRead, isAccessDenied } from "@/lib/api/authz";
 import { resolveCollectionName } from "@/lib/api/firestoreServer";
 import type { PaginatedRequest } from "@/lib/api/firestoreShared";
 
@@ -42,6 +43,13 @@ export async function POST(req: NextRequest) {
     return NextResponse.json(
       { error: "collection and filters.sortField required" },
       { status: 400 },
+    );
+  }
+  const decision = await authorizeRead(session, body.tenant, body.collection);
+  if (isAccessDenied(decision)) {
+    return NextResponse.json(
+      { error: decision.reason },
+      { status: decision.status },
     );
   }
   try {

--- a/booking-app/app/api/firestore/paginated/route.ts
+++ b/booking-app/app/api/firestore/paginated/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from "next/server";
+import admin from "@/lib/firebase/server/firebaseAdmin";
+import { requireSession } from "@/lib/api/requireSession";
+import { resolveCollectionName } from "@/lib/api/firestoreServer";
+import type { PaginatedRequest } from "@/lib/api/firestoreShared";
+
+const SEARCHABLE_FIELDS = [
+  "requestNumber",
+  "department",
+  "netId",
+  "email",
+  "title",
+  "description",
+  "firstName",
+  "lastName",
+  "roomId",
+];
+
+function parseDate(value: unknown): Date | null {
+  if (!value) return null;
+  if (typeof value === "string") {
+    const d = new Date(value);
+    return isNaN(d.getTime()) ? null : d;
+  }
+  if (typeof value === "number") return new Date(value);
+  if (value instanceof Date) return value;
+  return null;
+}
+
+export async function POST(req: NextRequest) {
+  const session = await requireSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  let body: PaginatedRequest;
+  try {
+    body = (await req.json()) as PaginatedRequest;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  if (!body?.collection || !body?.filters?.sortField) {
+    return NextResponse.json(
+      { error: "collection and filters.sortField required" },
+      { status: 400 },
+    );
+  }
+  try {
+    const collectionName = resolveCollectionName(body.collection, body.tenant);
+    const colRef = admin.firestore().collection(collectionName);
+    let q: FirebaseFirestore.Query = colRef;
+
+    // Date range filters
+    const range = Array.isArray(body.filters.dateRange)
+      ? body.filters.dateRange
+      : null;
+    if (range && range.length === 2) {
+      const start = parseDate(range[0]);
+      const end = parseDate(range[1]);
+      if (start)
+        q = q.where("startDate", ">=", admin.firestore.Timestamp.fromDate(start));
+      if (end)
+        q = q.where("startDate", "<=", admin.firestore.Timestamp.fromDate(end));
+    }
+
+    const searchQuery = body.filters.searchQuery?.trim();
+    if (searchQuery) {
+      // Search path: fetch with date filter only, then filter in-process.
+      const searchTerm = searchQuery.toLowerCase();
+      const orderedQuery = q.orderBy(body.filters.sortField, "desc");
+      const snapshot = await orderedQuery.get();
+      const matchingDocs = snapshot.docs.filter((doc) => {
+        const data = doc.data();
+        if (data.firstName && data.lastName) {
+          const fullName = `${data.firstName} ${data.lastName}`.toLowerCase();
+          if (fullName.includes(searchTerm)) return true;
+        }
+        return SEARCHABLE_FIELDS.some((field) => {
+          const value = data[field];
+          if (value === null || value === undefined) return false;
+          return String(value).toLowerCase().includes(searchTerm);
+        });
+      });
+      return NextResponse.json({
+        docs: matchingDocs.map((doc) => ({ id: doc.id, ...doc.data() })),
+      });
+    }
+
+    // Standard paginated path
+    let orderedQuery: FirebaseFirestore.Query = q.orderBy(
+      body.filters.sortField,
+      "desc",
+    );
+    if (body.lastVisible) {
+      const cursor = (body.lastVisible as Record<string, unknown>)[
+        body.filters.sortField
+      ];
+      const reviveCursor =
+        cursor &&
+        typeof cursor === "object" &&
+        cursor !== null &&
+        "__ts" in (cursor as Record<string, unknown>)
+          ? admin.firestore.Timestamp.fromMillis(
+              (cursor as { __ts: number }).__ts,
+            )
+          : cursor;
+      if (reviveCursor !== undefined && reviveCursor !== null) {
+        orderedQuery = orderedQuery.startAfter(reviveCursor);
+      }
+    }
+    if (typeof body.limit === "number") {
+      orderedQuery = orderedQuery.limit(body.limit);
+    }
+    const snapshot = await orderedQuery.get();
+    return NextResponse.json({
+      docs: snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })),
+    });
+  } catch (error) {
+    console.error("[/api/firestore/paginated] error:", error);
+    return NextResponse.json(
+      { error: (error as Error).message ?? "Internal error" },
+      { status: 500 },
+    );
+  }
+}

--- a/booking-app/app/api/firestore/userRights/route.ts
+++ b/booking-app/app/api/firestore/userRights/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import admin from "@/lib/firebase/server/firebaseAdmin";
 import { requireSession } from "@/lib/api/requireSession";
+import { authorizeWrite, isAccessDenied } from "@/lib/api/authz";
 import { resolveCollectionName, reviveValue } from "@/lib/api/firestoreServer";
 import { TableNames } from "@/components/src/policy";
 import {
@@ -41,6 +42,21 @@ export async function POST(req: NextRequest) {
     body = (await req.json()) as UserRightsRequest;
   } catch {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  // All actions on this route ultimately mutate the usersRights collection
+  // (or its legacy aliases ADMINS / PAS, which carry the same access level).
+  // Gate against USERS_RIGHTS once.
+  const decision = await authorizeWrite(
+    session,
+    body.tenant,
+    TableNames.USERS_RIGHTS,
+  );
+  if (isAccessDenied(decision)) {
+    return NextResponse.json(
+      { error: decision.reason },
+      { status: decision.status },
+    );
   }
 
   try {

--- a/booking-app/app/api/firestore/userRights/route.ts
+++ b/booking-app/app/api/firestore/userRights/route.ts
@@ -1,0 +1,201 @@
+import { NextRequest, NextResponse } from "next/server";
+import admin from "@/lib/firebase/server/firebaseAdmin";
+import { requireSession } from "@/lib/api/requireSession";
+import { resolveCollectionName, reviveValue } from "@/lib/api/firestoreServer";
+import { TableNames } from "@/components/src/policy";
+import {
+  USER_RIGHT_FLAG_FIELDS,
+  type UserRightFlagField,
+} from "@/lib/firebase/userRightsConstants";
+import type { UserRightsRequest } from "@/lib/api/firestoreShared";
+
+const USER_COLLECTIONS: TableNames[] = [TableNames.ADMINS, TableNames.PAS];
+
+function buildDefaultUserRightFlags(
+  overrides: Partial<Record<UserRightFlagField, boolean>> = {},
+): Record<UserRightFlagField, boolean> {
+  return USER_RIGHT_FLAG_FIELDS.reduce(
+    (acc, currentFlag) => {
+      acc[currentFlag] = overrides[currentFlag] ?? false;
+      return acc;
+    },
+    {} as Record<UserRightFlagField, boolean>,
+  );
+}
+
+function flagForLegacyCollection(
+  collection: string,
+): UserRightFlagField | null {
+  if (collection === TableNames.ADMINS) return "isAdmin";
+  if (collection === TableNames.PAS) return "isWorker";
+  return null;
+}
+
+export async function POST(req: NextRequest) {
+  const session = await requireSession();
+  if (!session) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  let body: UserRightsRequest;
+  try {
+    body = (await req.json()) as UserRightsRequest;
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  try {
+    const usersRightsCollection = resolveCollectionName(
+      TableNames.USERS_RIGHTS,
+      body.tenant,
+    );
+    const usersRightsRef = admin
+      .firestore()
+      .collection(usersRightsCollection);
+
+    if (body.action === "save") {
+      const isLegacy = USER_COLLECTIONS.includes(body.collection as TableNames);
+      if (isLegacy) {
+        const email = (body.data as Record<string, unknown>).email as
+          | string
+          | undefined;
+        if (!email) {
+          return NextResponse.json(
+            { error: "email required" },
+            { status: 400 },
+          );
+        }
+        const flag = flagForLegacyCollection(body.collection);
+        if (!flag) {
+          return NextResponse.json(
+            { error: "unsupported user collection" },
+            { status: 400 },
+          );
+        }
+        const existing = await usersRightsRef
+          .where("email", "==", email)
+          .get();
+        if (!existing.empty) {
+          await usersRightsRef
+            .doc(existing.docs[0].id)
+            .update({ [flag]: true });
+          return NextResponse.json({ id: existing.docs[0].id, updated: true });
+        }
+        const data = reviveValue(body.data) as Record<string, unknown>;
+        const docRef = await usersRightsRef.add({
+          email,
+          createdAt: data.createdAt ?? admin.firestore.Timestamp.now(),
+          ...buildDefaultUserRightFlags({ [flag]: true }),
+          ...data,
+        });
+        return NextResponse.json({ id: docRef.id, created: true });
+      }
+      const colRef = admin
+        .firestore()
+        .collection(resolveCollectionName(body.collection, body.tenant));
+      const data = reviveValue(body.data) as FirebaseFirestore.DocumentData;
+      const docRef = await colRef.add(data);
+      return NextResponse.json({ id: docRef.id, created: true });
+    }
+
+    if (body.action === "delete") {
+      const isLegacy = USER_COLLECTIONS.includes(body.collection as TableNames);
+      if (isLegacy) {
+        const userDoc = await usersRightsRef.doc(body.docId).get();
+        if (!userDoc.exists) {
+          return NextResponse.json(
+            { error: "user not found" },
+            { status: 404 },
+          );
+        }
+        const userData = userDoc.data() as Record<string, unknown>;
+        const flag = flagForLegacyCollection(body.collection);
+        const updatedFlags = {
+          isAdmin:
+            body.collection === TableNames.ADMINS ? false : userData.isAdmin,
+          isWorker:
+            body.collection === TableNames.PAS ? false : userData.isWorker,
+        };
+        if (!updatedFlags.isAdmin && !updatedFlags.isWorker) {
+          await usersRightsRef.doc(body.docId).delete();
+          return NextResponse.json({ deleted: true });
+        }
+        if (flag) {
+          await usersRightsRef.doc(body.docId).update({ [flag]: false });
+        }
+        return NextResponse.json({ updated: true });
+      }
+      const colRef = admin
+        .firestore()
+        .collection(resolveCollectionName(body.collection, body.tenant));
+      await colRef.doc(body.docId).delete();
+      return NextResponse.json({ deleted: true });
+    }
+
+    if (body.action === "upsertFlag") {
+      const trimmedEmail = body.email.trim();
+      if (!trimmedEmail) {
+        return NextResponse.json(
+          { error: "email required" },
+          { status: 400 },
+        );
+      }
+      const flag = body.flag as UserRightFlagField;
+      const existing = await usersRightsRef
+        .where("email", "==", trimmedEmail)
+        .get();
+      if (!existing.empty) {
+        await usersRightsRef
+          .doc(existing.docs[0].id)
+          .update({ [flag]: true });
+        return NextResponse.json({ id: existing.docs[0].id, updated: true });
+      }
+      const docRef = await usersRightsRef.add({
+        email: trimmedEmail,
+        createdAt: admin.firestore.Timestamp.now(),
+        ...buildDefaultUserRightFlags(),
+        [flag]: true,
+      });
+      return NextResponse.json({ id: docRef.id, created: true });
+    }
+
+    if (body.action === "clearFlag") {
+      const targetRef = usersRightsRef.doc(body.docId);
+      const userDoc = await targetRef.get();
+      if (!userDoc.exists) {
+        return NextResponse.json({ error: "user not found" }, { status: 404 });
+      }
+      const userData = userDoc.data() as Partial<
+        Record<UserRightFlagField, boolean>
+      >;
+      const flag = body.flag as UserRightFlagField;
+      const updatedFlags = USER_RIGHT_FLAG_FIELDS.reduce(
+        (acc, currentFlag) => {
+          if (currentFlag === flag) {
+            acc[currentFlag] = false;
+          } else {
+            acc[currentFlag] = userData[currentFlag] === true;
+          }
+          return acc;
+        },
+        {} as Record<UserRightFlagField, boolean>,
+      );
+      const shouldDelete = USER_RIGHT_FLAG_FIELDS.every(
+        (f) => !updatedFlags[f],
+      );
+      if (shouldDelete) {
+        await targetRef.delete();
+        return NextResponse.json({ deleted: true });
+      }
+      await targetRef.update({ [flag]: false });
+      return NextResponse.json({ updated: true });
+    }
+
+    return NextResponse.json({ error: "unknown action" }, { status: 400 });
+  } catch (error) {
+    console.error("[/api/firestore/userRights] error:", error);
+    return NextResponse.json(
+      { error: (error as Error).message ?? "Internal error" },
+      { status: 500 },
+    );
+  }
+}

--- a/booking-app/components/src/client/routes/admin/components/ServiceApproverUsers.tsx
+++ b/booking-app/components/src/client/routes/admin/components/ServiceApproverUsers.tsx
@@ -1,7 +1,7 @@
 import { AddCircleOutline } from "@mui/icons-material";
 import { IconButton, TextField } from "@mui/material";
 import Grid from "@mui/material/Unstable_Grid2/Grid2";
-import { Timestamp, where } from "firebase/firestore";
+import { Timestamp } from "firebase/firestore";
 import { useCallback, useContext, useEffect, useState } from "react";
 
 import ListTable from "../../components/ListTable";
@@ -40,7 +40,7 @@ export const ServiceApproverUsers = ({
   const loadServiceApprovers = useCallback(async () => {
     const fetchedData = await clientFetchAllDataFromCollection<any>(
       TableNames.USERS_RIGHTS,
-      [where(flagField, "==", true)],
+      [{ field: flagField, op: "==", value: true }],
       tenant,
     );
 

--- a/booking-app/components/src/client/routes/hooks/useSortBookingHistory.tsx
+++ b/booking-app/components/src/client/routes/hooks/useSortBookingHistory.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/components/src/types";
 import { clientFetchAllDataFromCollection } from "@/lib/firebase/firebase";
 import { TableCell, TableRow } from "@mui/material";
-import { Timestamp, where } from "firebase/firestore";
+import { Timestamp } from "firebase/firestore";
 import { useEffect, useState } from "react";
 import { formatDateTable, formatTimeAmPm } from "../../utils/date";
 import StatusChip from "../components/bookingTable/StatusChip";
@@ -25,7 +25,7 @@ export default function useSortBookingHistory(booking: BookingRow) {
     const fetchLogs = async () => {
       const logs = await clientFetchAllDataFromCollection<BookingLog>(
         TableNames.BOOKING_LOGS,
-        [where("requestNumber", "==", booking.requestNumber)],
+        [{ field: "requestNumber", op: "==", value: booking.requestNumber }],
       );
 
       if (logs.length > 0) {

--- a/booking-app/components/src/server/db.ts
+++ b/booking-app/components/src/server/db.ts
@@ -82,11 +82,10 @@ export async function callXStateTransitionAPI(
 export const fetchAllFutureBooking = async <Booking>(
   tenant?: string,
 ): Promise<Booking[]> => {
-  const now = Timestamp.now();
-  const futureQueryConstraints = [where("endDate", ">", now)];
+  const nowMs = Date.now();
   return clientFetchAllDataFromCollection<Booking>(
     TableNames.BOOKING,
-    futureQueryConstraints,
+    [{ field: "endDate", op: ">", value: { __ts: nowMs } }],
     tenant,
   );
 };

--- a/booking-app/lib/api/authz.ts
+++ b/booking-app/lib/api/authz.ts
@@ -1,0 +1,220 @@
+import admin from "@/lib/firebase/server/firebaseAdmin";
+import {
+  ApproverLevel,
+  TableNames,
+  getTenantCollectionName,
+} from "@/components/src/policy";
+import { PagePermission } from "@/components/src/types";
+import type { SessionContext } from "@/lib/api/requireSession";
+
+/**
+ * Resolve the caller's role for a given tenant by reading the same
+ * permission-source collections that `Provider.tsx` consults client-side.
+ * Performed via firebase-admin so it bypasses Firestore rules — these reads
+ * are the trusted server-side equivalent of the security model that NYU SSO
+ * removed when Firebase Auth went away.
+ */
+export async function resolveCallerRole(
+  session: SessionContext,
+  tenant: string | undefined,
+): Promise<PagePermission> {
+  const email = session.email;
+  const db = admin.firestore();
+
+  // SUPER_ADMIN is global (not tenant-scoped).
+  const superSnap = await db
+    .collection(TableNames.SUPER_ADMINS)
+    .where("email", "==", email)
+    .limit(1)
+    .get();
+  if (!superSnap.empty) return PagePermission.SUPER_ADMIN;
+
+  if (!tenant) return PagePermission.BOOKING;
+
+  const usersRightsCollection = getTenantCollectionName(
+    TableNames.USERS_RIGHTS,
+    tenant,
+  );
+  const usersRightsSnap = await db
+    .collection(usersRightsCollection)
+    .where("email", "==", email)
+    .limit(1)
+    .get();
+  const userRights = usersRightsSnap.empty
+    ? null
+    : (usersRightsSnap.docs[0].data() as Record<string, unknown>);
+  if (userRights?.isAdmin === true) return PagePermission.ADMIN;
+
+  const approversCollection = getTenantCollectionName(
+    TableNames.APPROVERS,
+    tenant,
+  );
+  const approverSnap = await db
+    .collection(approversCollection)
+    .where("email", "==", email)
+    .limit(1)
+    .get();
+  if (!approverSnap.empty) {
+    const data = approverSnap.docs[0].data() as Record<string, unknown>;
+    const level = Number(data.level);
+    if (level === ApproverLevel.EQUIPMENT) return PagePermission.SERVICES;
+    return PagePermission.LIAISON;
+  }
+
+  if (userRights?.isWorker === true) return PagePermission.PA;
+
+  return PagePermission.BOOKING;
+}
+
+/**
+ * Per-collection access policy enforced by `/api/firestore/*`.
+ *
+ * `read`/`write` describe the minimum role required. The previous
+ * Firestore security rules were the trust boundary; once the admin SDK
+ * bypasses them, this table is the boundary.
+ */
+type Role =
+  | "anyNYU"
+  | "paOrAbove"
+  | "adminOrSuper"
+  | "superOnly"
+  | "deny";
+
+type Policy = { read: Role; write: Role };
+
+// Collection name (without tenant prefix) → policy.
+// Unknown collections fall through to `DEFAULT_POLICY` (deny).
+const POLICY: Record<string, Policy> = {
+  // Permission-source collections — readable by any NYU user because the
+  // browser needs them to compute its own role; writable by admins.
+  [TableNames.SUPER_ADMINS]: { read: "anyNYU", write: "superOnly" },
+  [TableNames.USERS_RIGHTS]: { read: "anyNYU", write: "adminOrSuper" },
+  [TableNames.APPROVERS]: { read: "anyNYU", write: "adminOrSuper" },
+  [TableNames.ADMINS]: { read: "anyNYU", write: "adminOrSuper" },
+  [TableNames.PAS]: { read: "anyNYU", write: "adminOrSuper" },
+
+  // Tenant config — readable by all, writes go through dedicated routes.
+  [TableNames.TENANT_SCHEMA]: { read: "anyNYU", write: "deny" },
+
+  // Public-ish reference data — anyone signed in can read; admins curate.
+  [TableNames.BOOKING_TYPES]: { read: "anyNYU", write: "adminOrSuper" },
+  [TableNames.DEPARTMENTS]: { read: "anyNYU", write: "adminOrSuper" },
+  [TableNames.OPERATION_HOURS]: { read: "anyNYU", write: "adminOrSuper" },
+  [TableNames.BLACKOUT_PERIODS]: { read: "anyNYU", write: "adminOrSuper" },
+  [TableNames.SAFETY_TRAINING]: { read: "anyNYU", write: "adminOrSuper" },
+  [TableNames.RESOURCES]: { read: "anyNYU", write: "adminOrSuper" },
+  [TableNames.SETTINGS]: { read: "anyNYU", write: "adminOrSuper" },
+  [TableNames.POLICY_SETTINGS]: { read: "anyNYU", write: "adminOrSuper" },
+
+  // Pre-ban audit log — only the admin "PreBan" page reads it.
+  [TableNames.PRE_BAN_LOGS]: { read: "adminOrSuper", write: "adminOrSuper" },
+
+  // Banned-users list is consulted in the regular booking flow
+  // (`bookingProvider.tsx` blocks banned users from booking), so any
+  // authenticated NYU user needs read access. Writes stay admin-only.
+  // Server-side "am I banned?" filtering is a defense-in-depth followup.
+  [TableNames.BANNED]: { read: "anyNYU", write: "adminOrSuper" },
+
+  // Bookings / logs — any authenticated NYU user can read because regular
+  // users see their own bookings on `/[tenant]/my-bookings` and the
+  // current implementation filters client-side (`filterPageContext` in
+  // `useBookingFilters.ts`). Tightening this to server-side filtering is
+  // the right next step but out of scope for the SSO regression fix.
+  // Writes go through dedicated `/api/bookings/*` routes that handle the
+  // XState lifecycle and per-user authorization in their own logic.
+  [TableNames.BOOKING]: { read: "anyNYU", write: "deny" },
+  [TableNames.BOOKING_LOGS]: { read: "anyNYU", write: "deny" },
+};
+
+const DEFAULT_POLICY: Policy = { read: "deny", write: "deny" };
+
+function getPolicy(collection: string): Policy {
+  return POLICY[collection] ?? DEFAULT_POLICY;
+}
+
+function roleSatisfies(actual: PagePermission, required: Role): boolean {
+  switch (required) {
+    case "deny":
+      return false;
+    case "anyNYU":
+      return true;
+    case "paOrAbove":
+      return (
+        actual === PagePermission.PA ||
+        actual === PagePermission.LIAISON ||
+        actual === PagePermission.SERVICES ||
+        actual === PagePermission.ADMIN ||
+        actual === PagePermission.SUPER_ADMIN
+      );
+    case "adminOrSuper":
+      return (
+        actual === PagePermission.ADMIN ||
+        actual === PagePermission.SUPER_ADMIN
+      );
+    case "superOnly":
+      return actual === PagePermission.SUPER_ADMIN;
+  }
+}
+
+export type AccessGranted = { ok: true; role: PagePermission };
+export type AccessDenied = {
+  ok: false;
+  status: 401 | 403;
+  reason: string;
+};
+export type AccessDecision = AccessGranted | AccessDenied;
+
+export function isAccessDenied(d: AccessDecision): d is AccessDenied {
+  return d.ok === false;
+}
+
+/**
+ * Authorize a read against the policy table for the given collection.
+ * Caller is responsible for ensuring `session` is non-null beforehand.
+ */
+export async function authorizeRead(
+  session: SessionContext,
+  tenant: string | undefined,
+  collection: string,
+): Promise<AccessDecision> {
+  const policy = getPolicy(collection);
+  if (policy.read === "deny") {
+    return { ok: false, status: 403, reason: `read denied for ${collection}` };
+  }
+  if (policy.read === "anyNYU") {
+    // No role lookup needed — saves a Firestore round-trip on the hot path.
+    return { ok: true, role: PagePermission.BOOKING };
+  }
+  const role = await resolveCallerRole(session, tenant);
+  if (!roleSatisfies(role, policy.read)) {
+    return {
+      ok: false,
+      status: 403,
+      reason: `read denied for ${collection} (role=${role}, requires=${policy.read})`,
+    };
+  }
+  return { ok: true, role };
+}
+
+export async function authorizeWrite(
+  session: SessionContext,
+  tenant: string | undefined,
+  collection: string,
+): Promise<AccessDecision> {
+  const policy = getPolicy(collection);
+  if (policy.write === "deny") {
+    return { ok: false, status: 403, reason: `write denied for ${collection}` };
+  }
+  if (policy.write === "anyNYU") {
+    return { ok: true, role: PagePermission.BOOKING };
+  }
+  const role = await resolveCallerRole(session, tenant);
+  if (!roleSatisfies(role, policy.write)) {
+    return {
+      ok: false,
+      status: 403,
+      reason: `write denied for ${collection} (role=${role}, requires=${policy.write})`,
+    };
+  }
+  return { ok: true, role };
+}

--- a/booking-app/lib/api/authz.ts
+++ b/booking-app/lib/api/authz.ts
@@ -120,10 +120,15 @@ const POLICY: Record<string, Policy> = {
   // current implementation filters client-side (`filterPageContext` in
   // `useBookingFilters.ts`). Tightening this to server-side filtering is
   // the right next step but out of scope for the SSO regression fix.
-  // Writes go through dedicated `/api/bookings/*` routes that handle the
-  // XState lifecycle and per-user authorization in their own logic.
-  [TableNames.BOOKING]: { read: "anyNYU", write: "deny" },
-  [TableNames.BOOKING_LOGS]: { read: "anyNYU", write: "deny" },
+  //
+  // Writes go through dedicated `/api/bookings/*` routes for the XState
+  // lifecycle, but a few staff UI controls (e.g. `EquipmentCheckoutToggle`
+  // calling `clientUpdateDataByCalendarEventId`) still flip booking fields
+  // directly. Allow PA and above so those controls keep working; further
+  // tightening belongs in a followup that routes those mutations through
+  // dedicated endpoints.
+  [TableNames.BOOKING]: { read: "anyNYU", write: "paOrAbove" },
+  [TableNames.BOOKING_LOGS]: { read: "anyNYU", write: "paOrAbove" },
 };
 
 const DEFAULT_POLICY: Policy = { read: "deny", write: "deny" };

--- a/booking-app/lib/api/firestoreServer.ts
+++ b/booking-app/lib/api/firestoreServer.ts
@@ -1,0 +1,92 @@
+import admin from "@/lib/firebase/server/firebaseAdmin";
+import { getTenantCollectionName } from "@/components/src/policy";
+import type { OrderBySpec, WhereSpec } from "@/lib/api/firestoreShared";
+
+/** Resolve the tenant-prefixed collection name (mirrors getTenantCollectionName). */
+export function resolveCollectionName(
+  baseCollection: string,
+  tenant?: string,
+): string {
+  return getTenantCollectionName(baseCollection, tenant);
+}
+
+/**
+ * Convert a wire-format value back into the Firestore-native form.
+ *
+ * Recognises three serialized Timestamp shapes:
+ *  - `{ __ts: <epochMs> }` — the explicit wrapper produced by `wrapTimestamp`
+ *  - `{ seconds, nanoseconds }` — what the client SDK's Timestamp.toJSON() emits
+ *  - `{ _seconds, _nanoseconds }` — what admin SDK's Timestamp serializes as
+ *
+ * Also recurses into objects/arrays so nested fields in write payloads are
+ * normalised.
+ */
+export function reviveValue(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) return value.map(reviveValue);
+  if (typeof value !== "object") return value;
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj);
+
+  if (keys.length === 1 && "__ts" in obj) {
+    return admin.firestore.Timestamp.fromMillis(obj.__ts as number);
+  }
+  if (
+    keys.length === 2 &&
+    typeof obj.seconds === "number" &&
+    typeof obj.nanoseconds === "number"
+  ) {
+    return new admin.firestore.Timestamp(
+      obj.seconds as number,
+      obj.nanoseconds as number,
+    );
+  }
+  if (
+    keys.length === 2 &&
+    typeof obj._seconds === "number" &&
+    typeof obj._nanoseconds === "number"
+  ) {
+    return new admin.firestore.Timestamp(
+      obj._seconds as number,
+      obj._nanoseconds as number,
+    );
+  }
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    out[k] = reviveValue(v);
+  }
+  return out;
+}
+
+/** Apply the where/orderBy/limit clauses described by the wire request. */
+export function applyQuery(
+  base: FirebaseFirestore.Query,
+  spec: { where?: WhereSpec[]; orderBy?: OrderBySpec; limit?: number },
+): FirebaseFirestore.Query {
+  let q = base;
+  if (spec.where) {
+    for (const clause of spec.where) {
+      q = q.where(clause.field, clause.op, reviveValue(clause.value));
+    }
+  }
+  if (spec.orderBy) {
+    q = q.orderBy(spec.orderBy.field, spec.orderBy.direction ?? "asc");
+  }
+  if (typeof spec.limit === "number") {
+    q = q.limit(spec.limit);
+  }
+  return q;
+}
+
+/** Fetch all documents matching a query, returning `{id, ...data}` shape. */
+export async function listDocs(
+  baseCollection: string,
+  tenant: string | undefined,
+  spec: { where?: WhereSpec[]; orderBy?: OrderBySpec; limit?: number },
+): Promise<Array<Record<string, unknown> & { id: string }>> {
+  const collectionName = resolveCollectionName(baseCollection, tenant);
+  const colRef = admin.firestore().collection(collectionName);
+  const q = applyQuery(colRef, spec);
+  const snapshot = await q.get();
+  return snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+}

--- a/booking-app/lib/api/firestoreShared.ts
+++ b/booking-app/lib/api/firestoreShared.ts
@@ -1,0 +1,119 @@
+/**
+ * Wire format shared between the browser-side `lib/firebase/firebase.ts`
+ * helpers and the `/api/firestore/*` routes that proxy them through the
+ * Firebase Admin SDK.
+ */
+
+export type WhereOp =
+  | "=="
+  | "!="
+  | "<"
+  | "<="
+  | ">"
+  | ">="
+  | "in"
+  | "not-in"
+  | "array-contains"
+  | "array-contains-any";
+
+export type WhereSpec = {
+  field: string;
+  op: WhereOp;
+  /**
+   * Plain JSON value, or `{ __ts: <epochMs> }` for Firestore Timestamp values.
+   * Server reconstructs Timestamps via `admin.firestore.Timestamp.fromMillis`.
+   */
+  value: unknown;
+};
+
+export type OrderBySpec = {
+  field: string;
+  direction?: "asc" | "desc";
+};
+
+export type ListRequest = {
+  collection: string;
+  tenant?: string;
+  where?: WhereSpec[];
+  orderBy?: OrderBySpec;
+  limit?: number;
+};
+
+export type GetDocRequest = {
+  collection: string;
+  tenant?: string;
+  docId: string;
+};
+
+export type PaginatedRequest = {
+  collection: string;
+  tenant?: string;
+  /**
+   * Filters as defined in `components/src/types.ts`.
+   * `dateRange` Date values come through as ISO strings via JSON.stringify.
+   */
+  filters: {
+    dateRange?: Array<string | null> | string;
+    sortField: string;
+    searchQuery?: string;
+  };
+  limit?: number;
+  /** lastVisible[sortField] value used for startAfter cursor. */
+  lastVisible?: Record<string, unknown> | null;
+};
+
+export type MutateRequest =
+  | {
+      op: "create";
+      collection: string;
+      tenant?: string;
+      data: Record<string, unknown>;
+    }
+  | {
+      op: "update";
+      collection: string;
+      tenant?: string;
+      docId: string;
+      data: Record<string, unknown>;
+    }
+  | {
+      op: "delete";
+      collection: string;
+      tenant?: string;
+      docId: string;
+    };
+
+export type UserRightsRequest =
+  | {
+      action: "save";
+      collection: string;
+      tenant?: string;
+      data: Record<string, unknown>;
+    }
+  | {
+      action: "delete";
+      collection: string;
+      tenant?: string;
+      docId: string;
+    }
+  | {
+      action: "upsertFlag";
+      email: string;
+      flag: string;
+      tenant?: string;
+    }
+  | {
+      action: "clearFlag";
+      docId: string;
+      flag: string;
+      tenant?: string;
+    };
+
+/** Wrap a Firestore Timestamp / Date / epoch ms for the wire. */
+export function wrapTimestamp(value: Date | number | { toMillis(): number }): {
+  __ts: number;
+} {
+  if (typeof value === "number") return { __ts: value };
+  if (value instanceof Date) return { __ts: value.getTime() };
+  return { __ts: value.toMillis() };
+}

--- a/booking-app/lib/api/requireSession.ts
+++ b/booking-app/lib/api/requireSession.ts
@@ -1,0 +1,24 @@
+import { auth } from "@/lib/auth";
+import { shouldBypassAuth } from "@/lib/utils/testEnvironment";
+
+export type SessionContext = {
+  email: string;
+  netId: string;
+};
+
+/**
+ * Resolve the NextAuth session for an API route.
+ * Returns null if unauthenticated or non-NYU email.
+ * Returns a synthetic context in test environments.
+ */
+export async function requireSession(): Promise<SessionContext | null> {
+  if (shouldBypassAuth()) {
+    return { email: "test@nyu.edu", netId: "test" };
+  }
+  const session = await auth();
+  const email = session?.user?.email?.trim().toLowerCase();
+  if (!email || !email.endsWith("@nyu.edu")) {
+    return null;
+  }
+  return { email, netId: email.split("@")[0] };
+}

--- a/booking-app/lib/firebase/firebase.ts
+++ b/booking-app/lib/firebase/firebase.ts
@@ -3,28 +3,25 @@ import {
   TableNames,
   getTenantCollectionName,
 } from "@/components/src/policy";
-// saveData.ts
-import {
-  QueryConstraint,
-  Timestamp,
-  addDoc,
-  collection,
-  deleteDoc,
-  doc,
-  getDoc,
-  getDocs,
-  limit,
-  orderBy,
-  query,
-  setDoc,
-  startAfter,
-  updateDoc,
-  where,
-} from "firebase/firestore";
+import { Timestamp } from "firebase/firestore";
 
 import { Filters } from "@/components/src/types";
 import { SchemaContextType } from "@/components/src/client/routes/components/SchemaProvider";
-import { getDb } from "./firebaseClient";
+import {
+  USER_RIGHT_FLAG_FIELDS,
+  type UserRightFlagField,
+} from "@/lib/firebase/userRightsConstants";
+import type {
+  GetDocRequest,
+  ListRequest,
+  MutateRequest,
+  PaginatedRequest,
+  UserRightsRequest,
+  WhereSpec,
+} from "@/lib/api/firestoreShared";
+
+export { USER_RIGHT_FLAG_FIELDS };
+export type { UserRightFlagField };
 
 // Utility function to get current tenant from URL
 export const getCurrentTenant = (): string | undefined => {
@@ -50,30 +47,63 @@ export type AdminUserData = {
   createdAt: Timestamp;
 };
 
-export const USER_RIGHT_FLAG_FIELDS = [
-  "isAdmin",
-  "isWorker",
-  "isLiaison",
-  "isEquipment",
-  "isStaffing",
-  "isSetup",
-  "isCatering",
-  "isCleaning",
-  "isSecurity",
-] as const;
+/**
+ * Walk the parsed JSON tree and convert serialized Firestore Timestamps
+ * back into `Timestamp` instances. The admin SDK serializes Timestamp as
+ * `{ _seconds, _nanoseconds }`; the client SDK's Timestamp class restores
+ * `.toDate()` / `.toMillis()` semantics.
+ */
+function reviveTimestamps(value: unknown): unknown {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) return value.map(reviveTimestamps);
+  if (typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    if (
+      typeof obj._seconds === "number" &&
+      typeof obj._nanoseconds === "number" &&
+      Object.keys(obj).length === 2
+    ) {
+      return new Timestamp(obj._seconds, obj._nanoseconds);
+    }
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(obj)) {
+      out[k] = reviveTimestamps(v);
+    }
+    return out;
+  }
+  return value;
+}
 
-export type UserRightFlagField = (typeof USER_RIGHT_FLAG_FIELDS)[number];
+/**
+ * The old client-SDK helpers fell back to `getCurrentTenant()` when an
+ * explicit `tenant` arg was omitted. Preserve that contract so call sites
+ * inside a tenant subtree still hit the right collection without changes.
+ */
+function resolveTenantArg(tenant?: string): string | undefined {
+  return tenant ?? getCurrentTenant();
+}
 
-const buildDefaultUserRightFlags = (
-  overrides: Partial<Record<UserRightFlagField, boolean>> = {},
-) =>
-  USER_RIGHT_FLAG_FIELDS.reduce(
-    (acc, currentFlag) => {
-      acc[currentFlag] = overrides[currentFlag] ?? false;
-      return acc;
-    },
-    {} as Record<UserRightFlagField, boolean>,
-  );
+async function postJson<TBody, TResp = unknown>(
+  url: string,
+  body: TBody,
+): Promise<TResp> {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    let detail = "";
+    try {
+      detail = (await res.json()).error ?? "";
+    } catch {}
+    throw new Error(
+      `Firestore proxy ${url} failed: ${res.status}${detail ? ` ${detail}` : ""}`,
+    );
+  }
+  const parsed = await res.json();
+  return reviveTimestamps(parsed) as TResp;
+}
 
 export const clientDeleteDataFromFirestore = async (
   collectionName: string,
@@ -81,80 +111,30 @@ export const clientDeleteDataFromFirestore = async (
   tenant?: string,
 ) => {
   try {
-    const db = getDb();
-    const tenantCollection = getTenantCollection(collectionName, tenant);
-    await deleteDoc(doc(db, tenantCollection, docId));
+    await postJson<MutateRequest>("/api/firestore/mutate", {
+      op: "delete",
+      collection: collectionName,
+      tenant: resolveTenantArg(tenant),
+      docId,
+    });
     console.log("Document successfully deleted with ID:", docId);
   } catch (error) {
     console.error("Error deleting document: ", error);
   }
 };
 
-// Special function for handling user rights deletion
 export const clientDeleteUserRightsData = async (
   collectionName: TableNames,
   docId: string,
   tenant?: string,
 ) => {
   try {
-    const db = getDb();
-
-    // Check if this is one of the user collections that should use usersRights
-    const userCollections = [TableNames.ADMINS, TableNames.PAS];
-
-    if (userCollections.includes(collectionName)) {
-      // For user collections, we work directly with the usersRights collection
-      // The docId passed is from the usersRights collection
-      const usersRightsCollection = getTenantCollection(
-        TableNames.USERS_RIGHTS,
-        tenant,
-      );
-
-      // Get the document from usersRights collection
-      const userDoc = await getDoc(doc(db, usersRightsCollection, docId));
-
-      if (!userDoc.exists()) {
-        throw new Error("User document not found in usersRights collection");
-      }
-
-      const userData = userDoc.data();
-      const { email } = userData;
-
-      if (!email) {
-        throw new Error("Email not found in user document");
-      }
-
-      // Set the appropriate flag to false
-      let updateData: any = {};
-
-      if (collectionName === TableNames.ADMINS) {
-        updateData = { isAdmin: false };
-      } else if (collectionName === TableNames.PAS) {
-        updateData = { isWorker: false };
-      }
-
-      // Check if all flags are false, if so, remove the document
-      const updatedFlags = {
-        isAdmin:
-          collectionName === TableNames.ADMINS ? false : userData.isAdmin,
-        isWorker: collectionName === TableNames.PAS ? false : userData.isWorker,
-      };
-
-      if (!updatedFlags.isAdmin && !updatedFlags.isWorker) {
-        // All flags are false, remove the document
-        await deleteDoc(doc(db, usersRightsCollection, docId));
-        console.log("Removed user from usersRights as all flags are false");
-      } else {
-        // Update the flag
-        await updateDoc(doc(db, usersRightsCollection, docId), updateData);
-        console.log("Updated user flag in usersRights");
-      }
-    } else {
-      // Use original logic for non-user collections
-      const tenantCollection = getTenantCollection(collectionName, tenant);
-      await deleteDoc(doc(db, tenantCollection, docId));
-    }
-
+    await postJson<UserRightsRequest>("/api/firestore/userRights", {
+      action: "delete",
+      collection: collectionName,
+      docId,
+      tenant: resolveTenantArg(tenant),
+    });
     console.log("Document successfully deleted with ID:", docId);
   } catch (error) {
     console.error("Error deleting document: ", error);
@@ -168,94 +148,33 @@ export const clientSaveDataToFirestore = async (
   tenant?: string,
 ) => {
   try {
-    const db = getDb();
-    const tenantCollection = getTenantCollection(collectionName, tenant);
-    const docRef = await addDoc(collection(db, tenantCollection), data);
-
-    console.log("Document successfully written with ID:", docRef.id);
+    const { id } = await postJson<MutateRequest, { id: string }>(
+      "/api/firestore/mutate",
+      {
+        op: "create",
+        collection: collectionName,
+        tenant: resolveTenantArg(tenant),
+        data: data as Record<string, unknown>,
+      },
+    );
+    console.log("Document successfully written with ID:", id);
   } catch (error) {
     console.error("Error writing document: ", error);
   }
 };
 
-// Special function for handling user rights operations
 export const clientSaveUserRightsData = async (
   collectionName: TableNames,
   data: object,
   tenant?: string,
 ) => {
   try {
-    const db = getDb();
-
-    // Check if this is one of the user collections that should use usersRights
-    const userCollections = [TableNames.ADMINS, TableNames.PAS];
-
-    if (userCollections.includes(collectionName)) {
-      // Use usersRights collection instead
-      const usersRightsCollection = getTenantCollection(
-        TableNames.USERS_RIGHTS,
-        tenant,
-      );
-      const { email } = data as any;
-
-      if (!email) {
-        throw new Error("Email is required for user rights operations");
-      }
-
-      // Check if user already exists in usersRights
-      const existingUserQuery = query(
-        collection(db, usersRightsCollection),
-        where("email", "==", email),
-      );
-      const existingUserSnapshot = await getDocs(existingUserQuery);
-
-      if (!existingUserSnapshot.empty) {
-        // User exists, update the appropriate flag
-        const existingUserDoc = existingUserSnapshot.docs[0];
-        const existingData = existingUserDoc.data();
-
-        let updateData: any = {};
-
-        if (collectionName === TableNames.ADMINS) {
-          updateData = { isAdmin: true };
-        } else if (collectionName === TableNames.PAS) {
-          updateData = { isWorker: true };
-        }
-
-        await updateDoc(
-          doc(db, usersRightsCollection, existingUserDoc.id),
-          updateData,
-        );
-        console.log(
-          "Updated existing user in usersRights with ID:",
-          existingUserDoc.id,
-        );
-      } else {
-        // User doesn't exist, create new entry
-        const defaultFlags = buildDefaultUserRightFlags({
-          isAdmin: collectionName === TableNames.ADMINS,
-          isWorker: collectionName === TableNames.PAS,
-        });
-
-        const newUserData = {
-          email,
-          createdAt: (data as any).createdAt || Timestamp.now(),
-          ...defaultFlags,
-          ...(data as any),
-        };
-
-        const docRef = await addDoc(
-          collection(db, usersRightsCollection),
-          newUserData,
-        );
-        console.log("Created new user in usersRights with ID:", docRef.id);
-      }
-    } else {
-      // Use original logic for non-user collections
-      const tenantCollection = getTenantCollection(collectionName, tenant);
-      const docRef = await addDoc(collection(db, tenantCollection), data);
-      console.log("Document successfully written with ID:", docRef.id);
-    }
+    await postJson<UserRightsRequest>("/api/firestore/userRights", {
+      action: "save",
+      collection: collectionName,
+      tenant: resolveTenantArg(tenant),
+      data: data as Record<string, unknown>,
+    });
   } catch (error) {
     console.error("Error writing document: ", error);
     throw error;
@@ -271,30 +190,11 @@ export const clientUpsertUserRightFlag = async (
   if (!trimmedEmail) {
     throw new Error("Email is required");
   }
-
-  const db = getDb();
-  const usersRightsCollection = getTenantCollection(TableNames.USERS_RIGHTS, tenant);
-  const existingUserQuery = query(
-    collection(db, usersRightsCollection),
-    where("email", "==", trimmedEmail),
-  );
-  const existingUserSnapshot = await getDocs(existingUserQuery);
-
-  if (!existingUserSnapshot.empty) {
-    const existingUserDoc = existingUserSnapshot.docs[0];
-    await updateDoc(doc(db, usersRightsCollection, existingUserDoc.id), {
-      [flag]: true,
-    });
-    return;
-  }
-
-  const defaultFlags = buildDefaultUserRightFlags();
-
-  await addDoc(collection(db, usersRightsCollection), {
+  await postJson<UserRightsRequest>("/api/firestore/userRights", {
+    action: "upsertFlag",
     email: trimmedEmail,
-    createdAt: Timestamp.now(),
-    ...defaultFlags,
-    [flag]: true,
+    flag,
+    tenant: resolveTenantArg(tenant),
   });
 };
 
@@ -303,55 +203,28 @@ export const clientClearUserRightFlag = async (
   flag: UserRightFlagField,
   tenant?: string,
 ) => {
-  const db = getDb();
-  const usersRightsCollection = getTenantCollection(TableNames.USERS_RIGHTS, tenant);
-  const targetDocRef = doc(db, usersRightsCollection, docId);
-  const userDoc = await getDoc(targetDocRef);
-
-  if (!userDoc.exists()) {
-    throw new Error("User document not found in usersRights collection");
-  }
-
-  const userData = userDoc.data() as Partial<Record<UserRightFlagField, boolean>>;
-  const updatedFlags = USER_RIGHT_FLAG_FIELDS.reduce(
-    (acc, currentFlag) => {
-      if (currentFlag === flag) {
-        acc[currentFlag] = false;
-      } else {
-        acc[currentFlag] = userData[currentFlag] === true;
-      }
-      return acc;
-    },
-    {} as Record<UserRightFlagField, boolean>,
-  );
-
-  const shouldDeleteDoc = USER_RIGHT_FLAG_FIELDS.every(
-    (currentFlag) => !updatedFlags[currentFlag],
-  );
-
-  if (shouldDeleteDoc) {
-    await deleteDoc(targetDocRef);
-    return;
-  }
-
-  await updateDoc(targetDocRef, { [flag]: false });
+  await postJson<UserRightsRequest>("/api/firestore/userRights", {
+    action: "clearFlag",
+    docId,
+    flag,
+    tenant: resolveTenantArg(tenant),
+  });
 };
 
 export const clientFetchAllDataFromCollection = async <T>(
   collectionName: TableNames,
-  queryConstraints: QueryConstraint[] = [],
+  whereSpecs: WhereSpec[] = [],
   tenant?: string,
 ): Promise<T[]> => {
-  const db = getDb();
-  const tenantCollection = getTenantCollection(collectionName, tenant);
-  const colRef = collection(db, tenantCollection);
-  const q = query(colRef, ...queryConstraints);
-  const snapshot = await getDocs(q);
-  const data = snapshot.docs.map((document) => ({
-    id: document.id,
-    ...(document.data() as unknown as T),
-  }));
-  return data;
+  const { docs } = await postJson<
+    ListRequest,
+    { docs: Array<Record<string, unknown> & { id: string }> }
+  >("/api/firestore/list", {
+    collection: collectionName,
+    tenant: resolveTenantArg(tenant),
+    where: whereSpecs,
+  });
+  return docs as unknown as T[];
 };
 
 export const clientFetchAllDataFromCollectionWithLimitAndOffset = async <T>(
@@ -360,112 +233,65 @@ export const clientFetchAllDataFromCollectionWithLimitAndOffset = async <T>(
   offset: number,
   tenant?: string,
 ): Promise<T[]> => {
-  const db = getDb();
-  const tenantCollection = getTenantCollection(collectionName, tenant);
-  const colRef = collection(db, tenantCollection);
-  const q = query(colRef, limit(limitNumber), where("offset", ">=", offset));
-  const snapshot = await getDocs(q);
-  const data = snapshot.docs.map((document) => ({
-    id: document.id,
-    ...(document.data() as unknown as T),
-  }));
-  return data;
+  const { docs } = await postJson<
+    ListRequest,
+    { docs: Array<Record<string, unknown> & { id: string }> }
+  >("/api/firestore/list", {
+    collection: collectionName,
+    tenant: resolveTenantArg(tenant),
+    where: [{ field: "offset", op: ">=", value: offset }],
+    limit: limitNumber,
+  });
+  return docs as unknown as T[];
 };
 
 export const getPaginatedData = async <T>(
-  collectionName,
-  itemsPerPage = 10,
+  collectionName: string,
+  itemsPerPage: number = 10,
   filters: Filters,
-  lastVisible = null,
+  lastVisible: Record<string, unknown> | null = null,
   tenant?: string,
 ): Promise<T[]> => {
+  // Convert Date values in filters.dateRange to ISO strings for the wire.
+  const dateRange = Array.isArray(filters.dateRange)
+    ? filters.dateRange.map((d: any) =>
+        d instanceof Date ? d.toISOString() : d == null ? null : String(d),
+      )
+    : (filters.dateRange as unknown as string | undefined);
+
+  // Convert Timestamp on the cursor to {__ts}.
+  let serializedLast: Record<string, unknown> | null = null;
+  if (lastVisible) {
+    const cursorValue = lastVisible[filters.sortField];
+    if (cursorValue && typeof (cursorValue as any).toMillis === "function") {
+      serializedLast = {
+        [filters.sortField]: { __ts: (cursorValue as Timestamp).toMillis() },
+      };
+    } else if (cursorValue instanceof Date) {
+      serializedLast = {
+        [filters.sortField]: { __ts: cursorValue.getTime() },
+      };
+    } else {
+      serializedLast = { [filters.sortField]: cursorValue };
+    }
+  }
+
   try {
-    const db = getDb();
-    const tenantCollection = getTenantCollection(collectionName, tenant);
-    const colRef = collection(db, tenantCollection);
-    const queryParams = [];
-
-    // Add date range filters
-    if (filters.dateRange && filters.dateRange.length === 2) {
-      if (filters.dateRange[0]) {
-        queryParams.push(where("startDate", ">=", filters.dateRange[0]));
-      }
-      if (filters.dateRange[1]) {
-        queryParams.push(where("startDate", "<=", filters.dateRange[1]));
-      }
-    }
-
-    // If there's a search query, fetch data and filter client-side
-    if (filters.searchQuery && filters.searchQuery.trim() !== "") {
-      const searchTerm = filters.searchQuery.trim().toLowerCase();
-
-      // Define the fields we want to search
-      const searchableFields = [
-        "requestNumber",
-        "department",
-        "netId",
-        "email",
-        "title",
-        "description",
-        "firstName",
-        "lastName",
-        "roomId",
-      ];
-
-      // Fetch data with just date filters
-      const baseQuery = query(
-        colRef,
-        ...queryParams,
-        orderBy(filters.sortField, "desc"),
-      );
-
-      const snapshot = await getDocs(baseQuery);
-
-      // Filter documents that match the search term in any field
-      const matchingDocs = snapshot.docs.filter((doc) => {
-        const data = doc.data();
-
-        // Check for matches in combined firstName + lastName
-        if (data.firstName && data.lastName) {
-          const fullName = `${data.firstName} ${data.lastName}`.toLowerCase();
-          if (fullName.includes(searchTerm)) return true;
-        }
-
-        // Continue with existing field-by-field check
-        return searchableFields.some((field) => {
-          const fieldValue = data[field];
-          // Handle different types of fields
-          if (fieldValue === null || fieldValue === undefined) return false;
-          const stringValue = String(fieldValue).toLowerCase();
-          // Check if the field contains the search term anywhere
-          return stringValue.includes(searchTerm);
-        });
-      });
-
-      // Return all matching docs without pagination
-      return matchingDocs.map((doc) => ({
-        id: doc.id,
-        ...(doc.data() as unknown as T),
-      }));
-    }
-
-    // If no search query, use standard query with date filters
-    let q = query(colRef, ...queryParams, orderBy(filters.sortField, "desc"));
-
-    if (lastVisible) {
-      q = query(
-        colRef,
-        ...queryParams,
-        orderBy(filters.sortField, "desc"),
-        startAfter(lastVisible[filters.sortField]),
-      );
-    }
-
-    const snapshot = await getDocs(q);
-    return snapshot.docs.map((doc) => ({
-      id: doc.id,
-      ...(doc.data() as unknown as T),
-    }));
+    const { docs } = await postJson<
+      PaginatedRequest,
+      { docs: Array<Record<string, unknown> & { id: string }> }
+    >("/api/firestore/paginated", {
+      collection: collectionName,
+      tenant: resolveTenantArg(tenant),
+      filters: {
+        dateRange: dateRange as any,
+        sortField: filters.sortField,
+        searchQuery: (filters as any).searchQuery,
+      },
+      limit: itemsPerPage,
+      lastVisible: serializedLast,
+    });
+    return docs as unknown as T[];
   } catch (error) {
     console.error("Error getting paginated data:", error);
     throw error;
@@ -476,53 +302,46 @@ export const clientGetFinalApproverEmailFromDatabase = async (): Promise<
   string | null
 > => {
   try {
-    const db = getDb();
-    const approversCollection = collection(db, TableNames.APPROVERS);
-    const q = query(
-      approversCollection,
-      where("level", "==", ApproverLevel.FINAL),
-    );
-    const querySnapshot = await getDocs(q);
-    if (!querySnapshot.empty) {
-      const doc = querySnapshot.docs[0]; // assuming only one final approver
-      const finalApproverEmail = doc.data().email;
-      if (finalApproverEmail) {
-        console.log("HERE", finalApproverEmail);
-        return finalApproverEmail;
-      }
-    }
+    const { docs } = await postJson<
+      ListRequest,
+      { docs: Array<{ email?: string }> }
+    >("/api/firestore/list", {
+      collection: TableNames.APPROVERS,
+      where: [{ field: "level", op: "==", value: ApproverLevel.FINAL }],
+    });
+    if (docs.length > 0 && docs[0].email) return docs[0].email;
     return null;
   } catch (error) {
     console.error("Error fetching finalApproverEmail:", error);
     return null;
   }
 };
+
 export const clientGetDataByCalendarEventId = async <T>(
   collectionName: TableNames,
   calendarEventId: string,
   tenant?: string,
 ): Promise<(T & { id: string }) | null> => {
   try {
-    const db = getDb();
-    const tenantCollection = getTenantCollection(collectionName, tenant);
-    const colRef = collection(db, tenantCollection);
-    const q = query(colRef, where("calendarEventId", "==", calendarEventId));
-    const snapshot = await getDocs(q);
-
-    if (snapshot.empty) {
-      return null;
-    }
-
-    const doc = snapshot.docs[0];
-    return {
-      id: doc.id,
-      ...(doc.data() as unknown as T),
-    };
+    const { docs } = await postJson<
+      ListRequest,
+      { docs: Array<Record<string, unknown> & { id: string }> }
+    >("/api/firestore/list", {
+      collection: collectionName,
+      tenant: resolveTenantArg(tenant),
+      where: [
+        { field: "calendarEventId", op: "==", value: calendarEventId },
+      ],
+      limit: 1,
+    });
+    if (docs.length === 0) return null;
+    return docs[0] as unknown as T & { id: string };
   } catch (error) {
     console.error("Error getting data by calendar event ID:", error);
     return null;
   }
 };
+
 export const clientUpdateDataInFirestore = async (
   collectionName: string,
   docId: string,
@@ -530,13 +349,13 @@ export const clientUpdateDataInFirestore = async (
   tenant?: string,
 ) => {
   try {
-    const db = getDb();
-    const tenantCollection = getTenantCollection(
-      collectionName as TableNames,
-      tenant,
-    );
-    const docRef = doc(db, tenantCollection, docId);
-    await updateDoc(docRef, updatedData);
+    await postJson<MutateRequest>("/api/firestore/mutate", {
+      op: "update",
+      collection: collectionName,
+      tenant: resolveTenantArg(tenant),
+      docId,
+      data: updatedData as Record<string, unknown>,
+    });
     console.log("Document successfully updated with ID:", docId);
   } catch (error) {
     console.error("Error updating document: ", error);
@@ -547,15 +366,18 @@ export const clientGetTenantSchema = async (
   tenant: string,
 ): Promise<SchemaContextType | null> => {
   try {
-    const db = getDb();
-    const docRef = doc(db, "tenantSchema", tenant);
-    const docSnap = await getDoc(docRef);
-
-    if (docSnap.exists()) {
-      return docSnap.data() as SchemaContextType;
+    const { doc } = await postJson<
+      GetDocRequest,
+      { doc: (Record<string, unknown> & { id: string }) | null }
+    >("/api/firestore/getDoc", {
+      collection: "tenantSchema",
+      docId: tenant,
+    });
+    if (!doc) {
+      console.log(`No schema found for tenant: ${tenant}`);
+      return null;
     }
-    console.log(`No schema found for tenant: ${tenant}`);
-    return null;
+    return doc as unknown as SchemaContextType;
   } catch (error) {
     console.error("Error fetching tenant schema:", error);
     return null;

--- a/booking-app/lib/firebase/userRightsConstants.ts
+++ b/booking-app/lib/firebase/userRightsConstants.ts
@@ -1,0 +1,13 @@
+export const USER_RIGHT_FLAG_FIELDS = [
+  "isAdmin",
+  "isWorker",
+  "isLiaison",
+  "isEquipment",
+  "isStaffing",
+  "isSetup",
+  "isCatering",
+  "isCleaning",
+  "isSecurity",
+] as const;
+
+export type UserRightFlagField = (typeof USER_RIGHT_FLAG_FIELDS)[number];

--- a/booking-app/tests/e2e/helpers/itp-mock-routes.ts
+++ b/booking-app/tests/e2e/helpers/itp-mock-routes.ts
@@ -227,6 +227,46 @@ export async function registerItpBookingMocks(page: Page) {
     })
   );
 
+  // After the SSO migration, browser-side Firestore reads/writes go through
+  // /api/firestore/* which proxies via firebase-admin. CI has no service
+  // account credentials, so the real route returns 500. Stub them with the
+  // shapes Provider.tsx expects.
+  await page.route("**/api/firestore/list", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: jsonHeaders,
+      body: JSON.stringify({ docs: [] }),
+    })
+  );
+  await page.route("**/api/firestore/getDoc", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: jsonHeaders,
+      body: JSON.stringify({ doc: null }),
+    })
+  );
+  await page.route("**/api/firestore/paginated", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: jsonHeaders,
+      body: JSON.stringify({ docs: [] }),
+    })
+  );
+  await page.route("**/api/firestore/mutate", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: jsonHeaders,
+      body: JSON.stringify({ id: "mock-doc-id", ok: true }),
+    })
+  );
+  await page.route("**/api/firestore/userRights", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: jsonHeaders,
+      body: JSON.stringify({ id: "mock-doc-id", ok: true }),
+    })
+  );
+
   // Mock Google Auth endpoints
   await page.route("**/accounts.google.com/**", (route) =>
     route.fulfill({

--- a/booking-app/tests/e2e/helpers/mock-routes.ts
+++ b/booking-app/tests/e2e/helpers/mock-routes.ts
@@ -284,6 +284,47 @@ export async function registerBookingMocks(page: Page) {
     })
   );
 
+  // After the SSO migration, browser-side Firestore reads/writes go through
+  // /api/firestore/* which proxies via firebase-admin. CI has no service
+  // account credentials, so the real route returns 500. Stub them with the
+  // shapes Provider.tsx expects so per-page mocks (registered after this
+  // helper) can still take precedence for endpoints they care about.
+  await page.route("**/api/firestore/list", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: jsonHeaders,
+      body: JSON.stringify({ docs: [] }),
+    })
+  );
+  await page.route("**/api/firestore/getDoc", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: jsonHeaders,
+      body: JSON.stringify({ doc: null }),
+    })
+  );
+  await page.route("**/api/firestore/paginated", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: jsonHeaders,
+      body: JSON.stringify({ docs: [] }),
+    })
+  );
+  await page.route("**/api/firestore/mutate", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: jsonHeaders,
+      body: JSON.stringify({ id: "mock-doc-id", ok: true }),
+    })
+  );
+  await page.route("**/api/firestore/userRights", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: jsonHeaders,
+      body: JSON.stringify({ id: "mock-doc-id", ok: true }),
+    })
+  );
+
   // Mock Google Auth endpoints
   await page.route("**/accounts.google.com/**", (route) =>
     route.fulfill({

--- a/booking-app/tests/unit/firebase-client-tenant.unit.test.ts
+++ b/booking-app/tests/unit/firebase-client-tenant.unit.test.ts
@@ -3,95 +3,63 @@ import {
   clientDeleteDataFromFirestore,
   clientSaveDataToFirestore,
 } from "@/lib/firebase/firebase";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockDeleteDoc = vi.fn().mockResolvedValue(undefined);
-const mockAddDoc = vi.fn().mockResolvedValue({ id: "new-doc-id" });
-const mockDoc = vi.fn((_db, collectionName, docId) => ({
-  _collection: collectionName,
-  _id: docId,
-}));
-const mockCollection = vi.fn((_db, collectionName) => ({
-  _collection: collectionName,
-}));
-
-vi.mock("firebase/firestore", () => ({
-  deleteDoc: (...args: any[]) => mockDeleteDoc(...args),
-  addDoc: (...args: any[]) => mockAddDoc(...args),
-  doc: (...args: any[]) => mockDoc(...args),
-  collection: (...args: any[]) => mockCollection(...args),
-  getDocs: vi.fn().mockResolvedValue({ docs: [] }),
-  getDoc: vi.fn(),
-  updateDoc: vi.fn(),
-  setDoc: vi.fn(),
-  query: vi.fn((ref) => ref),
-  where: vi.fn(),
-  orderBy: vi.fn(),
-  limit: vi.fn(),
-  startAfter: vi.fn(),
-  Timestamp: {
-    now: vi.fn(() => ({ toDate: () => new Date() })),
-    fromDate: vi.fn((d: Date) => ({ toDate: () => d })),
-  },
-}));
-
-vi.mock("@/lib/firebase/firebaseClient", () => ({
-  getDb: vi.fn().mockReturnValue({}),
-  initializeDb: vi.fn(),
-}));
-
-vi.mock("@/components/src/types", async (importOriginal) => {
-  const actual = await importOriginal();
-  return { ...actual };
-});
 vi.mock("@/components/src/client/routes/components/SchemaProvider", () => ({}));
 
-describe("clientDeleteDataFromFirestore — tenant collection resolution", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+/**
+ * After the SSO migration, client-side helpers POST to `/api/firestore/*`
+ * instead of touching Firestore directly. The contract these tests guard:
+ *   1. The request goes to the right endpoint
+ *   2. The body's `collection` and `tenant` fields match the URL-derived /
+ *      explicit tenant input
+ *   3. Tenant prefixing happens server-side, so the helper just forwards the
+ *      raw collection name + resolved tenant
+ */
 
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
+const fetchMock = vi.fn(async () => ({
+  ok: true,
+  json: async () => ({ id: "new-doc-id" }),
+}));
 
-  it("uses the tenant-prefixed collection when the URL contains a tenant segment", async () => {
+beforeEach(() => {
+  fetchMock.mockClear();
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function lastBody() {
+  const call = fetchMock.mock.calls.at(-1);
+  if (!call) throw new Error("fetch was not called");
+  const init = call[1] as RequestInit;
+  return JSON.parse(init.body as string);
+}
+
+describe("clientDeleteDataFromFirestore — request contract", () => {
+  it("forwards tenant derived from URL", async () => {
     vi.stubGlobal("location", { pathname: "/mc/admin/settings/policy" });
 
-    await clientDeleteDataFromFirestore(TableNames.BLACKOUT_PERIODS, "period-1");
+    await clientDeleteDataFromFirestore(TableNames.BLACKOUT_PERIODS, "p1");
 
-    expect(mockDoc).toHaveBeenCalledWith(
-      expect.anything(),
-      "mc-blackoutPeriods",
-      "period-1",
-    );
-    expect(mockDeleteDoc).toHaveBeenCalledTimes(1);
+    const call = fetchMock.mock.calls.at(-1)!;
+    expect(call[0]).toBe("/api/firestore/mutate");
+    expect(lastBody()).toMatchObject({
+      op: "delete",
+      collection: "blackoutPeriods",
+      tenant: "mc",
+      docId: "p1",
+    });
   });
 
-  it("uses the base collection name for non-tenant-specific collections", async () => {
-    vi.stubGlobal("location", { pathname: "/mc/admin/settings/policy" });
-
-    await clientDeleteDataFromFirestore("settings", "settings-1");
-
-    expect(mockDoc).toHaveBeenCalledWith(
-      expect.anything(),
-      "settings",
-      "settings-1",
-    );
-    expect(mockDeleteDoc).toHaveBeenCalledTimes(1);
-  });
-
-  it("uses the base collection name when no tenant is in the URL", async () => {
+  it("omits tenant when the URL has none", async () => {
     vi.stubGlobal("location", { pathname: "/" });
 
-    await clientDeleteDataFromFirestore(TableNames.BLACKOUT_PERIODS, "period-1");
+    await clientDeleteDataFromFirestore(TableNames.BLACKOUT_PERIODS, "p1");
 
-    expect(mockDoc).toHaveBeenCalledWith(
-      expect.anything(),
-      "blackoutPeriods",
-      "period-1",
-    );
-    expect(mockDeleteDoc).toHaveBeenCalledTimes(1);
+    expect(lastBody().tenant).toBeUndefined();
   });
 
   it("respects an explicit tenant argument over the URL", async () => {
@@ -99,64 +67,38 @@ describe("clientDeleteDataFromFirestore — tenant collection resolution", () =>
 
     await clientDeleteDataFromFirestore(
       TableNames.BLACKOUT_PERIODS,
-      "period-1",
+      "p1",
       "mc",
     );
 
-    expect(mockDoc).toHaveBeenCalledWith(
-      expect.anything(),
-      "mc-blackoutPeriods",
-      "period-1",
-    );
-    expect(mockDeleteDoc).toHaveBeenCalledTimes(1);
+    expect(lastBody().tenant).toBe("mc");
   });
 });
 
-describe("clientSaveDataToFirestore — tenant collection resolution", () => {
+describe("clientSaveDataToFirestore — request contract", () => {
   const sampleData = { name: "Winter Break", isActive: true };
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
-  it("uses the tenant-prefixed collection when the URL contains a tenant segment", async () => {
+  it("forwards tenant derived from URL", async () => {
     vi.stubGlobal("location", { pathname: "/mc/admin/settings/policy" });
 
     await clientSaveDataToFirestore(TableNames.BLACKOUT_PERIODS, sampleData);
 
-    expect(mockCollection).toHaveBeenCalledWith(
-      expect.anything(),
-      "mc-blackoutPeriods",
-    );
-    expect(mockAddDoc).toHaveBeenCalledTimes(1);
+    const call = fetchMock.mock.calls.at(-1)!;
+    expect(call[0]).toBe("/api/firestore/mutate");
+    expect(lastBody()).toMatchObject({
+      op: "create",
+      collection: "blackoutPeriods",
+      tenant: "mc",
+      data: sampleData,
+    });
   });
 
-  it("uses the base collection name for non-tenant-specific collections", async () => {
-    vi.stubGlobal("location", { pathname: "/mc/admin/settings/policy" });
-
-    await clientSaveDataToFirestore("departments", sampleData);
-
-    expect(mockCollection).toHaveBeenCalledWith(
-      expect.anything(),
-      "departments",
-    );
-    expect(mockAddDoc).toHaveBeenCalledTimes(1);
-  });
-
-  it("uses the base collection name when no tenant is in the URL", async () => {
+  it("omits tenant when the URL has none", async () => {
     vi.stubGlobal("location", { pathname: "/" });
 
     await clientSaveDataToFirestore(TableNames.BLACKOUT_PERIODS, sampleData);
 
-    expect(mockCollection).toHaveBeenCalledWith(
-      expect.anything(),
-      "blackoutPeriods",
-    );
-    expect(mockAddDoc).toHaveBeenCalledTimes(1);
+    expect(lastBody().tenant).toBeUndefined();
   });
 
   it("respects an explicit tenant argument over the URL", async () => {
@@ -168,10 +110,6 @@ describe("clientSaveDataToFirestore — tenant collection resolution", () => {
       "mc",
     );
 
-    expect(mockCollection).toHaveBeenCalledWith(
-      expect.anything(),
-      "mc-blackoutPeriods",
-    );
-    expect(mockAddDoc).toHaveBeenCalledTimes(1);
+    expect(lastBody().tenant).toBe("mc");
   });
 });

--- a/booking-app/tests/unit/firestoreAuthz.unit.test.ts
+++ b/booking-app/tests/unit/firestoreAuthz.unit.test.ts
@@ -72,8 +72,13 @@ describe("authorizeWrite", () => {
     expect(decision.ok).toBe(true);
   });
 
-  it("denies writes to bookings (must use /api/bookings/*)", async () => {
-    superSnap.mockReturnValue([{ email: session.email }]);
+  it("allows PA write to bookings (e.g. equipment checkout toggle)", async () => {
+    usersRightsSnap.mockReturnValue([{ isWorker: true }]);
+    const decision = await authorizeWrite(session, "mc", "bookings");
+    expect(decision.ok).toBe(true);
+  });
+
+  it("blocks regular booking-role user write to bookings", async () => {
     const decision = await authorizeWrite(session, "mc", "bookings");
     expect(decision.ok).toBe(false);
   });

--- a/booking-app/tests/unit/firestoreAuthz.unit.test.ts
+++ b/booking-app/tests/unit/firestoreAuthz.unit.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const superSnap = vi.fn();
+const usersRightsSnap = vi.fn();
+const approverSnap = vi.fn();
+
+function snapshot(docs: Array<Record<string, unknown>>) {
+  return {
+    empty: docs.length === 0,
+    docs: docs.map((data) => ({ data: () => data })),
+  };
+}
+
+vi.mock("@/lib/firebase/server/firebaseAdmin", () => {
+  const collection = vi.fn((name: string) => {
+    const where = (_field: string, _op: string, _value: unknown) => ({
+      limit: () => ({
+        get: async () => {
+          if (name === "usersSuperAdmin") return snapshot(superSnap());
+          if (name.endsWith("usersRights")) return snapshot(usersRightsSnap());
+          if (name.endsWith("usersApprovers")) return snapshot(approverSnap());
+          return snapshot([]);
+        },
+      }),
+    });
+    return { where };
+  });
+  return {
+    default: {
+      firestore: () => ({ collection }),
+    },
+  };
+});
+
+import { authorizeRead, authorizeWrite } from "@/lib/api/authz";
+
+const session = { email: "rh3555@nyu.edu", netId: "rh3555" };
+
+beforeEach(() => {
+  superSnap.mockReturnValue([]);
+  usersRightsSnap.mockReturnValue([]);
+  approverSnap.mockReturnValue([]);
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("authorizeWrite", () => {
+  it("blocks non-admin write to usersRights", async () => {
+    const decision = await authorizeWrite(session, "mc", "usersRights");
+    expect(decision.ok).toBe(false);
+    if (!decision.ok) {
+      expect(decision.status).toBe(403);
+    }
+  });
+
+  it("allows admin write to usersRights", async () => {
+    usersRightsSnap.mockReturnValue([{ isAdmin: true }]);
+    const decision = await authorizeWrite(session, "mc", "usersRights");
+    expect(decision.ok).toBe(true);
+  });
+
+  it("blocks admin from writing usersSuperAdmin (super-only)", async () => {
+    usersRightsSnap.mockReturnValue([{ isAdmin: true }]);
+    const decision = await authorizeWrite(session, "mc", "usersSuperAdmin");
+    expect(decision.ok).toBe(false);
+  });
+
+  it("allows super_admin to write usersSuperAdmin", async () => {
+    superSnap.mockReturnValue([{ email: session.email }]);
+    const decision = await authorizeWrite(session, "mc", "usersSuperAdmin");
+    expect(decision.ok).toBe(true);
+  });
+
+  it("denies writes to bookings (must use /api/bookings/*)", async () => {
+    superSnap.mockReturnValue([{ email: session.email }]);
+    const decision = await authorizeWrite(session, "mc", "bookings");
+    expect(decision.ok).toBe(false);
+  });
+
+  it("denies writes to unknown collection by default", async () => {
+    superSnap.mockReturnValue([{ email: session.email }]);
+    const decision = await authorizeWrite(session, "mc", "totally-fake");
+    expect(decision.ok).toBe(false);
+  });
+});
+
+describe("authorizeRead", () => {
+  it("allows any NYU user to read tenantSchema", async () => {
+    const decision = await authorizeRead(session, "mc", "tenantSchema");
+    expect(decision.ok).toBe(true);
+  });
+
+  it("allows any NYU user to read bookings (legacy compat)", async () => {
+    const decision = await authorizeRead(session, "mc", "bookings");
+    expect(decision.ok).toBe(true);
+  });
+
+  it("blocks non-admin read of preBanLogs", async () => {
+    const decision = await authorizeRead(session, "mc", "preBanLogs");
+    expect(decision.ok).toBe(false);
+    if (!decision.ok) {
+      expect(decision.status).toBe(403);
+    }
+  });
+
+  it("allows admin read of preBanLogs", async () => {
+    usersRightsSnap.mockReturnValue([{ isAdmin: true }]);
+    const decision = await authorizeRead(session, "mc", "preBanLogs");
+    expect(decision.ok).toBe(true);
+  });
+
+  it("denies reads to unknown collection by default", async () => {
+    const decision = await authorizeRead(session, "mc", "totally-fake");
+    expect(decision.ok).toBe(false);
+  });
+});

--- a/booking-app/tests/unit/firestoreServer-reviveValue.unit.test.ts
+++ b/booking-app/tests/unit/firestoreServer-reviveValue.unit.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/firebase/server/firebaseAdmin", () => {
+  const fromMillisMock = vi.fn(
+    (ms: number) => ({ kind: "fromMillis", ms }) as const,
+  );
+  class FakeAdminTimestamp {
+    constructor(
+      public readonly seconds: number,
+      public readonly nanoseconds: number,
+    ) {}
+    static fromMillis = fromMillisMock;
+  }
+  return {
+    default: {
+      firestore: Object.assign(() => ({}), {
+        Timestamp: FakeAdminTimestamp,
+      }),
+    },
+  };
+});
+
+const adminModule = await import("@/lib/firebase/server/firebaseAdmin");
+const FakeAdminTimestamp = (adminModule.default as any).firestore
+  .Timestamp as new (
+  s: number,
+  n: number,
+) => { seconds: number; nanoseconds: number };
+const fromMillisMock = (FakeAdminTimestamp as any).fromMillis as ReturnType<
+  typeof vi.fn
+>;
+
+import { reviveValue } from "@/lib/api/firestoreServer";
+
+describe("reviveValue", () => {
+  it("revives `{__ts}` shape via Timestamp.fromMillis", () => {
+    const result = reviveValue({ __ts: 1700000000000 });
+    expect(fromMillisMock).toHaveBeenCalledWith(1700000000000);
+    expect(result).toEqual({ kind: "fromMillis", ms: 1700000000000 });
+  });
+
+  it("revives client-SDK `{seconds, nanoseconds}` shape", () => {
+    const result = reviveValue({ seconds: 100, nanoseconds: 250 });
+    expect(result).toBeInstanceOf(FakeAdminTimestamp);
+    expect((result as FakeAdminTimestamp).seconds).toBe(100);
+    expect((result as FakeAdminTimestamp).nanoseconds).toBe(250);
+  });
+
+  it("revives admin-SDK `{_seconds, _nanoseconds}` shape", () => {
+    const result = reviveValue({ _seconds: 200, _nanoseconds: 750 });
+    expect(result).toBeInstanceOf(FakeAdminTimestamp);
+    expect((result as FakeAdminTimestamp).seconds).toBe(200);
+    expect((result as FakeAdminTimestamp).nanoseconds).toBe(750);
+  });
+
+  it("recurses into nested objects", () => {
+    const result = reviveValue({
+      title: "x",
+      meta: { createdAt: { __ts: 5 }, value: 7 },
+    });
+    expect(result).toMatchObject({
+      title: "x",
+      meta: { createdAt: { kind: "fromMillis", ms: 5 }, value: 7 },
+    });
+  });
+
+  it("recurses into arrays", () => {
+    const result = reviveValue([{ __ts: 1 }, { __ts: 2 }, "noop"]);
+    expect(result).toEqual([
+      { kind: "fromMillis", ms: 1 },
+      { kind: "fromMillis", ms: 2 },
+      "noop",
+    ]);
+  });
+
+  it("passes primitives through unchanged", () => {
+    expect(reviveValue("hello")).toBe("hello");
+    expect(reviveValue(42)).toBe(42);
+    expect(reviveValue(true)).toBe(true);
+    expect(reviveValue(null)).toBe(null);
+    expect(reviveValue(undefined)).toBe(undefined);
+  });
+
+  it("does not misidentify ordinary 2-key objects as timestamps", () => {
+    const obj = { firstName: "Riho", lastName: "Hagi" };
+    const result = reviveValue(obj);
+    expect(result).toEqual(obj);
+  });
+});

--- a/booking-app/tests/unit/server-db.unit.test.ts
+++ b/booking-app/tests/unit/server-db.unit.test.ts
@@ -183,10 +183,17 @@ describe("server/db", () => {
 
     const result = await fetchAllFutureBooking("tenant-1");
 
-    expect(mockWhere).toHaveBeenCalledWith("endDate", ">", expect.anything());
+    // After SSO migration the helper no longer goes through Firestore SDK
+    // `where()`; it passes a serializable WhereSpec straight to the API proxy.
     expect(mockClientFetchAllDataFromCollection).toHaveBeenCalledWith(
       "bookings",
-      [expect.objectContaining({ field: "endDate", operator: ">" })],
+      [
+        expect.objectContaining({
+          field: "endDate",
+          op: ">",
+          value: expect.objectContaining({ __ts: expect.any(Number) }),
+        }),
+      ],
       "tenant-1",
     );
     expect(result).toEqual([{ id: "booking" }]);


### PR DESCRIPTION
## Summary of Changes

The NYU SSO migration (#1424) removed Firebase Authentication, but the browser still talks to Firestore via the client SDK — which now has no auth token to send. Every client-side `clientFetchAllDataFromCollection` / `clientSaveDataToFirestore` etc. fails with `Missing or insufficient permissions`. Visible symptom: **the SuperAdmin / Admin / PA / Liaison context dropdown in the navbar disappears** because permission resolution silently falls back to empty arrays. Bookings, banned users, blackout periods etc. also fail to load on admin pages.

E2E hides this completely — `applyE2EMock*` short-circuits the helpers in `Provider.tsx` before any Firestore call is made, so #1424 went green.

This PR moves all client-side Firestore traffic through five new `/api/firestore/*` endpoints that authorize via NextAuth `auth()` and execute via `firebase-admin` (which bypasses Firestore security rules). Each `client*` helper in `lib/firebase/firebase.ts` keeps its existing signature so the ~20 call sites in `Provider.tsx`, `ServiceApproverUsers.tsx`, `BookingBlackoutPeriods.tsx`, etc. don't change — only the internals switch to `fetch()`.

### New API surface

| Endpoint | Replaces |
|---|---|
| `POST /api/firestore/list` | `clientFetchAllDataFromCollection`, `clientFetchAllDataFromCollectionWithLimitAndOffset`, `clientGetDataByCalendarEventId`, `clientGetFinalApproverEmailFromDatabase` |
| `POST /api/firestore/getDoc` | `clientGetTenantSchema` |
| `POST /api/firestore/paginated` | `getPaginatedData` (date range, search, cursor) |
| `POST /api/firestore/mutate` | `clientSaveDataToFirestore`, `clientUpdateDataInFirestore`, `clientDeleteDataFromFirestore` |
| `POST /api/firestore/userRights` | `clientSaveUserRightsData`, `clientDeleteUserRightsData`, `clientUpsertUserRightFlag`, `clientClearUserRightFlag` (legacy ADMINS / PAS → usersRights flag mapping) |

### Timestamp handling

`reviveValue` on the server reconstructs Firestore Timestamps from the three serialized shapes that arrive over the wire (`{__ts}`, `{seconds, nanoseconds}`, `{_seconds, _nanoseconds}`). `reviveTimestamps` on the client does the same in reverse so `.toDate()` / `.toMillis()` keep working on returned data.

### Call site touch-ups

Three places previously imported `where()` from `firebase/firestore`; they now pass plain `WhereSpec` objects (`{ field, op, value }`):
- `components/src/client/routes/admin/components/ServiceApproverUsers.tsx`
- `components/src/client/routes/hooks/useSortBookingHistory.tsx`
- `components/src/server/db.ts` (`fetchAllFutureBooking`)

### Why this approach over Firebase custom-token bridging

Re-introducing Firebase Auth via `signInWithCustomToken` would have kept the browser talking to Firestore directly, but it means maintaining two parallel auth systems and undoing the simplification that #1424 just shipped. Server-side proxying gives single-source-of-truth auth (NextAuth), lets us tighten Firestore rules to deny client reads in a follow-up, and folds into the existing pattern already used by `app/api/bookings/*` routes.

### Out of scope

- Provider.tsx fires ~9 fetches on every page mount (× React Strict Mode = ~18 in dev). This pattern existed pre-migration but was invisible because reads went straight to Firestore. Worth a separate cleanup PR.
- `app/api/getData/route.ts` ironically uses the client SDK server-side and is dead code; left untouched.
- Tightening Firestore security rules to `allow read: if false;` (admin SDK ignores rules) — also a follow-up.

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

### Tests

- All 1413 unit tests pass (97 files). Two existing files updated to the new fetch-based contract; one new file (`firestoreServer-reviveValue.unit.test.ts`) covers the Timestamp revive edge cases.
- Auth-gate smoke: all 5 endpoints return `401` when called without a session.
- Manual verification on dev: SuperAdmin dropdown appears, `/mc/super` opens, paginated booking list loads with date sort intact, `Invalid time value` errors on detail views are gone after the Timestamp revive fix.
- **E2E coverage gap noted but not addressed in this PR**: `applyE2EMock*` helpers bypass the Firestore call path entirely, so the E2E suite cannot detect this class of regression. Worth flagging separately — a Firestore emulator + real-rules test would close it.

## Screenshots / Video

Permission resolution is internal state with no clean visual diff (the bug = "dropdown is missing", the fix = "dropdown appears"). Verified manually against `dev` Firestore — `usersSuperAdmin` entry for `rh3555@nyu.edu` now resolves to `PagePermission.SUPER_ADMIN` instead of falling back to `BOOKING`.