### PR TITLE
docs(copilot): enforce firestore composite indexes in PR review

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,19 +14,24 @@ If UI-related files are changed and no screenshots or videos are found in the PR
 
 ## Firestore composite index requirement
 
-Firestore rejects any query that needs a composite index when the index is missing — it fails with `FAILED_PRECONDITION` at runtime, not "runs slowly". Composite indexes for this repo are declared in `booking-app/firestore.indexes.json` and deployed by the `firebase deploy --only firestore:indexes` step in each App Engine deploy workflow.
+Firestore rejects any query that needs a composite index when the index is missing — it fails with `FAILED_PRECONDITION` at runtime, not "runs slowly".
 
-When a pull request introduces or modifies a Firestore query (`firebase-admin` `db.collection(...).where(...)` chains, or the equivalent client SDK queries) that requires a composite index, check whether `booking-app/firestore.indexes.json` has been updated to declare the matching index.
+Composite indexes for this repo are deployed by hard-coded `gcloud firestore indexes composite create` calls in the `Deploy Firestore indexes` step of `.github/workflows/deploy_development_app_engine.yml`, `deploy_staging_app_engine.yml`, and `deploy_production_app_engine.yml`. `booking-app/firestore.indexes.json` exists as a declarative source of truth but is **not consumed by the deploy workflows** (firebase-tools 15.x crashes on the multi-database `firebase.json` config, so the workflows switched to `gcloud` in e1c6c6f2 and now create indexes by name). To actually deploy a new composite index, the `create_index` calls in all three workflow files must be updated.
+
+When a pull request introduces or modifies a Firestore query (`firebase-admin` `db.collection(...).where(...)` chains, or the equivalent client SDK queries) that requires a composite index, check whether both:
+
+1. `booking-app/firestore.indexes.json` declares the matching index (for documentation / future re-enablement of `firebase deploy`), AND
+2. The `Deploy Firestore indexes` step in **all three** App Engine deploy workflows has a matching `create_index` call.
 
 A query needs a composite index when it combines any of the following on a single collection:
 
-- Two or more `.where(...)` clauses on different fields
-- A `.where(...)` plus a `.orderBy(...)` on a different field
-- A `.where(field, "in", [...])` or `array-contains-any` combined with another `.where(...)`
-- A `.where(field, <inequality>, ...)` (`<`, `<=`, `>`, `>=`, `!=`) plus a `.orderBy(...)` on a different field
+- A `.where(field, "in", [...])` (or `not-in` / `array-contains-any`) combined with another `.where(...)` on a different field
+- A `.where(field, <op>, ...)` plus a `.orderBy(...)` on a different field (where `<op>` is anything other than `==` on the same field as the `orderBy`)
+- A range / inequality `.where(...)` (`<`, `<=`, `>`, `>=`, `!=`) combined with another `.where(...)` on a different field
+- A range / inequality plus an `.orderBy(...)` on a different field
 
-Equality on a single field, or an `orderBy` on the same field as a `where`, does not need a composite index — single-field indexes are auto-managed by Firestore.
+Multiple equality (`==`) filters on different fields do **not** require a composite index — Firestore serves these by intersecting the auto-created single-field indexes. Plain equality on a single field, or an `orderBy` on the same field as a single `where`, also doesn't need a composite index.
 
-Watch for the tenant-prefixed collection naming pattern in this repo: `getTenantCollectionName("bookingLogs", "mc")` resolves to the `mc-bookingLogs` collection. The composite index in `firestore.indexes.json` must use the resolved collection name (e.g. `"collectionGroup": "mc-bookingLogs"`), and one entry is typically needed per tenant.
+Watch for the tenant-prefixed collection naming pattern in this repo: `getTenantCollectionName("bookingLogs", "mc")` resolves to the `mc-bookingLogs` collection. The composite index entries must use the resolved collection name (e.g. `mc-bookingLogs`), and one `create_index` call is typically needed per tenant.
 
