### PR TITLE
fix(ci): bump App Engine runtime and CI node-version to Node.js 22

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: booking-app/package-lock.json
 

--- a/.github/workflows/deploy_development_app_engine.yml
+++ b/.github/workflows/deploy_development_app_engine.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2

--- a/.github/workflows/deploy_production_app_engine.yml
+++ b/.github/workflows/deploy_production_app_engine.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2

--- a/.github/workflows/deploy_staging_app_engine.yml
+++ b/.github/workflows/deploy_staging_app_engine.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: booking-app/package-lock.json
 
@@ -97,7 +97,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: "npm"
           cache-dependency-path: booking-app/package-lock.json
 

--- a/.github/workflows/pr-prod-schema-check.yml
+++ b/.github/workflows/pr-prod-schema-check.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: booking-app/package-lock.json
 

--- a/.github/workflows/sync-tenant-schema.yml
+++ b/.github/workflows/sync-tenant-schema.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: booking-app/package-lock.json
 
@@ -98,7 +98,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: booking-app/package-lock.json
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install dependencies
         run: |

--- a/booking-app/app.development.yaml
+++ b/booking-app/app.development.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs20
+runtime: nodejs22
 instance_class: F1
 service: development
 

--- a/booking-app/app.production.yaml
+++ b/booking-app/app.production.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs20
+runtime: nodejs22
 instance_class: F1
 service: default
 

--- a/booking-app/app.staging.yaml
+++ b/booking-app/app.staging.yaml
@@ -1,4 +1,4 @@
-runtime: nodejs20
+runtime: nodejs22
 instance_class: B1
 service: staging
 


### PR DESCRIPTION
## Summary of Changes

App Engine Standard deploy was failing with:

```
ERROR: (gcloud.app.deploy) INVALID_ARGUMENT: Error(s) encountered validating runtime.
Runtime nodejs20 is end of support and no longer allowed.
```

Bump `runtime` in `booking-app/app.{development,staging,production}.yaml` from `nodejs20` to `nodejs22`, and align every GitHub Actions `setup-node` step (`build-check`, `unit-tests`, `e2e-tests`, `pr-prod-schema-check`, `sync-tenant-schema`, and the three `deploy_*_app_engine` workflows) so CI builds/tests on the same Node major as the deploy target.

## Schema Changes

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [ ] I thoroughly tested this feature locally
- [ ] I added or updated unit tests (or explained why not in the PR description)
- [x] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [ ] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

Notes on unchecked items:
- Local test skipped — change is config-only (runtime/CI version strings); CI on this PR exercises the bump end-to-end.
- No unit tests — there is nothing to assert beyond what CI itself runs against the new Node version.
- No screenshots — config-only change with no UI surface.

## Screenshots / Video

N/A — config-only change.