### PR TITLE
fix(e2e): exclude outside-month days in date picker selector

### DIFF
--- a/booking-app/tests/e2e/helpers/test-utils.ts
+++ b/booking-app/tests/e2e/helpers/test-utils.ts
@@ -56,10 +56,15 @@ export async function selectTimeSlot(
       await datePicker.getByText(new RegExp(monthName)).waitFor();
     }
 
-    await datePicker
-      .getByRole("gridcell", { name: tomorrowDay, exact: true })
-      .first()
-      .click();
+    // Exclude outside-month leak days (e.g. when April's grid shows 3/29 in
+    // its leading row, `name: '29'` matches both 3/29 and 4/29). The disabled
+    // outside-month cell would otherwise win `.first()` and time out the click.
+    const tomorrowCell = datePicker
+      .locator(
+        ".MuiPickersDay-root:not(.Mui-disabled):not(.MuiPickersDay-dayOutsideMonth)",
+      )
+      .filter({ hasText: new RegExp(`^${tomorrowDay}$`) });
+    await tomorrowCell.first().click();
   }
 
   const calendar = page.locator('[data-testid="booking-calendar-wrapper"]');


### PR DESCRIPTION
## Summary of Changes

Every booking-flow E2E started failing today (2026-04-28) at `selectTimeSlot()` with a 45s timeout clicking "tomorrow" in the MUI DateCalendar.

The MUI grid renders neighbor-month days as disabled filler cells (e.g. April 2026's first row shows `3/29 3/30 3/31 4/1 4/2 4/3 4/4`). When tomorrow's day number happens to coincide with one of those filler days, the previous locator

```ts
.getByRole("gridcell", { name: tomorrowDay, exact: true }).first()
```

resolves to the disabled outside-month cell, and `.click()` times out. Today (`tomorrow = 29`) `4/29` and `3/29` both match `name: '29'`, and `.first()` picks `3/29`. This will recur every month around the boundary days (e.g. May 26-30, June 27-31, etc.) — not a one-off flake.

This PR switches to a locator that filters out `.Mui-disabled` and `.MuiPickersDay-dayOutsideMonth`, so only the in-month tomorrow cell matches:

```ts
const tomorrowCell = datePicker
  .locator(
    ".MuiPickersDay-root:not(.Mui-disabled):not(.MuiPickersDay-dayOutsideMonth)",
  )
  .filter({ hasText: new RegExp(`^${tomorrowDay}$`) });
await tomorrowCell.first().click();
```

`itp-test-utils.ts` reuses `selectTimeSlot` from `test-utils.ts`, so the single change covers both MC and ITP suites.

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [ ] I added or updated unit tests — N/A: this is a Playwright helper change for an E2E selector, not feature code. The fix is verified by the E2E suites turning green again.
- [ ] I attached screenshots or a video demonstrating the feature — N/A: no UI change. See PR #1403's failure logs (job 73437066248) for the timeout repro.
- [x] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [x] I requested a code review from at least one other teammate

## Screenshots / Video

N/A — see the failing-cell snippet from the original CI log:

```
locator resolved to <button disabled ...
  class="... MuiPickersDay-dayOutsideMonth">29</button>
data-timestamp="1774756800000"   // = 2026-03-29
```