-If a PR adds or changes a Firestore compound query and `booking-app/firestore.indexes.json` is not updated accordingly, leave a comment asking the author to declare the required composite index(es) in that file so the existing deploy workflow can create them.
+If a PR adds or changes a Firestore query that needs a composite index and either `booking-app/firestore.indexes.json` or the deploy workflows are not updated to match, leave a comment asking the author to add the declaration to both places so the index is actually created at deploy time.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,3 +11,22 @@ Look for evidence such as:
 - Uploaded file attachments in the "Screenshots / Video" section
 
 If UI-related files are changed and no screenshots or videos are found in the PR description, leave a comment requesting the author to attach screenshots or a video demonstrating the UI changes, as required by the PR checklist.
+
+## Firestore composite index requirement
+
+Firestore rejects any query that needs a composite index when the index is missing — it fails with `FAILED_PRECONDITION` at runtime, not "runs slowly". Composite indexes for this repo are declared in `booking-app/firestore.indexes.json` and deployed by the `firebase deploy --only firestore:indexes` step in each App Engine deploy workflow.
+
+When a pull request introduces or modifies a Firestore query (`firebase-admin` `db.collection(...).where(...)` chains, or the equivalent client SDK queries) that requires a composite index, check whether `booking-app/firestore.indexes.json` has been updated to declare the matching index.
+
+A query needs a composite index when it combines any of the following on a single collection:
+
+- Two or more `.where(...)` clauses on different fields
+- A `.where(...)` plus a `.orderBy(...)` on a different field
+- A `.where(field, "in", [...])` or `array-contains-any` combined with another `.where(...)`
+- A `.where(field, <inequality>, ...)` (`<`, `<=`, `>`, `>=`, `!=`) plus a `.orderBy(...)` on a different field
+
+Equality on a single field, or an `orderBy` on the same field as a `where`, does not need a composite index — single-field indexes are auto-managed by Firestore.
+
+Watch for the tenant-prefixed collection naming pattern in this repo: `getTenantCollectionName("bookingLogs", "mc")` resolves to the `mc-bookingLogs` collection. The composite index in `firestore.indexes.json` must use the resolved collection name (e.g. `"collectionGroup": "mc-bookingLogs"`), and one entry is typically needed per tenant.
+
+If a PR adds or changes a Firestore compound query and `booking-app/firestore.indexes.json` is not updated accordingly, leave a comment asking the author to declare the required composite index(es) in that file so the existing deploy workflow can create them.


### PR DESCRIPTION
## Summary of Changes

Adds a new section to `.github/copilot-instructions.md` that asks Copilot to flag PRs introducing Firestore compound queries (multi-`where`, `where` + `orderBy` on different fields, `in` / `array-contains-any` combined with another `where`, inequality + `orderBy`) when `booking-app/firestore.indexes.json` is not updated to declare the matching composite index.

### Why now

PR #1419 (Bookings dashboard Interim column) added a new `where("calendarEventId", "in", [...]).where("status", "==", ...)` query against `<tenant>-bookingLogs` collections. Copilot reviewed the PR multiple times and noted that the query needs a composite index, but did not catch that `firestore.indexes.json` had no matching declaration — which would have caused `FAILED_PRECONDITION` on the first production call after deploy. The required indexes were added separately in #1419, but Copilot should have flagged the gap.

Firestore is unlike SQL here: a missing composite index doesn't degrade to a slow scan, it rejects the query outright. The instruction calls this out so reviewers (and Copilot) treat composite index declarations as part of the query's contract.

### Notes for reviewers

- The instruction enumerates the exact query shapes that need a composite index, so Copilot can pattern-match.
- It also calls out the tenant-prefix naming convention (`mc-bookingLogs`, `itp-bookingLogs`) so reviewers check for per-tenant entries, since `getTenantCollectionName` resolves at runtime.
- This is reviewer/Copilot guidance only — no runtime behavior change.

## Schema Changes

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [ ] I added or updated unit tests (or explained why not in the PR description)
- [x] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

### Why some checkboxes are unchecked

- **Unit tests**: docs-only change to `.github/copilot-instructions.md`. There is nothing to unit-test.
- **Copilot's feedback**: PR will be reviewed by Copilot once opened; will incorporate any feedback before merge.
- **Code review request**: will request a reviewer immediately after this PR opens.

## Screenshots / Video

N/A — docs-only change to Copilot review instructions.