### PR TITLE
fix(policy-settings): stop OperationalHoursRow re-fetching on every render

### DIFF
--- a/booking-app/components/src/client/routes/admin/components/policySettings/OperationalHoursRow.tsx
+++ b/booking-app/components/src/client/routes/admin/components/policySettings/OperationalHoursRow.tsx
@@ -53,10 +53,15 @@ export default function OperationalHoursRow({ day, setting, roomId }: Props) {
     updateOperationHours(day, openDate.hour(), e.$H, closed, roomId);
   };
 
-  // when we leave the page, the app reloads the newly set operation hours
-  useEffect(() => () => {
-    reloadOperationHours();
-  });
+  // when we leave the page, the app reloads the newly set operation hours.
+  // Empty deps so the cleanup only fires on unmount; without it React runs the
+  // cleanup on every render, which loops re-fetches and exhausts browser sockets.
+  useEffect(
+    () => () => {
+      reloadOperationHours();
+    },
+    [],
+  );
 
   return (
     <Box sx={{ p: 1 }}>


### PR DESCRIPTION
## Summary of Changes

Local-dev (and likely prod) error in the policy settings page:

```
POST http://localhost:3000/api/firestore/list net::ERR_INSUFFICIENT_RESOURCES
Provider.tsx:678 Error fetching data: TypeError: Failed to fetch
    at postJson (firebase.ts:77:21)
    at clientFetchAllDataFromCollection (firebase.ts:206:26)
    at fetchOperationHours (Provider.tsx:674:37)
    at OperationalHoursRow.useEffect (OperationalHoursRow.tsx:58:5)
```

Root cause in `components/src/client/routes/admin/components/policySettings/OperationalHoursRow.tsx`:

```ts
// when we leave the page, the app reloads the newly set operation hours
useEffect(() => () => {
  reloadOperationHours();
});  // ← no dependency array
```

Without a dependency array React runs the cleanup on every render. The cleanup calls `reloadOperationHours()`, which fires `clientFetchAllDataFromCollection` → POST `/api/firestore/list`, and the fetched data lands in context state and re-renders the row, so the cleanup runs again, looping. Chrome's per-origin socket limit (~6) is exhausted within a few hundred ms, surfacing as `ERR_INSUFFICIENT_RESOURCES`. While the socket pool is exhausted, *unrelated* requests on the same page also fail — most visibly the "Save" call when an admin tries to add a blackout period.

The comment ("when we leave the page, the app reloads…") confirms the intent: this should fire once, on unmount. Adding the empty dependency array `[]` makes the cleanup behave that way and stops the loop.

This is pre-existing (introduced in `1e761942 define operational hours per room`), unrelated to the recent SSO refactor. Surfaced now because someone tried to use the policy settings page locally.

## Schema Changes

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [ ] I added or updated unit tests (or explained why not in the PR description)
- [x] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

### Notes on unchecked boxes

- **Unit tests**: this is a render-loop bug in a `useEffect` cleanup. Catching it via vitest would require a render harness that asserts on side-effect call counts across re-renders, which is heavier than the one-line fix warrants. Manual verification: in the policy settings page, the Network tab no longer shows `/api/firestore/list` firing every few milliseconds, and adding a blackout period now succeeds.
- **Copilot feedback / Code review**: will address once the PR opens.

## Screenshots / Video

N/A — the user-visible change is "the policy settings page stops looping fetches and the Add Blackout Period button works again." There is no new UI.