### PR TITLE
ci: deploy Firestore indexes via gcloud instead of firebase-tools

### DIFF
--- a/.github/workflows/deploy_development_app_engine.yml
+++ b/.github/workflows/deploy_development_app_engine.yml
@@ -82,22 +82,44 @@ jobs:
           cd booking-app
           npm run build
 
-      - name: Install Firebase CLI
-        run: npm install -g firebase-tools@15.15.0
-
-      # Index deploy is currently a non-blocking step: if it fails, the App
-      # Engine deploy still proceeds so application updates aren't held up by
-      # an index sync issue. The `--debug` flag prints the underlying API
-      # error so the next failure surfaces a real diagnostic instead of
-      # firebase-tools' generic "An unexpected error has occurred" wrapper.
+      # Sync Firestore composite indexes for this environment's database.
+      # Uses gcloud directly (not `firebase deploy`) because firebase-tools
+      # 15.x throws TypeError on the multi-database `firestore` array in
+      # firebase.json, masking real failures behind a generic wrapper.
+      # gcloud is already authenticated via setup-gcloud above.
       - name: Deploy Firestore indexes
-        continue-on-error: true
+        timeout-minutes: 20
         run: |
-          cd booking-app
-          firebase deploy --only firestore:indexes \
-            --project ${{ secrets.GCP_PROJECT_ID }} \
-            --debug \
-            --non-interactive
+          DB='(default)'
+          PROJECT="${{ secrets.GCP_PROJECT_ID }}"
+
+          create_index() {
+            local CG="$1"
+            echo "Ensuring composite index on $CG (email asc, startDate desc) in $DB..."
+            set +e
+            OUTPUT=$(gcloud firestore indexes composite create \
+              --collection-group="$CG" \
+              --database="$DB" \
+              --project="$PROJECT" \
+              --field-config=field-path=email,order=ascending \
+              --field-config=field-path=startDate,order=descending \
+              --quiet 2>&1)
+            EXIT=$?
+            set -e
+            if [ $EXIT -ne 0 ]; then
+              if echo "$OUTPUT" | grep -qi "ALREADY_EXISTS"; then
+                echo "Index already exists for $CG, skipping"
+                return 0
+              fi
+              echo "Failed to create index for $CG:"
+              echo "$OUTPUT"
+              return 1
+            fi
+            echo "$OUTPUT"
+          }
+
+          create_index mc-bookings
+          create_index itp-bookings
 
       - name: Deploy to App Engine
         run: |

--- a/.github/workflows/deploy_production_app_engine.yml
+++ b/.github/workflows/deploy_production_app_engine.yml
@@ -82,22 +82,44 @@ jobs:
           cd booking-app
           npm run build
 
-      - name: Install Firebase CLI
-        run: npm install -g firebase-tools@15.15.0
-
-      # Index deploy is currently a non-blocking step: if it fails, the App
-      # Engine deploy still proceeds so application updates aren't held up by
-      # an index sync issue. The `--debug` flag prints the underlying API
-      # error so the next failure surfaces a real diagnostic instead of
-      # firebase-tools' generic "An unexpected error has occurred" wrapper.
+      # Sync Firestore composite indexes for this environment's database.
+      # Uses gcloud directly (not `firebase deploy`) because firebase-tools
+      # 15.x throws TypeError on the multi-database `firestore` array in
+      # firebase.json, masking real failures behind a generic wrapper.
+      # gcloud is already authenticated via setup-gcloud above.
       - name: Deploy Firestore indexes
-        continue-on-error: true
+        timeout-minutes: 20
         run: |
-          cd booking-app
-          firebase deploy --only firestore:indexes \
-            --project ${{ secrets.GCP_PROJECT_ID }} \
-            --debug \
-            --non-interactive
+          DB='booking-app-prod'
+          PROJECT="${{ secrets.GCP_PROJECT_ID }}"
+
+          create_index() {
+            local CG="$1"
+            echo "Ensuring composite index on $CG (email asc, startDate desc) in $DB..."
+            set +e
+            OUTPUT=$(gcloud firestore indexes composite create \
+              --collection-group="$CG" \
+              --database="$DB" \
+              --project="$PROJECT" \
+              --field-config=field-path=email,order=ascending \
+              --field-config=field-path=startDate,order=descending \
+              --quiet 2>&1)
+            EXIT=$?
+            set -e
+            if [ $EXIT -ne 0 ]; then
+              if echo "$OUTPUT" | grep -qi "ALREADY_EXISTS"; then
+                echo "Index already exists for $CG, skipping"
+                return 0
+              fi
+              echo "Failed to create index for $CG:"
+              echo "$OUTPUT"
+              return 1
+            fi
+            echo "$OUTPUT"
+          }
+
+          create_index mc-bookings
+          create_index itp-bookings
 
       - name: Deploy to App Engine
         run: |

--- a/.github/workflows/deploy_staging_app_engine.yml
+++ b/.github/workflows/deploy_staging_app_engine.yml
@@ -82,22 +82,44 @@ jobs:
           cd booking-app
           npm run build
 
