### PR TITLE
fix(my-bookings): scope server-side fetch to user email for USER context

### DIFF
--- a/.github/workflows/deploy_development_app_engine.yml
+++ b/.github/workflows/deploy_development_app_engine.yml
@@ -81,6 +81,17 @@ jobs:
         run: |
           cd booking-app
           npm run build
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Deploy Firestore indexes
+        run: |
+          cd booking-app
+          firebase deploy --only firestore:indexes \
+            --project ${{ secrets.GCP_PROJECT_ID }} \
+            --non-interactive
+
       - name: Deploy to App Engine
         run: |
           cd booking-app

--- a/.github/workflows/deploy_development_app_engine.yml
+++ b/.github/workflows/deploy_development_app_engine.yml
@@ -83,7 +83,7 @@ jobs:
           npm run build
 
       - name: Install Firebase CLI
-        run: npm install -g firebase-tools
+        run: npm install -g firebase-tools@15.15.0
 
       - name: Deploy Firestore indexes
         run: |

--- a/.github/workflows/deploy_production_app_engine.yml
+++ b/.github/workflows/deploy_production_app_engine.yml
@@ -81,6 +81,17 @@ jobs:
         run: |
           cd booking-app
           npm run build
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Deploy Firestore indexes
+        run: |
+          cd booking-app
+          firebase deploy --only firestore:indexes \
+            --project ${{ secrets.GCP_PROJECT_ID }} \
+            --non-interactive
+
       - name: Deploy to App Engine
         run: |
           cd booking-app

--- a/.github/workflows/deploy_production_app_engine.yml
+++ b/.github/workflows/deploy_production_app_engine.yml
@@ -83,7 +83,7 @@ jobs:
           npm run build
 
       - name: Install Firebase CLI
-        run: npm install -g firebase-tools
+        run: npm install -g firebase-tools@15.15.0
 
       - name: Deploy Firestore indexes
         run: |

--- a/.github/workflows/deploy_staging_app_engine.yml
+++ b/.github/workflows/deploy_staging_app_engine.yml
@@ -81,6 +81,17 @@ jobs:
         run: |
           cd booking-app
           npm run build
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      - name: Deploy Firestore indexes
+        run: |
+          cd booking-app
+          firebase deploy --only firestore:indexes \
+            --project ${{ secrets.GCP_PROJECT_ID }} \
+            --non-interactive
+
       - name: Deploy to App Engine
         run: |
           cd booking-app

--- a/.github/workflows/deploy_staging_app_engine.yml
+++ b/.github/workflows/deploy_staging_app_engine.yml
@@ -83,7 +83,7 @@ jobs:
           npm run build
 
       - name: Install Firebase CLI
-        run: npm install -g firebase-tools
+        run: npm install -g firebase-tools@15.15.0
 
       - name: Deploy Firestore indexes
         run: |

--- a/booking-app/app/api/firestore/paginated/route.ts
+++ b/booking-app/app/api/firestore/paginated/route.ts
@@ -70,6 +70,15 @@ export async function POST(req: NextRequest) {
         q = q.where("startDate", "<=", admin.firestore.Timestamp.fromDate(end));
     }
 
