### PR TITLE
ci: unblock App Engine deploy + surface real Firestore index error

### DIFF
--- a/.github/workflows/deploy_development_app_engine.yml
+++ b/.github/workflows/deploy_development_app_engine.yml
@@ -85,11 +85,18 @@ jobs:
       - name: Install Firebase CLI
         run: npm install -g firebase-tools@15.15.0
 
+      # Index deploy is currently a non-blocking step: if it fails, the App
+      # Engine deploy still proceeds so application updates aren't held up by
+      # an index sync issue. The `--debug` flag prints the underlying API
+      # error so the next failure surfaces a real diagnostic instead of
+      # firebase-tools' generic "An unexpected error has occurred" wrapper.
       - name: Deploy Firestore indexes
+        continue-on-error: true
         run: |
           cd booking-app
           firebase deploy --only firestore:indexes \
             --project ${{ secrets.GCP_PROJECT_ID }} \
+            --debug \
             --non-interactive
 
       - name: Deploy to App Engine

--- a/.github/workflows/deploy_production_app_engine.yml
+++ b/.github/workflows/deploy_production_app_engine.yml
@@ -85,11 +85,18 @@ jobs:
       - name: Install Firebase CLI
         run: npm install -g firebase-tools@15.15.0
 
+      # Index deploy is currently a non-blocking step: if it fails, the App
+      # Engine deploy still proceeds so application updates aren't held up by
+      # an index sync issue. The `--debug` flag prints the underlying API
+      # error so the next failure surfaces a real diagnostic instead of
+      # firebase-tools' generic "An unexpected error has occurred" wrapper.
       - name: Deploy Firestore indexes
+        continue-on-error: true
         run: |
           cd booking-app
           firebase deploy --only firestore:indexes \
             --project ${{ secrets.GCP_PROJECT_ID }} \
+            --debug \
             --non-interactive
 
       - name: Deploy to App Engine

--- a/.github/workflows/deploy_staging_app_engine.yml
+++ b/.github/workflows/deploy_staging_app_engine.yml
@@ -85,11 +85,18 @@ jobs:
       - name: Install Firebase CLI
         run: npm install -g firebase-tools@15.15.0
 
+      # Index deploy is currently a non-blocking step: if it fails, the App
+      # Engine deploy still proceeds so application updates aren't held up by
+      # an index sync issue. The `--debug` flag prints the underlying API
+      # error so the next failure surfaces a real diagnostic instead of
+      # firebase-tools' generic "An unexpected error has occurred" wrapper.
       - name: Deploy Firestore indexes
+        continue-on-error: true
         run: |
           cd booking-app
           firebase deploy --only firestore:indexes \
             --project ${{ secrets.GCP_PROJECT_ID }} \
+            --debug \
             --non-interactive
 
       - name: Deploy to App Engine


### PR DESCRIPTION
## Summary of Changes

PR #1443 wired \`firebase deploy --only firestore:indexes\` into the three App Engine deploy workflows. The step has been failing with firebase-tools' generic \`An unexpected error has occurred\` wrapper, and because it sat before \`Deploy to App Engine\`, the App Engine step has been skipped on every push since the merge — meaning the USER \`/my-bookings\` fix from #1443 isn't actually live on dev (and would be blocked from reaching staging/prod the same way).

This PR:

- Adds \`continue-on-error: true\` to the index deploy step so a failed index sync doesn't gate the application deploy. Application updates can ship while the index issue is investigated.
- Adds \`--debug\` to the firebase deploy command so the next failure surfaces the underlying API error (currently masked by firebase-tools).

The two IAM roles that were missing (\`datastore.indexAdmin\` and \`serviceusage.serviceUsageConsumer\`) have already been granted to the GitHub Actions service account on \`flowing-mantis-389917\`, so authorization is no longer the blocker. The remaining failure is likely a multi-database \`firebase.json\` parsing issue in firebase-tools 15.15.0, or a permission scope that doesn't surface in the local credential check — \`--debug\` will tell us which.

Once the real error is visible from the next run, a follow-up PR will fix the index deploy properly (most likely by either splitting the \`firestore\` array per environment or switching to \`gcloud firestore indexes composite create\`).

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [ ] I thoroughly tested this feature locally
- [ ] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [x] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video

CI-only change; no UI surface. Verification path:

1. Merge this PR → triggers the development deploy workflow on push to main.
2. \`Deploy Firestore indexes\` step runs with \`--debug\`.
3. If it fails, the verbose log shows the actual API response (instead of \`An unexpected error\`).
4. \`Deploy to App Engine\` proceeds regardless, so the application updates from #1443 reach dev.

The follow-up fix will be informed by what the \`--debug\` log shows.