-      - name: Install Firebase CLI
-        run: npm install -g firebase-tools@15.15.0
-
-      # Index deploy is currently a non-blocking step: if it fails, the App
-      # Engine deploy still proceeds so application updates aren't held up by
-      # an index sync issue. The `--debug` flag prints the underlying API
-      # error so the next failure surfaces a real diagnostic instead of
-      # firebase-tools' generic "An unexpected error has occurred" wrapper.
+      # Sync Firestore composite indexes for this environment's database.
+      # Uses gcloud directly (not `firebase deploy`) because firebase-tools
+      # 15.x throws TypeError on the multi-database `firestore` array in
+      # firebase.json, masking real failures behind a generic wrapper.
+      # gcloud is already authenticated via setup-gcloud above.
       - name: Deploy Firestore indexes
-        continue-on-error: true
+        timeout-minutes: 20
         run: |
-          cd booking-app
-          firebase deploy --only firestore:indexes \
-            --project ${{ secrets.GCP_PROJECT_ID }} \
-            --debug \
-            --non-interactive
+          DB='booking-app-staging'
+          PROJECT="${{ secrets.GCP_PROJECT_ID }}"
+
+          create_index() {
+            local CG="$1"
+            echo "Ensuring composite index on $CG (email asc, startDate desc) in $DB..."
+            set +e
+            OUTPUT=$(gcloud firestore indexes composite create \
+              --collection-group="$CG" \
+              --database="$DB" \
+              --project="$PROJECT" \
+              --field-config=field-path=email,order=ascending \
+              --field-config=field-path=startDate,order=descending \
+              --quiet 2>&1)
+            EXIT=$?
+            set -e
+            if [ $EXIT -ne 0 ]; then
+              if echo "$OUTPUT" | grep -qi "ALREADY_EXISTS"; then
+                echo "Index already exists for $CG, skipping"
+                return 0
+              fi
+              echo "Failed to create index for $CG:"
+              echo "$OUTPUT"
+              return 1
+            fi
+            echo "$OUTPUT"
+          }
+
+          create_index mc-bookings
+          create_index itp-bookings
 
       - name: Deploy to App Engine
         run: |

--- a/booking-app/firebase.json
+++ b/booking-app/firebase.json
@@ -5,10 +5,5 @@
     "frameworksBackend": {
       "region": "us-central1"
     }
-  },
-  "firestore": [
-    { "database": "(default)", "indexes": "firestore.indexes.json" },
-    { "database": "booking-app-staging", "indexes": "firestore.indexes.json" },
-    { "database": "booking-app-prod", "indexes": "firestore.indexes.json" }
-  ]
+  }
 }


### PR DESCRIPTION
## Summary of Changes

Replace the \`firebase deploy --only firestore:indexes\` step in each App Engine deploy workflow with a direct \`gcloud firestore indexes composite create\` call.

### Why

firebase-tools 15.15.0 throws

\`\`\`
TypeError: Cannot read properties of undefined (reading 'map')
    at deployIndexes (.../firebase-tools/lib/deploy/firestore/deploy.js:24)
\`\`\`

when handed the multi-database \`firestore\` array in \`firebase.json\`. The CLI hides this behind a generic \"An unexpected error has occurred\" wrapper, so the index step has been silently failing on every deploy since PR #1443. PR #1445 added \`--debug\` + \`continue-on-error\` to surface the real error and unblock App Engine deploys, which is how we caught it. The \`continue-on-error\` was masking the failure as \`success\` for the overall workflow conclusion.

### What

- Each workflow now uses \`gcloud firestore indexes composite create\` for its own database (\`(default)\` for dev, \`booking-app-staging\`, \`booking-app-prod\`). gcloud is already authenticated via \`setup-gcloud@v2\` and the GitHub Actions service account has \`roles/datastore.indexAdmin\` + \`roles/serviceusage.serviceUsageConsumer\`.
- \`ALREADY_EXISTS\` is grep-matched and treated as an idempotent no-op; any other non-zero exit fails the step.
- \`continue-on-error: true\` is removed — index sync failures now block deploys again, as they should.
- \`timeout-minutes: 20\` caps the step in case a build hangs.
- \`Install Firebase CLI\` step is dropped (no longer needed).
- \`firebase.json\`'s \`firestore\` section is dropped since nothing consumes it.
- \`firestore.indexes.json\` is kept as a spec file so the index list stays version-controlled even though the deploy is imperative.

### Verified locally

\`\`\`
$ gcloud firestore indexes composite create --collection-group=mc-bookings ... --database='(default)' ...
Create request issued
Waiting for operation [...] to complete...
.....................................done.
Created index [CICAgJim14AK].

$ gcloud firestore indexes composite create --collection-group=mc-bookings ... --database='(default)' ...   # second run
ERROR: (gcloud.firestore.indexes.composite.create) ALREADY_EXISTS: index already exists
$ echo $?
1
\`\`\`

The dev \`(default)\` database already has both \`mc-bookings\` and \`itp-bookings\` composite indexes (state: READY) from the local verification, so this PR's dev deploy will hit the idempotent path. Staging and prod will create their indexes on first deploy after merge (each takes 5–10 min build).

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [ ] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

Unit tests not added because this is a CI-only workflow change with no application code touched. Verification path is deploy-time observation: index step exits 0 on idempotent re-run, fails loudly on real errors, and \`/<tenant>/my-bookings\` returns 200 (not FAILED_PRECONDITION) after merge.

## Screenshots / Video

CI-only change; no UI surface.