+    // Scope to a single user's bookings when requested. The /my-bookings view
+    // sets this so the LIMIT-bounded paginated result set is filtered server-
+    // side instead of being filled by tenant-wide far-future bookings before
+    // the client gets to filter by email.
+    const userEmail = body.filters.userEmail?.trim();
+    if (userEmail) {
+      q = q.where("email", "==", userEmail);
+    }
+
     const searchQuery = body.filters.searchQuery?.trim();
     if (searchQuery) {
       // Search path: fetch with date filter only, then filter in-process.

--- a/booking-app/app/api/firestore/paginated/route.ts
+++ b/booking-app/app/api/firestore/paginated/route.ts
@@ -74,9 +74,14 @@ export async function POST(req: NextRequest) {
     // sets this so the LIMIT-bounded paginated result set is filtered server-
     // side instead of being filled by tenant-wide far-future bookings before
     // the client gets to filter by email.
-    const userEmail = body.filters.userEmail?.trim();
-    if (userEmail) {
-      q = q.where("email", "==", userEmail);
+    //
+    // The route is the server-side trust boundary: the email used for the
+    // filter is taken from the verified session, not the request body. The
+    // body field is treated as an opt-in flag — when present and non-empty,
+    // scope to the caller; otherwise return tenant-wide results as before.
+    const requestedUserEmail = body.filters.userEmail?.trim();
+    if (requestedUserEmail) {
+      q = q.where("email", "==", session.email);
     }
 
     const searchQuery = body.filters.searchQuery?.trim();

--- a/booking-app/components/src/client/routes/components/Provider.tsx
+++ b/booking-app/components/src/client/routes/components/Provider.tsx
@@ -365,6 +365,10 @@ export const DatabaseProvider = ({
         return Promise.resolve();
       }
 
+      // `filters.userEmail` is set by `useBookingFilters` when the active view
+      // is the USER /my-bookings tab, regardless of the caller's role. Forward
+      // it to the paginated route so a user's own booking isn't crowded out of
+      // the LIMIT-bounded result set by tenant-wide far-future bookings.
       const bookingsResponse: Booking[] = await fetchAllBookings(
         pagePermission,
         LIMIT,

--- a/booking-app/components/src/client/routes/components/bookingTable/hooks/useBookingFilters.ts
+++ b/booking-app/components/src/client/routes/components/bookingTable/hooks/useBookingFilters.ts
@@ -310,12 +310,20 @@ export function useBookingFilters(props: Props): BookingRow[] {
   }, []);
 
   useEffect(() => {
+    // On the USER /my-bookings tab, scope the server-side fetch to this user's
+    // own bookings. Without this, the paginated route's LIMIT-bounded result
+    // set is filled with tenant-wide far-future bookings (ordered by startDate
+    // desc) and the user's own booking is crowded out before the client-side
+    // `filterPageContext` ever sees it. Gated on `pageContext`, not the
+    // caller's role, because admins / PAs also use /my-bookings to see their
+    // own bookings.
     setFilters({
       dateRange: getDateRangeFromDateSelection(selectedDateRange),
       sortField: "startDate",
       searchQuery,
+      userEmail: pageContext === PageContextLevel.USER ? userEmail : undefined,
     });
-  }, [selectedDateRange, setFilters, searchQuery]);
+  }, [selectedDateRange, setFilters, searchQuery, pageContext, userEmail]);
 
   const rows: BookingRow[] = useMemo(
     () =>

--- a/booking-app/components/src/types.ts
+++ b/booking-app/components/src/types.ts
@@ -433,6 +433,8 @@ export type Filters = {
   dateRange: string | Date[];
   sortField: string;
   searchQuery?: string;
+  /** Set on the USER /my-bookings view to scope server-side fetch to one user. */
+  userEmail?: string;
 };
 
 export interface PreBanLog {

--- a/booking-app/firebase.json
+++ b/booking-app/firebase.json
@@ -5,5 +5,10 @@
     "frameworksBackend": {
       "region": "us-central1"
     }
-  }
+  },
+  "firestore": [
+    { "database": "(default)", "indexes": "firestore.indexes.json" },
+    { "database": "booking-app-staging", "indexes": "firestore.indexes.json" },
+    { "database": "booking-app-prod", "indexes": "firestore.indexes.json" }
+  ]
 }

--- a/booking-app/firestore.indexes.json
+++ b/booking-app/firestore.indexes.json
@@ -1,0 +1,21 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "mc-bookings",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "email", "order": "ASCENDING" },
+        { "fieldPath": "startDate", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "itp-bookings",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "email", "order": "ASCENDING" },
+        { "fieldPath": "startDate", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/booking-app/lib/api/firestoreShared.ts
+++ b/booking-app/lib/api/firestoreShared.ts
@@ -56,6 +56,12 @@ export type PaginatedRequest = {
     dateRange?: Array<string | null> | string;
     sortField: string;
     searchQuery?: string;
+    /**
+     * Limits results to bookings whose `email` field matches. Used by the
+     * USER `/my-bookings` view so a regular user's own booking isn't crowded
+     * out of the LIMIT-bounded result set by tenant-wide far-future bookings.
+     */
+    userEmail?: string;
   };
   limit?: number;
   /** lastVisible[sortField] value used for startAfter cursor. */

--- a/booking-app/lib/firebase/firebase.ts
+++ b/booking-app/lib/firebase/firebase.ts
@@ -289,7 +289,8 @@ export const getPaginatedData = async <T>(
       filters: {
         dateRange: dateRange as any,
         sortField: filters.sortField,
-        searchQuery: (filters as any).searchQuery,
+        searchQuery: filters.searchQuery,
+        userEmail: filters.userEmail,
       },
       limit: itemsPerPage,
       lastVisible: serializedLast,

--- a/booking-app/tests/unit/api-firestore-paginated.unit.test.ts
+++ b/booking-app/tests/unit/api-firestore-paginated.unit.test.ts
@@ -1,0 +1,181 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type WhereCall = { field: string; op: string; value: unknown };
+
+const mocks = vi.hoisted(() => {
+  const whereCalls: WhereCall[] = [];
+  let limitValue: number | undefined;
+  let orderByField: string | undefined;
+
+  const makeQuery = () => {
+    const q: any = {
+      where: vi.fn((field: string, op: string, value: unknown) => {
+        whereCalls.push({ field, op, value });
+        return q;
+      }),
+      orderBy: vi.fn((field: string) => {
+        orderByField = field;
+        return q;
+      }),
+      startAfter: vi.fn(() => q),
+      limit: vi.fn((n: number) => {
+        limitValue = n;
+        return q;
+      }),
+      get: vi.fn(async () => ({ docs: [] })),
+    };
+    return q;
+  };
+
+  const mockFirestoreFn = Object.assign(
+    () => ({
+      collection: vi.fn(() => makeQuery()),
+    }),
+    {
+      Timestamp: {
+        fromDate: (d: Date) => ({ __ts: d.getTime() }),
+        fromMillis: (n: number) => ({ __ts: n }),
+      },
+    },
+  );
+
+  return {
+    whereCalls,
+    getLimit: () => limitValue,
+    getOrderByField: () => orderByField,
+    reset: () => {
+      whereCalls.length = 0;
+      limitValue = undefined;
+      orderByField = undefined;
+    },
+    mockRequireSession: vi.fn(),
+    mockAuthorizeRead: vi.fn(),
+    mockFirestoreFn,
+  };
+});
+
+vi.mock("@/lib/api/requireSession", () => ({
+  requireSession: () => mocks.mockRequireSession(),
+}));
+
+vi.mock("@/lib/api/authz", () => ({
+  authorizeRead: (...args: unknown[]) => mocks.mockAuthorizeRead(...args),
+  isAccessDenied: (d: { ok: boolean }) => d.ok === false,
+}));
+
+vi.mock("@/lib/firebase/server/firebaseAdmin", () => ({
+  default: {
+    firestore: mocks.mockFirestoreFn,
+  },
+}));
+
+import { POST } from "@/app/api/firestore/paginated/route";
+
+const request = (body: object) =>
+  new NextRequest("http://localhost:3000/api/firestore/paginated", {
+    method: "POST",
+    headers: new Headers({ "Content-Type": "application/json" }),
+    body: JSON.stringify(body),
+  });
+
+describe("POST /api/firestore/paginated — userEmail filter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.reset();
+    mocks.mockRequireSession.mockResolvedValue({
+      email: "alice@nyu.edu",
+      netId: "alice",
+    });
+    mocks.mockAuthorizeRead.mockResolvedValue({ ok: true, role: "BOOKING" });
+  });
+
+  it("applies where('email','==',userEmail) when filters.userEmail is set", async () => {
+    const res = await POST(
+      request({
+        collection: "bookings",
+        tenant: "mc",
+        filters: {
+          dateRange: [new Date("2026-01-01").toISOString(), null],
+          sortField: "startDate",
+          userEmail: "alice@nyu.edu",
+        },
+        limit: 10,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const emailFilter = mocks.whereCalls.find((w) => w.field === "email");
+    expect(emailFilter).toEqual({
+      field: "email",
+      op: "==",
+      value: "alice@nyu.edu",
+    });
+  });
+
+  it("does not apply email filter when filters.userEmail is absent", async () => {
+    const res = await POST(
+      request({
+        collection: "bookings",
+        tenant: "mc",
+        filters: {
+          dateRange: [new Date("2026-01-01").toISOString(), null],
+          sortField: "startDate",
+        },
+        limit: 10,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mocks.whereCalls.find((w) => w.field === "email")).toBeUndefined();
+  });
+
+  it("trims whitespace and skips filter for empty userEmail", async () => {
+    const res = await POST(
+      request({
+        collection: "bookings",
+        tenant: "mc",
+        filters: {
+          dateRange: [new Date("2026-01-01").toISOString(), null],
+          sortField: "startDate",
+          userEmail: "   ",
+        },
+        limit: 10,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mocks.whereCalls.find((w) => w.field === "email")).toBeUndefined();
+  });
+
+  it("applies email filter on the search path as well", async () => {
+    const res = await POST(
+      request({
+        collection: "bookings",
+        tenant: "mc",
+        filters: {
+          dateRange: [new Date("2026-01-01").toISOString(), null],
+          sortField: "startDate",
+          searchQuery: "title",
+          userEmail: "alice@nyu.edu",
+        },
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const emailFilter = mocks.whereCalls.find((w) => w.field === "email");
+    expect(emailFilter?.value).toBe("alice@nyu.edu");
+  });
+
+  it("returns 401 without session", async () => {
+    mocks.mockRequireSession.mockResolvedValue(null);
+    const res = await POST(
+      request({
+        collection: "bookings",
+        tenant: "mc",
+        filters: { sortField: "startDate", userEmail: "alice@nyu.edu" },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/booking-app/tests/unit/api-firestore-paginated.unit.test.ts
+++ b/booking-app/tests/unit/api-firestore-paginated.unit.test.ts
@@ -90,7 +90,7 @@ describe("POST /api/firestore/paginated — userEmail filter", () => {
     mocks.mockAuthorizeRead.mockResolvedValue({ ok: true, role: "BOOKING" });
   });
 
-  it("applies where('email','==',userEmail) when filters.userEmail is set", async () => {
+  it("applies where('email','==',session.email) when filters.userEmail is set", async () => {
     const res = await POST(
       request({
         collection: "bookings",
@@ -111,6 +111,28 @@ describe("POST /api/firestore/paginated — userEmail filter", () => {
       op: "==",
       value: "alice@nyu.edu",
     });
+  });
+
+  it("ignores client-supplied userEmail and uses session email instead", async () => {
+    // The route is the trust boundary: a caller can opt into per-user scoping,
+    // but the actual email used for the filter is taken from the verified
+    // session, never the request body.
+    const res = await POST(
+      request({
+        collection: "bookings",
+        tenant: "mc",
+        filters: {
+          dateRange: [new Date("2026-01-01").toISOString(), null],
+          sortField: "startDate",
+          userEmail: "someone-else@nyu.edu",
+        },
+        limit: 10,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const emailFilter = mocks.whereCalls.find((w) => w.field === "email");
+    expect(emailFilter?.value).toBe("alice@nyu.edu");
   });
 
   it("does not apply email filter when filters.userEmail is absent", async () => {
@@ -148,7 +170,7 @@ describe("POST /api/firestore/paginated — userEmail filter", () => {
     expect(mocks.whereCalls.find((w) => w.field === "email")).toBeUndefined();
   });
 
-  it("applies email filter on the search path as well", async () => {
+  it("applies email filter on the search path as well, using session email", async () => {
     const res = await POST(
       request({
         collection: "bookings",


### PR DESCRIPTION
## Summary of Changes

The `/my-bookings` (USER context) tab was silently returning zero results: a regular user's own bookings — including the one they just submitted today — never appeared in the table.

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [x] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video
<img width="1442" height="404" alt="Screenshot 2026-04-28 at 4 52 14 PM" src="https://github.com/user-attachments/assets/0180096e-5fcb-4474-9651-cff0becc7d33" />

