### PR TITLE
chore(pr-template): require Schema Changes section in every PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,19 @@
 
 <!-- Briefly describe what was changed and why -->
 
+## Schema Changes
+
+<!-- Required for every PR. Pick exactly one. -->
+
+- [ ] No tenant schema changes
+- [ ] Schema changed (describe below)
+
+<!-- If schema changed, list affected tenants and what changed.
+Example:
+- mc: added `showCleaning` flag
+- itp: added new resource (roomId 999)
+-->
+
 ## Checklist
 
 - [ ] I linked relevant issue(s) in the Development section


### PR DESCRIPTION
## Summary of Changes

Add a required \`Schema Changes\` section to the PR template so every PR explicitly states whether it touches \`tenantSchema\` and, if so, what changed.

The tenant schema lives in Firestore and currently drifts between local dev, the dev environment, staging, and prod with no audit trail in PR history. The new section forces reviewers and release owners to confirm:

- whether a PR contains schema changes at all
- which tenants are affected
- what the change is

so that scanning recent merged PRs is enough to know what schema diffs are in the pipeline before promoting dev → staging → prod.

## Schema Changes

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [ ] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

Unit tests not added — this is a markdown template change.

## Screenshots / Video

Documentation-only change; no UI surface. The new section will appear at the top of every newly opened PR's description, between \`Summary of Changes\` and \`Checklist\`.