### PR TITLE
Add tenant schema CLI backup to Firestore with dry-run local export

### DIFF
--- a/booking-app/docs/SCHEMA_SYNC_GUIDE.md
+++ b/booking-app/docs/SCHEMA_SYNC_GUIDE.md
@@ -55,3 +55,7 @@ resources: defineObjectArrayWithDefaults(defaultResource),
 ```
 
 This allows the merge process to automatically apply defaults to each item in the array.
+
+## See also
+
+- [Tenant schema CLI backup](./TENANT_SCHEMA_BACKUP.md) — back up `tenantSchema` to `tenantSchemaBackup`; use `--dry-run` for local JSON only.

--- a/booking-app/docs/TENANT_SCHEMA_BACKUP.md
+++ b/booking-app/docs/TENANT_SCHEMA_BACKUP.md
@@ -1,0 +1,64 @@
+# Tenant schema backup (CLI)
+
+Backs up Firestore **`tenantSchema`** documents into the **`tenantSchemaBackup`** collection—the same place **`syncTenantSchemas`** and **`copyCollection`** write before mutating schemas.
+
+## Behavior
+
+| Mode | What happens |
+|------|----------------|
+| **Default** (`npm run backup:tenant-schema`) | Writes one new document per tenant into **`tenantSchemaBackup`**, using `backupTenantSchemaDocument` / `backupTenantSchemaCollection` from `scripts/tenantSchemaBackup.js`. Backup type label in doc ids: **`cli-backup`**. |
+| **`--dry-run`** | Does **not** write to Firestore. Exports JSON under **`scripts/output/tenant-schema-backup/<timestamp>/`** (same naming pattern as Firestore backup ids) plus **`manifest.json`** for inspection. |
+
+## Prerequisites
+
+- Run commands from the `booking-app` directory (where `package.json` lives).
+- `.env.local` must define Firebase Admin credentials (`FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY`), same as `npm run sync:schemas`.
+
+## Usage
+
+```bash
+# Back up all tenantSchema docs → tenantSchemaBackup (development / default DB)
+npm run backup:tenant-schema
+
+# Dry run: write JSON locally only (no Firestore writes)
+npm run backup:tenant-schema -- --dry-run
+
+# Staging or production Firestore database
+npm run backup:tenant-schema -- --database staging
+npm run backup:tenant-schema -- --database production
+
+# Single tenant (one backup document in tenantSchemaBackup)
+npm run backup:tenant-schema -- --tenant mc
+
+# With --dry-run only: optional output directory (default: scripts/output/tenant-schema-backup/<timestamp>)
+npm run backup:tenant-schema -- --dry-run --output-dir ./my-preview
+```
+
+`--output-dir` applies only when **`--dry-run`** is set; it is ignored for real Firestore backups.
+
+## Firestore backup ids
+
+Real backups use the same id format as other tooling:  
+`<tenantId>-backup-cli-backup-<timestamp>`  
+(see `createBackupDocId` in `scripts/tenantSchemaBackup.js`).
+
+## Local dry-run output
+
+- Folder: `scripts/output/tenant-schema-backup/<backup-timestamp>/`
+- Files: `<backupDocId>.json` (serialized Firestore types use `__firestore*` markers for readability)
+- `manifest.json` lists tenants and files
+
+`scripts/output/` is gitignored.
+
+## Related
+
+- [Tenant schema sync guide](./SCHEMA_SYNC_GUIDE.md)
+- `scripts/tenantSchemaBackup.js`
+- `scripts/syncTenantSchemas.ts` — uses backup type `sync-defaults`
+- `scripts/copyCollection.js` — uses backup type `copy`
+
+## Help
+
+```bash
+npm run backup:tenant-schema -- --help
+```

--- a/booking-app/package.json
+++ b/booking-app/package.json
@@ -18,7 +18,8 @@
     "copy:production:dry-run": "node scripts/copyCollection.js --source-database development --target-database production --source-collection tenantSchema --target-collection tenantSchema --dry-run --report-file dry-run-production-details.json",
     "mergeUsers": "node scripts/mergeUsersCollections.js",
     "sync:schemas": "npx ts-node --transpile-only --compiler-options '{\"module\":\"commonjs\",\"jsx\":\"react\"}' scripts/syncTenantSchemas.ts",
-    "sync:schemas:dry-run": "npx ts-node --transpile-only --compiler-options '{\"module\":\"commonjs\",\"jsx\":\"react\"}' scripts/syncTenantSchemas.ts --dry-run"
+    "sync:schemas:dry-run": "npx ts-node --transpile-only --compiler-options '{\"module\":\"commonjs\",\"jsx\":\"react\"}' scripts/syncTenantSchemas.ts --dry-run",
+    "backup:tenant-schema": "npx ts-node --transpile-only --compiler-options '{\"module\":\"commonjs\",\"jsx\":\"react\"}' scripts/backupTenantSchemaToDisk.ts"
   },
   "dependencies": {
     "@emotion/styled": "^11.13.0",

--- a/booking-app/scripts/README.md
+++ b/booking-app/scripts/README.md
@@ -1,0 +1,5 @@
+# Scripts
+
+Long-form documentation for scripts lives under `docs/`.
+
+- **[Tenant schema CLI backup](../docs/TENANT_SCHEMA_BACKUP.md)** — `npm run backup:tenant-schema`, `backupTenantSchemaToDisk.ts`

--- a/booking-app/scripts/backupTenantSchemaToDisk.ts
+++ b/booking-app/scripts/backupTenantSchemaToDisk.ts
@@ -1,0 +1,291 @@
+/**
+ * Back up Firestore `tenantSchema` to `tenantSchemaBackup` (same as sync/copy).
+ *
+ * Default: writes via tenantSchemaBackup.js (Firestore).
+ * With --dry-run: writes JSON under scripts/output/ only (no Firestore writes).
+ *
+ * Documentation: docs/TENANT_SCHEMA_BACKUP.md
+ */
+
+require("dotenv").config({ path: ".env.local" });
+import * as admin from "firebase-admin";
+import * as fs from "fs";
+import * as path from "path";
+
+const {
+  TENANT_SCHEMA_COLLECTION,
+  TENANT_SCHEMA_BACKUP_COLLECTION,
+  formatBackupTimestamp,
+  createBackupDocId,
+  backupTenantSchemaDocument,
+  backupTenantSchemaCollection,
+} = require("./tenantSchemaBackup");
+
+/** Backup type in document ids; distinct from sync-defaults / copy. */
+const BACKUP_TYPE_CLI = "cli-backup";
+
+const DATABASES = {
+  development: "default",
+  staging: "booking-app-staging",
+  production: "booking-app-prod",
+} as const;
+
+type DatabaseEnv = keyof typeof DATABASES;
+
+interface BackupOptions {
+  database: DatabaseEnv;
+  tenant?: string;
+  outputDir?: string;
+  dryRun: boolean;
+}
+
+function serializeValue(val: unknown): unknown {
+  if (val === null || val === undefined) {
+    return val;
+  }
+  if (typeof val === "bigint") {
+    return val.toString();
+  }
+  if (val instanceof admin.firestore.Timestamp) {
+    return {
+      __firestoreTimestamp: true,
+      iso: val.toDate().toISOString(),
+    };
+  }
+  if (val instanceof admin.firestore.GeoPoint) {
+    return {
+      __firestoreGeoPoint: true,
+      latitude: val.latitude,
+      longitude: val.longitude,
+    };
+  }
+  if (val instanceof admin.firestore.DocumentReference) {
+    return { __firestoreDocumentReference: true, path: val.path };
+  }
+  if (Array.isArray(val)) {
+    return val.map(serializeValue);
+  }
+  if (typeof val === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(val as Record<string, unknown>)) {
+      out[k] = serializeValue(v);
+    }
+    return out;
+  }
+  return val;
+}
+
+function parseArgs(): BackupOptions {
+  const args = process.argv.slice(2);
+  const options: BackupOptions = {
+    database: "development",
+    dryRun: false,
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    switch (args[i]) {
+      case "--dry-run":
+        options.dryRun = true;
+        break;
+      case "--tenant":
+        options.tenant = args[++i];
+        break;
+      case "--database":
+        options.database = (args[++i] || "development") as DatabaseEnv;
+        break;
+      case "--output-dir":
+        options.outputDir = args[++i];
+        break;
+      case "--help":
+        console.log(`
+Back up tenantSchema → tenantSchemaBackup (Firestore), or preview to disk.
+
+Usage:
+  npm run backup:tenant-schema -- [options]
+
+Options:
+  --database <env>   development | staging | production (default: development)
+  --tenant <id>      Back up only this document id (default: all documents)
+  --dry-run          Do not write Firestore; export JSON under scripts/output/…
+  --output-dir <dir> With --dry-run only: output folder (default: scripts/output/tenant-schema-backup/<timestamp>)
+  --help             Show this message
+
+Examples:
+  npm run backup:tenant-schema
+  npm run backup:tenant-schema -- --dry-run
+  npm run backup:tenant-schema -- --database staging --tenant mc
+`);
+        process.exit(0);
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (!DATABASES[options.database]) {
+    console.error(
+      `Invalid --database "${options.database}". Use: ${Object.keys(DATABASES).join(", ")}`
+    );
+    process.exit(1);
+  }
+
+  return options;
+}
+
+function initializeDb(databaseName: string): admin.firestore.Firestore {
+  if (!admin.apps.length) {
+    admin.initializeApp({
+      credential: admin.credential.cert({
+        projectId: process.env.FIREBASE_PROJECT_ID,
+        clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+        privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n"),
+      }),
+    });
+  }
+
+  const db = admin.firestore();
+  if (databaseName !== "default") {
+    db.settings({ databaseId: databaseName });
+  }
+  return db;
+}
+
+function defaultOutputRoot(runStamp: string): string {
+  return path.join(__dirname, "output", "tenant-schema-backup", runStamp);
+}
+
+async function backupToFirestore(
+  db: admin.firestore.Firestore,
+  col: admin.firestore.CollectionReference,
+  options: BackupOptions
+): Promise<void> {
+  if (options.tenant) {
+    const doc = await col.doc(options.tenant).get();
+    if (!doc.exists) {
+      console.error(`No document "${options.tenant}" in ${TENANT_SCHEMA_COLLECTION}`);
+      process.exit(1);
+    }
+    const data = doc.data();
+    if (!data) {
+      console.error(`Document "${options.tenant}" has no data`);
+      process.exit(1);
+    }
+    const { backupDocId, backupCollection } = await backupTenantSchemaDocument(
+      db,
+      options.tenant,
+      data,
+      BACKUP_TYPE_CLI
+    );
+    console.log(`Backed up ${options.tenant} → ${backupCollection}/${backupDocId}`);
+    return;
+  }
+
+  const result = await backupTenantSchemaCollection(
+    db,
+    options.database,
+    BACKUP_TYPE_CLI,
+    false
+  );
+  if (!result.success) {
+    process.exit(1);
+  }
+}
+
+async function backupToDiskDryRun(
+  db: admin.firestore.Firestore,
+  col: admin.firestore.CollectionReference,
+  options: BackupOptions,
+  firestoreDbId: string
+): Promise<void> {
+  let docs: admin.firestore.DocumentSnapshot[];
+  if (options.tenant) {
+    const doc = await col.doc(options.tenant).get();
+    if (!doc.exists) {
+      console.error(`No document "${options.tenant}" in ${TENANT_SCHEMA_COLLECTION}`);
+      process.exit(1);
+    }
+    docs = [doc];
+  } else {
+    const snapshot = await col.get();
+    if (snapshot.empty) {
+      console.log(`No documents in ${TENANT_SCHEMA_COLLECTION} (${options.database})`);
+      process.exit(0);
+    }
+    docs = snapshot.docs;
+  }
+
+  const runStamp = formatBackupTimestamp();
+  const outDir = options.outputDir
+    ? path.resolve(process.cwd(), options.outputDir)
+    : defaultOutputRoot(runStamp);
+
+  console.log(
+    `[dry-run] Environment: ${options.database} (Firestore databaseId: ${firestoreDbId === "default" ? "(default)" : firestoreDbId})`
+  );
+  console.log(`[dry-run] Would NOT write to ${TENANT_SCHEMA_BACKUP_COLLECTION}; writing local files under:`);
+  console.log(`  ${outDir}`);
+  console.log(`[dry-run] Documents: ${docs.length}`);
+
+  const manifest = {
+    mode: "dry-run-local-export" as const,
+    exportedAt: new Date().toISOString(),
+    environment: options.database,
+    firestoreDatabaseId: firestoreDbId,
+    collection: TENANT_SCHEMA_COLLECTION,
+    backupType: BACKUP_TYPE_CLI,
+    backupTimestamp: runStamp,
+    documents: [] as { tenantId: string; backupDocId: string; file: string }[],
+  };
+
+  fs.mkdirSync(outDir, { recursive: true });
+
+  for (const doc of docs) {
+    const backupDocId = createBackupDocId(doc.id, BACKUP_TYPE_CLI, runStamp);
+    const fileName = `${backupDocId}.json`;
+    manifest.documents.push({
+      tenantId: doc.id,
+      backupDocId,
+      file: fileName,
+    });
+    const payload = serializeValue(doc.data());
+    const filePath = path.join(outDir, fileName);
+    fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+    console.log(`  wrote ${filePath}`);
+  }
+
+  fs.writeFileSync(
+    path.join(outDir, "manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf8"
+  );
+  console.log(`  manifest: ${path.join(outDir, "manifest.json")}`);
+}
+
+async function main() {
+  const options = parseArgs();
+  const firestoreDbId = DATABASES[options.database];
+  const db = initializeDb(firestoreDbId);
+  const col = db.collection(TENANT_SCHEMA_COLLECTION);
+
+  console.log(
+    `Environment: ${options.database} (Firestore databaseId: ${firestoreDbId === "default" ? "(default)" : firestoreDbId})`
+  );
+
+  if (!options.dryRun && options.outputDir) {
+    console.log("Note: --output-dir is ignored unless --dry-run is set.");
+  }
+
+  if (options.dryRun) {
+    await backupToDiskDryRun(db, col, options, firestoreDbId);
+  } else {
+    console.log(`Writing backups to Firestore collection: ${TENANT_SCHEMA_BACKUP_COLLECTION}`);
+    await backupToFirestore(db, col, options);
+  }
+
+  console.log("Done.");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/booking-app/scripts/tenantSchemaBackup.js
+++ b/booking-app/scripts/tenantSchemaBackup.js
@@ -1,12 +1,15 @@
 const TENANT_SCHEMA_COLLECTION = "tenantSchema";
 const TENANT_SCHEMA_BACKUP_COLLECTION = "tenantSchemaBackup";
 
-const createBackupDocId = (tenantId, backupType) => {
-  const timestamp = new Date()
+const formatBackupTimestamp = () =>
+  new Date()
     .toISOString()
     .replace(/[:.]/g, "-")
     .replace("T", "_")
     .replace("Z", "");
+
+/** @param {string} [timestamp] Same stamp for all docs in a batch (e.g. disk export); omit for a new stamp per call. */
+const createBackupDocId = (tenantId, backupType, timestamp = formatBackupTimestamp()) => {
   return `${tenantId}-backup-${backupType}-${timestamp}`;
 };
 
@@ -102,6 +105,7 @@ const backupTenantSchemaCollection = async (
 module.exports = {
   TENANT_SCHEMA_COLLECTION,
   TENANT_SCHEMA_BACKUP_COLLECTION,
+  formatBackupTimestamp,
   createBackupDocId,
   backupTenantSchemaDocument,
   backupTenantSchemaCollection,


### PR DESCRIPTION
## Summary of Changes

Introduce backupTenantSchemaToDisk.ts and npm run backup:tenant-schema. Default run copies tenantSchema documents into tenantSchemaBackup using the shared tenantSchemaBackup helpers; --dry-run writes JSON under scripts/output only. Extend createBackupDocId with an optional shared timestamp for batched disk exports. Document usage in docs/TENANT_SCHEMA_BACKUP.md and link from SCHEMA_SYNC_GUIDE and scripts/README.

https://github.com/ITPNYU/booking-app/issues/1238

## Schema Changes

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

<!-- If schema changed, list affected tenants and what changed.
Example:
- mc: added `showCleaning` flag
- itp: added new resource (roomId 999)
-->

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [x] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [x] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [x] I requested a code review from at least one other teammate

## Screenshots / Video

<img width="741" height="264" alt="image" src="https://github.com/user-attachments/assets/abbad985-b87e-48fe-b166-ebecbc2e359e" />