### PR TITLE
fix(admin): raise booking page LIMIT from 10 to 500

### DIFF
--- a/booking-app/components/src/client/routes/components/Provider.tsx
+++ b/booking-app/components/src/client/routes/components/Provider.tsx
@@ -189,7 +189,7 @@ export const DatabaseProvider = ({
     dateRange: "",
     sortField: "startDate",
   });
-  const LIMIT = 10;
+  const LIMIT = 500;
 
   const { user } = useAuth();
   const netId = useMemo(() => userEmail?.split("@")[0], [userEmail]);


### PR DESCRIPTION
## Summary of Changes

Fixes a regression where the admin / liaison / PA / services bookings tables only show **the first 10 rows**. Bumps `LIMIT` in `Provider.tsx` from `10` to `500`.

### Why this surfaced now

- `LIMIT = 10` has existed since 2024-12 (`f301ba4e` "Progress on showing previous bookings"). It was originally paired with a **Load More** button that advanced the `lastItem` cursor.
- In 2025-04, **#682 "Replace TableRow with DataGrid"** swapped the table UI to MUI DataGrid and dropped the Load More button. `loadMoreEnabled` / `setLoadMoreEnabled` / `lastItem` stayed in `Provider`, but no UI calls them anymore — they became dead state.
- This was not visible to users because the old `getPaginatedData` (client Firestore SDK) **accepted `itemsPerPage` but never applied `.limit()` to the Firestore query**. `getDocs(q)` returned every doc matching the dateRange filter, so the table looked complete.
- **#1431 "fix: route client-side Firestore reads/writes through API + Admin SDK"** (merged 2026-04-23) routed reads through `/api/firestore/paginated` (Admin SDK), and the server endpoint honors `limit` correctly. From that point on, only the first 10 rows ever come back — which is what users are now reporting.

### Fix

Minimal change: raise `LIMIT` to `500` so a realistic tenant's full result set fits in the first page. Behavior matches what users effectively had pre-#1431. The `loadMoreEnabled` / `lastItem` dead code is left for a separate cleanup.

### Scope

- All bookings tables (admin / liaison / PA / services / user) — they share the same `fetchBookings` path in `Provider.tsx`.
- DataGrid client-side `pageSize = 100` in `Bookings.tsx:626` is unchanged; client pagination still works on the larger fetched set.

## Schema Changes

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description) — single-constant change, no new logic to cover; behavior matches pre-#1431
- [x] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [x] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video

<img width="3840" height="11402" alt="FireShot Capture 089 - Media Commons Booking -  localhost" src="https://github.com/user-attachments/assets/b97db9e4-806c-4c7e-a3ac-7ddf160961db" />
