### PR TITLE
fix(firestore): revive 3-key Timestamp shape; consolidate wire helpers

### DIFF
--- a/booking-app/components/src/client/routes/admin/components/SyncCalendars.tsx
+++ b/booking-app/components/src/client/routes/admin/components/SyncCalendars.tsx
@@ -28,12 +28,13 @@ import { useState } from "react";
 
 import AlertToast from "../../components/AlertToast";
 import { TIMEZONE } from "../../../utils/date";
+import { serializedTimestampToMillis } from "@/lib/utils/timestampWire";
 
 const formatFirestoreTimestamp = (value: any): string => {
   if (!value) return "";
-  const seconds = value.seconds ?? value._seconds;
-  if (typeof seconds !== "number") return String(value);
-  const date = new Date(seconds * 1000);
+  const ms = serializedTimestampToMillis(value);
+  if (ms === null) return String(value);
+  const date = new Date(ms);
   return date.toLocaleString("en-US", {
     timeZone: TIMEZONE,
     year: "numeric",

--- a/booking-app/components/src/client/utils/serverDate.ts
+++ b/booking-app/components/src/client/utils/serverDate.ts
@@ -1,5 +1,6 @@
 import { format, toZonedTime } from "date-fns-tz";
 import { Timestamp } from "firebase-admin/firestore";
+import { extractSecondsNanos } from "@/lib/utils/timestampWire";
 import { TIMEZONE } from "./date";
 
 type DateInput = Date | Timestamp | { [key: string]: any } | number | string;
@@ -8,9 +9,9 @@ const parseTimestamp = (value: DateInput): Timestamp => {
   if (value instanceof Timestamp) return value;
   if (value instanceof Date) return Timestamp.fromDate(value);
   if (typeof value === "object" && value !== null) {
-    const seconds = Number(value.seconds || value._seconds || 0);
-    const nanoseconds = Number(value.nanoseconds || value._nanoseconds || 0);
-    return new Timestamp(seconds, nanoseconds);
+    const sn = extractSecondsNanos(value);
+    if (sn !== null) return new Timestamp(sn.seconds, sn.nanoseconds);
+    return new Timestamp(0, 0);
   }
   return Timestamp.fromDate(new Date(value.toString()));
 };

--- a/booking-app/components/src/utils/bookingInterimHours.ts
+++ b/booking-app/components/src/utils/bookingInterimHours.ts
@@ -1,3 +1,4 @@
+import { serializedTimestampToMillis } from "@/lib/utils/timestampWire";
 import { BookingStatusLabel } from "../types";
 import { getStatusFromXState } from "./statusFromXState";
 
@@ -10,18 +11,7 @@ function timestampToMillis(ts: unknown): number | null {
   }
   if (ts instanceof Date) return ts.getTime();
   if (typeof ts === "number" && !Number.isNaN(ts)) return ts;
-  const sec = (ts as { seconds?: number; _seconds?: number }).seconds;
-  const secAlt = (ts as { seconds?: number; _seconds?: number })._seconds;
-  const nanos = (ts as { nanoseconds?: number; _nanoseconds?: number })
-    .nanoseconds;
-  const nanosAlt = (ts as { nanoseconds?: number; _nanoseconds?: number })
-    ._nanoseconds;
-  const s = sec ?? secAlt;
-  if (typeof s === "number") {
-    const n = nanos ?? nanosAlt ?? 0;
-    return s * 1000 + (typeof n === "number" ? Math.floor(n / 1e6) : 0);
-  }
-  return null;
+  return serializedTimestampToMillis(ts);
 }
 
 /** Statuses where time-in-queue (interim) still accumulates before final approval */

--- a/booking-app/lib/api/firestoreServer.ts
+++ b/booking-app/lib/api/firestoreServer.ts
@@ -13,9 +13,13 @@ export function resolveCollectionName(
 /**
  * Convert a wire-format value back into the Firestore-native form.
  *
- * Recognises three serialized Timestamp shapes:
+ * Recognises four serialized Timestamp shapes:
  *  - `{ __ts: <epochMs> }` — the explicit wrapper produced by `wrapTimestamp`
  *  - `{ seconds, nanoseconds }` — what the client SDK's Timestamp.toJSON() emits
+ *  - `{ type: "firestore/timestamp/1.0", seconds, nanoseconds }` —
+ *    what `JSON.stringify` produces from a client SDK Timestamp instance via its
+ *    `toJSON()` (the `type` discriminator is what Firebase Studio / Functions
+ *    use to reconstruct it). Saved as a plain map if not revived here.
  *  - `{ _seconds, _nanoseconds }` — what admin SDK's Timestamp serializes as
  *
  * Also recurses into objects/arrays so nested fields in write payloads are
@@ -32,9 +36,10 @@ export function reviveValue(value: unknown): unknown {
     return admin.firestore.Timestamp.fromMillis(obj.__ts as number);
   }
   if (
-    keys.length === 2 &&
     typeof obj.seconds === "number" &&
-    typeof obj.nanoseconds === "number"
+    typeof obj.nanoseconds === "number" &&
+    (keys.length === 2 ||
+      (keys.length === 3 && obj.type === "firestore/timestamp/1.0"))
   ) {
     return new admin.firestore.Timestamp(
       obj.seconds as number,

--- a/booking-app/lib/api/firestoreServer.ts
+++ b/booking-app/lib/api/firestoreServer.ts
@@ -1,6 +1,7 @@
 import admin from "@/lib/firebase/server/firebaseAdmin";
 import { getTenantCollectionName } from "@/components/src/policy";
 import type { OrderBySpec, WhereSpec } from "@/lib/api/firestoreShared";
+import { reviveSerializedTimestamps } from "@/lib/utils/timestampWire";
 
 /** Resolve the tenant-prefixed collection name (mirrors getTenantCollectionName). */
 export function resolveCollectionName(
@@ -11,56 +12,16 @@ export function resolveCollectionName(
 }
 
 /**
- * Convert a wire-format value back into the Firestore-native form.
- *
- * Recognises four serialized Timestamp shapes:
- *  - `{ __ts: <epochMs> }` — the explicit wrapper produced by `wrapTimestamp`
- *  - `{ seconds, nanoseconds }` — what the client SDK's Timestamp.toJSON() emits
- *  - `{ type: "firestore/timestamp/1.0", seconds, nanoseconds }` —
- *    what `JSON.stringify` produces from a client SDK Timestamp instance via its
- *    `toJSON()` (the `type` discriminator is what Firebase Studio / Functions
- *    use to reconstruct it). Saved as a plain map if not revived here.
- *  - `{ _seconds, _nanoseconds }` — what admin SDK's Timestamp serializes as
- *
- * Also recurses into objects/arrays so nested fields in write payloads are
- * normalised.
+ * Convert a wire-format value back into the Firestore-native form by
+ * replacing any serialized Timestamp shape with a real admin SDK `Timestamp`.
+ * Recognised shapes are documented on `reviveSerializedTimestamps` in
+ * `@/lib/utils/timestampWire`.
  */
 export function reviveValue(value: unknown): unknown {
-  if (value === null || value === undefined) return value;
-  if (Array.isArray(value)) return value.map(reviveValue);
-  if (typeof value !== "object") return value;
-  const obj = value as Record<string, unknown>;
-  const keys = Object.keys(obj);
-
-  if (keys.length === 1 && "__ts" in obj) {
-    return admin.firestore.Timestamp.fromMillis(obj.__ts as number);
-  }
-  if (
-    typeof obj.seconds === "number" &&
-    typeof obj.nanoseconds === "number" &&
-    (keys.length === 2 ||
-      (keys.length === 3 && obj.type === "firestore/timestamp/1.0"))
-  ) {
-    return new admin.firestore.Timestamp(
-      obj.seconds as number,
-      obj.nanoseconds as number,
-    );
-  }
-  if (
-    keys.length === 2 &&
-    typeof obj._seconds === "number" &&
-    typeof obj._nanoseconds === "number"
-  ) {
-    return new admin.firestore.Timestamp(
-      obj._seconds as number,
-      obj._nanoseconds as number,
-    );
-  }
-  const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(obj)) {
-    out[k] = reviveValue(v);
-  }
-  return out;
+  return reviveSerializedTimestamps(
+    value,
+    (s, n) => new admin.firestore.Timestamp(s, n),
+  );
 }
 
 /** Apply the where/orderBy/limit clauses described by the wire request. */

--- a/booking-app/lib/firebase/firebase.ts
+++ b/booking-app/lib/firebase/firebase.ts
@@ -5,6 +5,7 @@ import {
 } from "@/components/src/policy";
 import { Timestamp } from "firebase/firestore";
 
+import { reviveSerializedTimestamps } from "@/lib/utils/timestampWire";
 import { Filters } from "@/components/src/types";
 import { SchemaContextType } from "@/components/src/client/routes/components/SchemaProvider";
 import {
@@ -49,54 +50,15 @@ export type AdminUserData = {
 
 /**
  * Walk the parsed JSON tree and convert serialized Firestore Timestamps
- * back into `Timestamp` instances so callers can keep using `.toDate()` /
- * `.toMillis()` semantics.
- *
- * Recognises four serialized shapes:
- *  - `{ __ts: <epochMs> }` — the explicit wrapper produced by `wrapTimestamp`
- *  - `{ seconds, nanoseconds }` — client SDK `Timestamp.toJSON()` (newer)
- *  - `{ type: "firestore/timestamp/1.0", seconds, nanoseconds }` — client SDK
- *    `Timestamp.toJSON()` when the type discriminator is present. This shape
- *    can also appear as document data on Firestore if a client-serialized
- *    Timestamp was ever written without being coerced back to a real
- *    Timestamp on the server.
- *  - `{ _seconds, _nanoseconds }` — admin SDK `Timestamp` serialization
+ * back into client SDK `Timestamp` instances so callers can keep using
+ * `.toDate()` / `.toMillis()` semantics. The recognised serialized shapes
+ * are documented on `reviveSerializedTimestamps` in `@/lib/utils/timestampWire`.
  *
  * Exported so callers that hit other admin-SDK-backed JSON endpoints
  * (e.g. `/api/permissions`) can apply the same revival.
  */
 export function reviveTimestamps(value: unknown): unknown {
-  if (value === null || value === undefined) return value;
-  if (Array.isArray(value)) return value.map(reviveTimestamps);
-  if (typeof value === "object") {
-    const obj = value as Record<string, unknown>;
-    const keys = Object.keys(obj);
-
-    if (keys.length === 1 && typeof obj.__ts === "number") {
-      return Timestamp.fromMillis(obj.__ts);
-    }
-    if (
-      typeof obj.seconds === "number" &&
-      typeof obj.nanoseconds === "number" &&
-      (keys.length === 2 ||
-        (keys.length === 3 && obj.type === "firestore/timestamp/1.0"))
-    ) {
-      return new Timestamp(obj.seconds, obj.nanoseconds);
-    }
-    if (
-      keys.length === 2 &&
-      typeof obj._seconds === "number" &&
-      typeof obj._nanoseconds === "number"
-    ) {
-      return new Timestamp(obj._seconds, obj._nanoseconds);
-    }
-    const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(obj)) {
-      out[k] = reviveTimestamps(v);
-    }
-    return out;
-  }
-  return value;
+  return reviveSerializedTimestamps(value, (s, n) => new Timestamp(s, n));
 }
 
 /**

--- a/booking-app/lib/firebase/firebase.ts
+++ b/booking-app/lib/firebase/firebase.ts
@@ -49,9 +49,18 @@ export type AdminUserData = {
 
 /**
  * Walk the parsed JSON tree and convert serialized Firestore Timestamps
- * back into `Timestamp` instances. The admin SDK serializes Timestamp as
- * `{ _seconds, _nanoseconds }`; the client SDK's Timestamp class restores
- * `.toDate()` / `.toMillis()` semantics.
+ * back into `Timestamp` instances so callers can keep using `.toDate()` /
+ * `.toMillis()` semantics.
+ *
+ * Recognises four serialized shapes:
+ *  - `{ __ts: <epochMs> }` — the explicit wrapper produced by `wrapTimestamp`
+ *  - `{ seconds, nanoseconds }` — client SDK `Timestamp.toJSON()` (newer)
+ *  - `{ type: "firestore/timestamp/1.0", seconds, nanoseconds }` — client SDK
+ *    `Timestamp.toJSON()` when the type discriminator is present. This shape
+ *    can also appear as document data on Firestore if a client-serialized
+ *    Timestamp was ever written without being coerced back to a real
+ *    Timestamp on the server.
+ *  - `{ _seconds, _nanoseconds }` — admin SDK `Timestamp` serialization
  *
  * Exported so callers that hit other admin-SDK-backed JSON endpoints
  * (e.g. `/api/permissions`) can apply the same revival.
@@ -61,10 +70,23 @@ export function reviveTimestamps(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(reviveTimestamps);
   if (typeof value === "object") {
     const obj = value as Record<string, unknown>;
+    const keys = Object.keys(obj);
+
+    if (keys.length === 1 && typeof obj.__ts === "number") {
+      return Timestamp.fromMillis(obj.__ts);
+    }
     if (
+      typeof obj.seconds === "number" &&
+      typeof obj.nanoseconds === "number" &&
+      (keys.length === 2 ||
+        (keys.length === 3 && obj.type === "firestore/timestamp/1.0"))
+    ) {
+      return new Timestamp(obj.seconds, obj.nanoseconds);
+    }
+    if (
+      keys.length === 2 &&
       typeof obj._seconds === "number" &&
-      typeof obj._nanoseconds === "number" &&
-      Object.keys(obj).length === 2
+      typeof obj._nanoseconds === "number"
     ) {
       return new Timestamp(obj._seconds, obj._nanoseconds);
     }

--- a/booking-app/lib/firebase/server/adminDb.ts
+++ b/booking-app/lib/firebase/server/adminDb.ts
@@ -15,6 +15,7 @@ import {
 
 import { BookingLog, BookingStatusLabel } from "@/components/src/types";
 import { traceDatabase } from "@/lib/newrelic-utils";
+import { serializedTimestampToMillis } from "@/lib/utils/timestampWire";
 import admin from "./firebaseAdmin";
 
 const db = admin.firestore();
@@ -390,16 +391,7 @@ function timestampToMillis(value: any): number | null {
   if (typeof value.toMillis === "function") return value.toMillis();
   if (typeof value.toDate === "function") return value.toDate().getTime();
   if (typeof value === "number" && Number.isFinite(value)) return value;
-
-  const seconds = value.seconds ?? value._seconds;
-  const nanoseconds = value.nanoseconds ?? value._nanoseconds ?? 0;
-  if (typeof seconds === "number") {
-    return (
-      seconds * 1000 +
-      (typeof nanoseconds === "number" ? Math.floor(nanoseconds / 1e6) : 0)
-    );
-  }
-  return null;
+  return serializedTimestampToMillis(value);
 }
 
 export const getLatestBookingStatusLogs = async (

--- a/booking-app/lib/utils/timestampWire.ts
+++ b/booking-app/lib/utils/timestampWire.ts
@@ -82,9 +82,12 @@ export function isSerializedTimestamp(
  * Read (seconds, nanoseconds) from any of the four serialized shapes. Returns
  * null if the value is not a recognised serialized timestamp.
  *
- * Intentionally permissive about extra keys when the caller has already
- * validated with `isSerializedTimestamp`, so the same helper works for both
- * strict-walk and ad-hoc lookups.
+ * Permissive about exact key count (so `isSerializedTimestamp` is not a
+ * prerequisite for ad-hoc callers) but strict about the `type` discriminator:
+ * if a `type` key is present and is not the Firestore discriminator, the
+ * value is rejected. This keeps the helper consistent with
+ * `isSerializedTimestamp` for the "wrong discriminator" case so that
+ * non-Firestore typed envelopes are not silently coerced.
  */
 export function extractSecondsNanos(
   value: unknown,
@@ -97,6 +100,10 @@ export function extractSecondsNanos(
       seconds: Math.floor(obj.__ts / 1000),
       nanoseconds: (obj.__ts % 1000) * 1e6,
     };
+  }
+
+  if ("type" in obj && obj.type !== FIRESTORE_TIMESTAMP_TYPE) {
+    return null;
   }
 
   const sec =

--- a/booking-app/lib/utils/timestampWire.ts
+++ b/booking-app/lib/utils/timestampWire.ts
@@ -1,0 +1,154 @@
+/**
+ * SDK-agnostic helpers for the serialized Timestamp shapes this codebase has
+ * to read from the wire.
+ *
+ * Across `/api/firestore/list` responses, `/api/firestore/mutate` requests,
+ * raw Firestore document snapshots reached over JSON, and historical data
+ * already saved as plain maps, four shapes appear:
+ *
+ *   - `{ __ts: <epochMs> }`
+ *     The explicit wrapper produced by `wrapTimestamp`.
+ *   - `{ seconds, nanoseconds }`
+ *     Client SDK `Timestamp.toJSON()` (newer).
+ *   - `{ type: "firestore/timestamp/1.0", seconds, nanoseconds }`
+ *     Client SDK `Timestamp.toJSON()` with the discriminator. Also the shape
+ *     that ends up stored in Firestore when a JSON-serialized client
+ *     Timestamp is written without being coerced back to a real Timestamp.
+ *   - `{ _seconds, _nanoseconds }`
+ *     Admin SDK `Timestamp` serialization.
+ *
+ * Consumers that take a value of unknown origin should call
+ * `isSerializedTimestamp` before reading, and use `extractSecondsNanos` or
+ * `serializedTimestampToMillis` to read it. Tree-walking callers can use
+ * `reviveSerializedTimestamps` and pass an SDK-specific Timestamp factory.
+ */
+
+export type SerializedTimestamp =
+  | { __ts: number }
+  | { seconds: number; nanoseconds: number }
+  | {
+      type: "firestore/timestamp/1.0";
+      seconds: number;
+      nanoseconds: number;
+    }
+  | { _seconds: number; _nanoseconds: number };
+
+const FIRESTORE_TIMESTAMP_TYPE = "firestore/timestamp/1.0";
+
+/**
+ * Strict predicate. Returns true only for the four documented shapes (exact
+ * key count and types). The strictness matters when called inside a tree
+ * walker so that ordinary 2-key objects (e.g. `{ firstName, lastName }`) are
+ * not mistaken for a timestamp.
+ */
+export function isSerializedTimestamp(
+  value: unknown,
+): value is SerializedTimestamp {
+  if (value === null || typeof value !== "object") return false;
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj);
+
+  if (keys.length === 1 && typeof obj.__ts === "number") return true;
+
+  if (
+    keys.length === 2 &&
+    typeof obj.seconds === "number" &&
+    typeof obj.nanoseconds === "number"
+  ) {
+    return true;
+  }
+
+  if (
+    keys.length === 3 &&
+    obj.type === FIRESTORE_TIMESTAMP_TYPE &&
+    typeof obj.seconds === "number" &&
+    typeof obj.nanoseconds === "number"
+  ) {
+    return true;
+  }
+
+  if (
+    keys.length === 2 &&
+    typeof obj._seconds === "number" &&
+    typeof obj._nanoseconds === "number"
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Read (seconds, nanoseconds) from any of the four serialized shapes. Returns
+ * null if the value is not a recognised serialized timestamp.
+ *
+ * Intentionally permissive about extra keys when the caller has already
+ * validated with `isSerializedTimestamp`, so the same helper works for both
+ * strict-walk and ad-hoc lookups.
+ */
+export function extractSecondsNanos(
+  value: unknown,
+): { seconds: number; nanoseconds: number } | null {
+  if (value === null || typeof value !== "object") return null;
+  const obj = value as Record<string, unknown>;
+
+  if (typeof obj.__ts === "number") {
+    return {
+      seconds: Math.floor(obj.__ts / 1000),
+      nanoseconds: (obj.__ts % 1000) * 1e6,
+    };
+  }
+
+  const sec =
+    typeof obj.seconds === "number"
+      ? obj.seconds
+      : typeof obj._seconds === "number"
+        ? obj._seconds
+        : null;
+  if (sec === null) return null;
+
+  const nanos =
+    typeof obj.nanoseconds === "number"
+      ? obj.nanoseconds
+      : typeof obj._nanoseconds === "number"
+        ? obj._nanoseconds
+        : 0;
+  return { seconds: sec, nanoseconds: nanos };
+}
+
+/**
+ * Convert a serialized timestamp to epoch milliseconds. Returns null if the
+ * input is not a recognized serialized timestamp shape.
+ */
+export function serializedTimestampToMillis(value: unknown): number | null {
+  const sn = extractSecondsNanos(value);
+  if (sn === null) return null;
+  return sn.seconds * 1000 + Math.floor(sn.nanoseconds / 1e6);
+}
+
+/**
+ * Walk a parsed JSON tree and replace every serialized timestamp with the
+ * SDK-specific Timestamp produced by `fromSecondsNanos`. Strict matching is
+ * used so ordinary objects whose key count happens to be 2 (or 3) are not
+ * misidentified.
+ */
+export function reviveSerializedTimestamps<T>(
+  value: unknown,
+  fromSecondsNanos: (seconds: number, nanoseconds: number) => T,
+): unknown {
+  if (value === null || value === undefined) return value;
+  if (Array.isArray(value)) {
+    return value.map((v) => reviveSerializedTimestamps(v, fromSecondsNanos));
+  }
+  if (typeof value !== "object") return value;
+  if (isSerializedTimestamp(value)) {
+    const { seconds, nanoseconds } = extractSecondsNanos(value)!;
+    return fromSecondsNanos(seconds, nanoseconds);
+  }
+  const obj = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    out[k] = reviveSerializedTimestamps(v, fromSecondsNanos);
+  }
+  return out;
+}

--- a/booking-app/tests/unit/firebase-reviveTimestamps.unit.test.ts
+++ b/booking-app/tests/unit/firebase-reviveTimestamps.unit.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Override the global firebase/firestore mock from setup.ts so we get a
+// real-ish Timestamp class with the methods reviveTimestamps relies on.
+vi.mock("firebase/firestore", () => {
+  class FakeTimestamp {
+    constructor(
+      public readonly seconds: number,
+      public readonly nanoseconds: number,
+    ) {}
+    static fromMillis(ms: number) {
+      return new FakeTimestamp(Math.floor(ms / 1000), (ms % 1000) * 1e6);
+    }
+    static fromDate(date: Date) {
+      return FakeTimestamp.fromMillis(date.getTime());
+    }
+    static now() {
+      return FakeTimestamp.fromMillis(Date.now());
+    }
+    toMillis() {
+      return this.seconds * 1000 + Math.floor(this.nanoseconds / 1e6);
+    }
+    toDate() {
+      return new Date(this.toMillis());
+    }
+  }
+  return {
+    getFirestore: vi.fn(() => ({})),
+    Timestamp: FakeTimestamp,
+  };
+});
+
+const firestoreModule = await import("firebase/firestore");
+const FakeTimestamp = firestoreModule.Timestamp as new (
+  s: number,
+  n: number,
+) => { seconds: number; nanoseconds: number; toMillis(): number };
+
+const { reviveTimestamps } = await import("@/lib/firebase/firebase");
+
+describe("reviveTimestamps", () => {
+  it("revives `{__ts}` shape via Timestamp.fromMillis", () => {
+    const result = reviveTimestamps({ __ts: 1700000000000 }) as InstanceType<
+      typeof FakeTimestamp
+    >;
+    expect(result).toBeInstanceOf(FakeTimestamp);
+    expect(result.toMillis()).toBe(1700000000000);
+  });
+
+  it("revives client-SDK `{seconds, nanoseconds}` shape", () => {
+    const result = reviveTimestamps({
+      seconds: 100,
+      nanoseconds: 250,
+    }) as InstanceType<typeof FakeTimestamp>;
+    expect(result).toBeInstanceOf(FakeTimestamp);
+    expect(result.seconds).toBe(100);
+    expect(result.nanoseconds).toBe(250);
+  });
+
+  it("revives client-SDK `{type, seconds, nanoseconds}` shape (Timestamp.toJSON discriminator)", () => {
+    const result = reviveTimestamps({
+      type: "firestore/timestamp/1.0",
+      seconds: 1788235200,
+      nanoseconds: 0,
+    }) as InstanceType<typeof FakeTimestamp>;
+    expect(result).toBeInstanceOf(FakeTimestamp);
+    expect(result.seconds).toBe(1788235200);
+    expect(result.nanoseconds).toBe(0);
+  });
+
+  it("revives admin-SDK `{_seconds, _nanoseconds}` shape", () => {
+    const result = reviveTimestamps({
+      _seconds: 200,
+      _nanoseconds: 750,
+    }) as InstanceType<typeof FakeTimestamp>;
+    expect(result).toBeInstanceOf(FakeTimestamp);
+    expect(result.seconds).toBe(200);
+    expect(result.nanoseconds).toBe(750);
+  });
+
+  it("recurses into nested objects", () => {
+    const result = reviveTimestamps({
+      title: "x",
+      meta: { createdAt: { __ts: 5000 }, value: 7 },
+    }) as {
+      title: string;
+      meta: { createdAt: InstanceType<typeof FakeTimestamp>; value: number };
+    };
+    expect(result.title).toBe("x");
+    expect(result.meta.createdAt).toBeInstanceOf(FakeTimestamp);
+    expect(result.meta.createdAt.toMillis()).toBe(5000);
+    expect(result.meta.value).toBe(7);
+  });
+
+  it("recurses into arrays", () => {
+    const result = reviveTimestamps([
+      { __ts: 1000 },
+      { type: "firestore/timestamp/1.0", seconds: 2, nanoseconds: 0 },
+      "noop",
+    ]) as [
+      InstanceType<typeof FakeTimestamp>,
+      InstanceType<typeof FakeTimestamp>,
+      string,
+    ];
+    expect(result[0]).toBeInstanceOf(FakeTimestamp);
+    expect(result[0].toMillis()).toBe(1000);
+    expect(result[1]).toBeInstanceOf(FakeTimestamp);
+    expect(result[1].seconds).toBe(2);
+    expect(result[2]).toBe("noop");
+  });
+
+  it("passes primitives through unchanged", () => {
+    expect(reviveTimestamps("hello")).toBe("hello");
+    expect(reviveTimestamps(42)).toBe(42);
+    expect(reviveTimestamps(true)).toBe(true);
+    expect(reviveTimestamps(null)).toBe(null);
+    expect(reviveTimestamps(undefined)).toBe(undefined);
+  });
+
+  it("does not misidentify ordinary 2-key objects as timestamps", () => {
+    const obj = { firstName: "Riho", lastName: "Hagi" };
+    const result = reviveTimestamps(obj);
+    expect(result).toEqual(obj);
+    expect(result).not.toBeInstanceOf(FakeTimestamp);
+  });
+
+  it("does not misidentify 3-key objects without the firestore type discriminator", () => {
+    const obj = {
+      type: "something/else/2.0",
+      seconds: 100,
+      nanoseconds: 0,
+    };
+    const result = reviveTimestamps(obj);
+    expect(result).toEqual(obj);
+    expect(result).not.toBeInstanceOf(FakeTimestamp);
+  });
+});

--- a/booking-app/tests/unit/firestoreServer-reviveValue.unit.test.ts
+++ b/booking-app/tests/unit/firestoreServer-reviveValue.unit.test.ts
@@ -46,6 +46,17 @@ describe("reviveValue", () => {
     expect((result as FakeAdminTimestamp).nanoseconds).toBe(250);
   });
 
+  it("revives client-SDK `{type, seconds, nanoseconds}` shape (Timestamp.toJSON discriminator)", () => {
+    const result = reviveValue({
+      type: "firestore/timestamp/1.0",
+      seconds: 1788235200,
+      nanoseconds: 0,
+    });
+    expect(result).toBeInstanceOf(FakeAdminTimestamp);
+    expect((result as FakeAdminTimestamp).seconds).toBe(1788235200);
+    expect((result as FakeAdminTimestamp).nanoseconds).toBe(0);
+  });
+
   it("revives admin-SDK `{_seconds, _nanoseconds}` shape", () => {
     const result = reviveValue({ _seconds: 200, _nanoseconds: 750 });
     expect(result).toBeInstanceOf(FakeAdminTimestamp);

--- a/booking-app/tests/unit/firestoreServer-reviveValue.unit.test.ts
+++ b/booking-app/tests/unit/firestoreServer-reviveValue.unit.test.ts
@@ -1,15 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/firebase/server/firebaseAdmin", () => {
-  const fromMillisMock = vi.fn(
-    (ms: number) => ({ kind: "fromMillis", ms }) as const,
-  );
   class FakeAdminTimestamp {
     constructor(
       public readonly seconds: number,
       public readonly nanoseconds: number,
     ) {}
-    static fromMillis = fromMillisMock;
   }
   return {
     default: {
@@ -26,17 +22,15 @@ const FakeAdminTimestamp = (adminModule.default as any).firestore
   s: number,
   n: number,
 ) => { seconds: number; nanoseconds: number };
-const fromMillisMock = (FakeAdminTimestamp as any).fromMillis as ReturnType<
-  typeof vi.fn
->;
 
 import { reviveValue } from "@/lib/api/firestoreServer";
 
 describe("reviveValue", () => {
-  it("revives `{__ts}` shape via Timestamp.fromMillis", () => {
-    const result = reviveValue({ __ts: 1700000000000 });
-    expect(fromMillisMock).toHaveBeenCalledWith(1700000000000);
-    expect(result).toEqual({ kind: "fromMillis", ms: 1700000000000 });
+  it("revives `{__ts}` shape into admin Timestamp", () => {
+    const result = reviveValue({ __ts: 1700000000500 });
+    expect(result).toBeInstanceOf(FakeAdminTimestamp);
+    expect((result as FakeAdminTimestamp).seconds).toBe(1700000000);
+    expect((result as FakeAdminTimestamp).nanoseconds).toBe(500_000_000);
   });
 
   it("revives client-SDK `{seconds, nanoseconds}` shape", () => {
@@ -67,21 +61,32 @@ describe("reviveValue", () => {
   it("recurses into nested objects", () => {
     const result = reviveValue({
       title: "x",
-      meta: { createdAt: { __ts: 5 }, value: 7 },
-    });
-    expect(result).toMatchObject({
-      title: "x",
-      meta: { createdAt: { kind: "fromMillis", ms: 5 }, value: 7 },
-    });
+      meta: { createdAt: { __ts: 5000 }, value: 7 },
+    }) as {
+      title: string;
+      meta: { createdAt: InstanceType<typeof FakeAdminTimestamp>; value: number };
+    };
+    expect(result.title).toBe("x");
+    expect(result.meta.createdAt).toBeInstanceOf(FakeAdminTimestamp);
+    expect(result.meta.createdAt.seconds).toBe(5);
+    expect(result.meta.value).toBe(7);
   });
 
   it("recurses into arrays", () => {
-    const result = reviveValue([{ __ts: 1 }, { __ts: 2 }, "noop"]);
-    expect(result).toEqual([
-      { kind: "fromMillis", ms: 1 },
-      { kind: "fromMillis", ms: 2 },
+    const result = reviveValue([
+      { __ts: 1000 },
+      { __ts: 2000 },
       "noop",
-    ]);
+    ]) as [
+      InstanceType<typeof FakeAdminTimestamp>,
+      InstanceType<typeof FakeAdminTimestamp>,
+      string,
+    ];
+    expect(result[0]).toBeInstanceOf(FakeAdminTimestamp);
+    expect(result[0].seconds).toBe(1);
+    expect(result[1]).toBeInstanceOf(FakeAdminTimestamp);
+    expect(result[1].seconds).toBe(2);
+    expect(result[2]).toBe("noop");
   });
 
   it("passes primitives through unchanged", () => {

--- a/booking-app/tests/unit/timestampWire.unit.test.ts
+++ b/booking-app/tests/unit/timestampWire.unit.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  extractSecondsNanos,
+  isSerializedTimestamp,
+  reviveSerializedTimestamps,
+  serializedTimestampToMillis,
+} from "@/lib/utils/timestampWire";
+
+describe("isSerializedTimestamp", () => {
+  it("accepts `{__ts}` wrapper", () => {
+    expect(isSerializedTimestamp({ __ts: 1700000000000 })).toBe(true);
+  });
+
+  it("accepts client SDK `{seconds, nanoseconds}`", () => {
+    expect(isSerializedTimestamp({ seconds: 1, nanoseconds: 2 })).toBe(true);
+  });
+
+  it("accepts client SDK `{type, seconds, nanoseconds}` discriminator", () => {
+    expect(
+      isSerializedTimestamp({
+        type: "firestore/timestamp/1.0",
+        seconds: 1,
+        nanoseconds: 2,
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts admin SDK `{_seconds, _nanoseconds}`", () => {
+    expect(isSerializedTimestamp({ _seconds: 1, _nanoseconds: 2 })).toBe(true);
+  });
+
+  it("rejects ordinary 2-key object", () => {
+    expect(isSerializedTimestamp({ firstName: "a", lastName: "b" })).toBe(
+      false,
+    );
+  });
+
+  it("rejects 3-key object without firestore discriminator", () => {
+    expect(
+      isSerializedTimestamp({
+        type: "something/else/2.0",
+        seconds: 1,
+        nanoseconds: 2,
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects 4+-key objects even with seconds/nanoseconds", () => {
+    expect(
+      isSerializedTimestamp({
+        type: "firestore/timestamp/1.0",
+        seconds: 1,
+        nanoseconds: 2,
+        extra: "no",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects null / non-object primitives", () => {
+    expect(isSerializedTimestamp(null)).toBe(false);
+    expect(isSerializedTimestamp(undefined)).toBe(false);
+    expect(isSerializedTimestamp(42)).toBe(false);
+    expect(isSerializedTimestamp("hello")).toBe(false);
+  });
+});
+
+describe("extractSecondsNanos", () => {
+  it("extracts from `{__ts}`", () => {
+    expect(extractSecondsNanos({ __ts: 1500 })).toEqual({
+      seconds: 1,
+      nanoseconds: 500_000_000,
+    });
+  });
+
+  it("extracts from `{seconds, nanoseconds}`", () => {
+    expect(extractSecondsNanos({ seconds: 5, nanoseconds: 7 })).toEqual({
+      seconds: 5,
+      nanoseconds: 7,
+    });
+  });
+
+  it("extracts from `{type, seconds, nanoseconds}`", () => {
+    expect(
+      extractSecondsNanos({
+        type: "firestore/timestamp/1.0",
+        seconds: 9,
+        nanoseconds: 0,
+      }),
+    ).toEqual({ seconds: 9, nanoseconds: 0 });
+  });
+
+  it("extracts from `{_seconds, _nanoseconds}`", () => {
+    expect(extractSecondsNanos({ _seconds: 11, _nanoseconds: 13 })).toEqual({
+      seconds: 11,
+      nanoseconds: 13,
+    });
+  });
+
+  it("returns null for unrecognized objects", () => {
+    expect(extractSecondsNanos({ foo: "bar" })).toBe(null);
+    expect(extractSecondsNanos(null)).toBe(null);
+    expect(extractSecondsNanos(42)).toBe(null);
+  });
+});
+
+describe("serializedTimestampToMillis", () => {
+  it("converts {seconds, nanoseconds} to millis", () => {
+    expect(serializedTimestampToMillis({ seconds: 2, nanoseconds: 500_000_000 })).toBe(
+      2500,
+    );
+  });
+
+  it("returns null when shape is unrecognized", () => {
+    expect(serializedTimestampToMillis({ foo: "bar" })).toBe(null);
+  });
+});
+
+describe("reviveSerializedTimestamps", () => {
+  const make = (s: number, n: number) => ({ kind: "ts" as const, s, n });
+
+  it("revives a top-level timestamp", () => {
+    expect(
+      reviveSerializedTimestamps({ seconds: 5, nanoseconds: 6 }, make),
+    ).toEqual({ kind: "ts", s: 5, n: 6 });
+  });
+
+  it("revives nested timestamps", () => {
+    expect(
+      reviveSerializedTimestamps(
+        {
+          name: "x",
+          startDate: {
+            type: "firestore/timestamp/1.0",
+            seconds: 1,
+            nanoseconds: 0,
+          },
+        },
+        make,
+      ),
+    ).toEqual({ name: "x", startDate: { kind: "ts", s: 1, n: 0 } });
+  });
+
+  it("revives inside arrays", () => {
+    expect(
+      reviveSerializedTimestamps(
+        [{ __ts: 1000 }, "noop", { _seconds: 2, _nanoseconds: 3 }],
+        make,
+      ),
+    ).toEqual([
+      { kind: "ts", s: 1, n: 0 },
+      "noop",
+      { kind: "ts", s: 2, n: 3 },
+    ]);
+  });
+
+  it("does not misidentify ordinary objects", () => {
+    expect(
+      reviveSerializedTimestamps(
+        { firstName: "a", lastName: "b" },
+        make,
+      ),
+    ).toEqual({ firstName: "a", lastName: "b" });
+  });
+
+  it("passes primitives through", () => {
+    expect(reviveSerializedTimestamps("hi", make)).toBe("hi");
+    expect(reviveSerializedTimestamps(42, make)).toBe(42);
+    expect(reviveSerializedTimestamps(null, make)).toBe(null);
+    expect(reviveSerializedTimestamps(undefined, make)).toBe(undefined);
+  });
+});

--- a/booking-app/tests/unit/timestampWire.unit.test.ts
+++ b/booking-app/tests/unit/timestampWire.unit.test.ts
@@ -102,6 +102,16 @@ describe("extractSecondsNanos", () => {
     expect(extractSecondsNanos(null)).toBe(null);
     expect(extractSecondsNanos(42)).toBe(null);
   });
+
+  it("rejects objects whose `type` is present but not the Firestore discriminator", () => {
+    expect(
+      extractSecondsNanos({
+        type: "something/else/2.0",
+        seconds: 1,
+        nanoseconds: 0,
+      }),
+    ).toBe(null);
+  });
 });
 
 describe("serializedTimestampToMillis", () => {


### PR DESCRIPTION
## Summary of Changes

Production bug: admins could not interact with the Blackout Period admin page after the first blackout period was saved. The page crashed on render with `TypeError: e.toDate is not a function`.

The `Deploy Firestore indexes` step caught no Firestore index problems — it was a state-on-disk problem. When the SSO refactor routed all client Firestore reads/writes through `/api/firestore/*` (commit `91de6fb8`, on main 2026-04-23, in prod via PR #1462 on 2026-05-07), the wire revival helpers `reviveTimestamps` and `reviveValue` were written to recognise only the 2-key shapes:

- `{ __ts: <epochMs> }`
- `{ seconds, nanoseconds }`
- `{ _seconds, _nanoseconds }`

But when a client UI builds an object containing a client-SDK `Timestamp` and posts it to `/api/firestore/mutate`, `JSON.stringify` materialises that Timestamp via its `toJSON()`, which emits a **3-key** discriminator shape:

```
{ type: "firestore/timestamp/1.0", seconds, nanoseconds }
```

`reviveValue` did not match this strict 3-key shape, so the value was written to Firestore as a literal map (not a real Timestamp column). When the same data came back through `/api/firestore/list`, `reviveTimestamps` also did not match it, so the value reached the UI as a plain object and `.toDate()` blew up on first interaction.

Production hit this today for the first time when an admin saved an "AY 26-27 Blackout" period — the first blackoutPeriod created on `booking-app-prod` since the SSO refactor.

### Fix

1. **bug fix** (`05f5c308`): teach both `reviveValue` (server, write) and `reviveTimestamps` (client, read) to recognise the 3-key `{ type, seconds, nanoseconds }` shape. New writes now coerce back to a real admin Timestamp before the Firestore write, so the document column type stays a real Timestamp. Existing documents that already landed in the broken map shape (the production blackoutPeriod doc) are read back as Timestamps on the client so `.toDate()` keeps working.

2. **consolidation refactor** (`0f12a429`): six places in the repo had their own ad-hoc helper for the same "is this thing a serialized Firestore Timestamp on the wire" question — `reviveTimestamps`, `reviveValue`, `parseTimestamp` (serverDate), two `timestampToMillis` (bookingInterimHours, adminDb), and an inline `formatFirestoreTimestamp` in `SyncCalendars`. Each detected the four serialized shapes differently. The two tree-walking ones used strict matching and so were the only ones that visibly failed on the 3-key shape; the other four happened to read `value.seconds` and silently ignored the extras. They are still semantic duplicates, so a future bug would have a different surface in each one. Extracted the detection + extraction + tree-walking into `lib/utils/timestampWire.ts` (`isSerializedTimestamp`, `extractSecondsNanos`, `serializedTimestampToMillis`, `reviveSerializedTimestamps`) and moved each call site to defer wire-shape work there. Net **-88 lines**; one place to add the next shape if Firebase introduces another.

### Existing broken doc

The production `mc-blackoutPeriods/CEXirghLvnLIrtdL548v` doc ("AY 26-27 Blackout") will still have `startDate` / `endDate` stored as plain maps after this deploys. The read-side revive makes the UI work without further action, but if anyone cares about Firestore-level `startDate >= X` queries on that specific doc, it would need to be re-saved (or hand-fixed) so the column becomes a real Timestamp again. Not required for the immediate UI fix.

## Schema Changes

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [x] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video
<img width="1210" height="345" alt="Screenshot 2026-05-14 at 5 33 55 PM" src="https://github.com/user-attachments/assets/3046c60a-420a-4d34-a2c6-0a936ed33be1" />

<img width="1445" height="640" alt="Screenshot 2026-05-14 at 5 31 25 PM" src="https://github.com/user-attachments/assets/18175a7e-4f0c-4382-83c6-1cb02b49fe06" />
