### PR TITLE
fix(export): stream bookings to avoid F1 OOM on /api/bookings/export

### DIFF
--- a/booking-app/app/api/bookings/export/route.ts
+++ b/booking-app/app/api/bookings/export/route.ts
@@ -4,31 +4,169 @@ import { NextRequest, NextResponse } from "next/server";
 import { TableNames } from "@/components/src/policy";
 import { Booking, RoomSetting, formatOrigin } from "@/components/src/types";
 import {
-  serverFetchAllDataFromCollection,
+  getServerTenantCollection,
   serverGetDocumentById,
 } from "@/lib/firebase/server/adminDb";
+import admin from "@/lib/firebase/server/firebaseAdmin";
 import { applyEnvironmentCalendarIds } from "@/lib/utils/calendarEnvironment";
 import { toFirebaseTimestamp } from "@/components/src/client/utils/serverDate";
 import { formatInTimeZone } from "date-fns-tz";
-import { parse } from "json2csv";
 
 import { TIMEZONE } from "../shared";
 
+const HEADERS = [
+  "Request #",
+  "School",
+  "Department",
+  "Role (Affiliation)",
+  "Room(s)",
+  "Booking Start Date",
+  "Booking End Date",
+  "Booking Start Time",
+  "Booking End Time",
+  "Time In Use, Hours",
+  "# rooms used",
+  "ACTUAL hours",
+  "Reservation Title",
+  "Reservation Description",
+  "Expected Attendance",
+  "Reservation Origin",
+  "Booking Type",
+  "Attendee Affiliation(s)",
+  "End Event Status",
+  "Requested At",
+  "First Approved At",
+  "Final Approved At",
+  "Declined At",
+  "Checked In At",
+  "Checked Out At",
+  "No Show At",
+  "Canceled At",
+  "Closed At",
+  "Room Setup Needed (Y/N)",
+  "Room Setup Details",
+  "Equipment Services (Y/N)",
+  "Equipment Service Details",
+  "Staffing Services (Y/N)",
+  "Staffing Service Details",
+  "Catering (Y/N)",
+  "Cleaning Services (Y/N)",
+  "Hire Security (Y/N)",
+] as const;
+
+const escapeCsv = (value: unknown): string => {
+  if (value == null) return "";
+  const str = String(value);
+  if (/[",\n\r]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+};
+
+const toDate = (timestamp: unknown): Date | null => {
+  if (timestamp == null) return null;
+  try {
+    const date = toFirebaseTimestamp(timestamp as any).toDate();
+    return isNaN(date.getTime()) ? null : date;
+  } catch {
+    return null;
+  }
+};
+
+const safeFormat = (timestamp: unknown, fmt: string): string => {
+  const date = toDate(timestamp);
+  return date ? formatInTimeZone(date, TIMEZONE, fmt) : "";
+};
+
+const getBookingStatus = (booking: Booking): string => {
+  if (booking.finalApprovedAt) return "Approved";
+  if (booking.declinedAt) return "Declined";
+  if (booking.canceledAt) return "Canceled";
+  if (booking.checkedOutAt) return "Checked out";
+  if (booking.checkedInAt) return "Checked in";
+  if (booking.noShowedAt) return "No Show";
+  if (booking.firstApprovedAt) return "Pending";
+  return "Requested";
+};
+
+const calculateTimeInUse = (startDate: unknown, endDate: unknown): number => {
+  const start = toDate(startDate);
+  const end = toDate(endDate);
+  if (!start || !end) return 0;
+  return (
+    Math.round(((end.getTime() - start.getTime()) / (1000 * 60 * 60)) * 100) /
+    100
+  );
+};
+
+const countRooms = (roomId: string | number): number => {
+  const roomIdStr = String(roomId);
+  return roomIdStr.includes(",") ? roomIdStr.split(",").length : 1;
+};
+
+const buildRow = (booking: Booking): string => {
+  const timeInUse = calculateTimeInUse(booking.startDate, booking.endDate);
+  const roomCount = countRooms(booking.roomId);
+  const b = booking as any;
+
+  const values: unknown[] = [
+    booking.requestNumber,
+    b.school === "Other" && b.otherSchool ? b.otherSchool : b.school || "",
+    booking.department === "Other" && booking.otherDepartment
+      ? booking.otherDepartment
+      : booking.department,
+    booking.role,
+    booking.roomId,
+    safeFormat(booking.startDate, "M/d/yyyy"),
+    safeFormat(booking.endDate, "M/d/yyyy"),
+    safeFormat(booking.startDate, "h:mm a"),
+    safeFormat(booking.endDate, "h:mm a"),
+    timeInUse,
+    roomCount,
+    timeInUse * roomCount,
+    booking.title,
+    booking.description,
+    booking.expectedAttendance,
+    booking.origin ? formatOrigin(booking.origin) : "",
+    booking.bookingType,
+    booking.attendeeAffiliation,
+    getBookingStatus(booking),
+    safeFormat(booking.requestedAt, "M/d/yyyy h:mm a"),
+    safeFormat(booking.firstApprovedAt, "M/d/yyyy h:mm a"),
+    safeFormat(booking.finalApprovedAt, "M/d/yyyy h:mm a"),
+    safeFormat(booking.declinedAt, "M/d/yyyy h:mm a"),
+    safeFormat(booking.checkedInAt, "M/d/yyyy h:mm a"),
+    safeFormat(booking.checkedOutAt, "M/d/yyyy h:mm a"),
+    safeFormat(booking.noShowedAt, "M/d/yyyy h:mm a"),
+    safeFormat(booking.canceledAt, "M/d/yyyy h:mm a"),
+    safeFormat(booking.closedAt, "M/d/yyyy h:mm a"),
+    booking.roomSetup === "yes" ? "Yes" : "No",
+    booking.setupDetails || "",
+    booking.equipmentServices && booking.equipmentServices.length > 0
+      ? "Yes"
+      : "No",
+    booking.equipmentServicesDetails || "",
+    booking.staffingServices && booking.staffingServices.length > 0
+      ? "Yes"
+      : "No",
+    booking.staffingServicesDetails || "",
+    booking.catering === "yes" ? "Yes" : "No",
+    booking.cleaningService === "yes" ? "Yes" : "No",
+    booking.hireSecurity === "yes" ? "Yes" : "No",
+  ];
+
+  return values.map(escapeCsv).join(",");
+};
+
 export async function GET(request: NextRequest) {
-  // Get tenant from request headers or default to 'mc'
   const tenant = request.headers.get("x-tenant") || DEFAULT_TENANT;
 
-  const [bookings, schema] = await Promise.all([
-    serverFetchAllDataFromCollection<Booking>(TableNames.BOOKING, [], tenant),
-    serverGetDocumentById(TableNames.TENANT_SCHEMA, tenant),
-  ]);
-
-  // Apply environment-based calendar ID selection
+  // Schema is small; fetched up front so room mapping (if needed in future
+  // columns) is available before we start streaming rows.
+  const schema = await serverGetDocumentById(TableNames.TENANT_SCHEMA, tenant);
   const resourcesWithCorrectCalendarIds = schema?.resources
     ? applyEnvironmentCalendarIds(schema.resources)
     : [];
-
-  // Convert schema resources to RoomSetting format
   const rooms: RoomSetting[] = resourcesWithCorrectCalendarIds.map(
     (resource: any) => ({
       roomId: resource.roomId,
@@ -38,135 +176,46 @@ export async function GET(request: NextRequest) {
       calendarRef: undefined,
     }),
   );
+  // Reserved for future column additions that need the lookup.
+  void rooms;
 
-  // Create room ID to name mapping
-  const roomMap = new Map<number, string>();
-  rooms.forEach(room => {
-    roomMap.set(room.roomId, room.name);
+  const collectionName = getServerTenantCollection(TableNames.BOOKING, tenant);
+  const docStream = admin
+    .firestore()
+    .collection(collectionName)
+    .orderBy("requestNumber")
+    .stream() as unknown as NodeJS.ReadableStream & { destroy: () => void };
+
+  const encoder = new TextEncoder();
+  const headerLine = HEADERS.map(escapeCsv).join(",") + "\n";
+
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(headerLine));
+      docStream.on("data", (docSnap: any) => {
+        try {
+          const booking = { id: docSnap.id, ...docSnap.data() } as Booking;
+          controller.enqueue(encoder.encode(buildRow(booking) + "\n"));
+        } catch (err) {
+          controller.error(err);
+          docStream.destroy();
+        }
+      });
+      docStream.on("end", () => controller.close());
+      docStream.on("error", (err: Error) => controller.error(err));
+    },
+    cancel() {
+      docStream.destroy();
+    },
   });
 
-  // Helper function to determine booking status
-  const getBookingStatus = (booking: Booking): string => {
-    if (booking.finalApprovedAt) return "Approved";
-    if (booking.declinedAt) return "Declined";
-    if (booking.canceledAt) return "Canceled";
-    if (booking.checkedOutAt) return "Checked out";
-    if (booking.checkedInAt) return "Checked in";
-    if (booking.noShowedAt) return "No Show";
-    if (booking.firstApprovedAt) return "Pending";
-    return "Requested";
-  };
-
-  // Helper function to calculate time in use hours
-  const calculateTimeInUse = (startDate: any, endDate: any): number => {
-    const start = toDate(startDate);
-    const end = toDate(endDate);
-    if (!start || !end) return 0;
-    return (
-      Math.round(((end.getTime() - start.getTime()) / (1000 * 60 * 60)) * 100) /
-      100
-    );
-  };
-
-  // Helper function to count rooms used
-  const countRooms = (roomId: string | number): number => {
-    const roomIdStr = String(roomId);
-    return roomIdStr.includes(",") ? roomIdStr.split(",").length : 1;
-  };
-
-  // Parse any timestamp shape (admin Timestamp, {seconds, nanoseconds},
-  // {_seconds, _nanoseconds}, Date, string, number) via the shared helper.
-  // Returns null if missing or unparseable so the caller can render "".
-  const toDate = (timestamp: any): Date | null => {
-    if (timestamp == null) return null;
-    try {
-      const date = toFirebaseTimestamp(timestamp).toDate();
-      return isNaN(date.getTime()) ? null : date;
-    } catch {
-      return null;
-    }
-  };
-
-  const safeFormat = (timestamp: any, fmt: string): string => {
-    const date = toDate(timestamp);
-    return date ? formatInTimeZone(date, TIMEZONE, fmt) : "";
-  };
-
-  // Transform bookings to CSV format
-  const csvData = bookings
-    .sort((a, b) => a.requestNumber - b.requestNumber)
-    .map(booking => {
-      const timeInUse = calculateTimeInUse(booking.startDate, booking.endDate);
-      const roomCount = countRooms(booking.roomId);
-
-      return {
-        "Request #": booking.requestNumber,
-        School:
-          (booking as any).school === "Other" && (booking as any).otherSchool
-            ? (booking as any).otherSchool
-            : (booking as any).school || "",
-        Department:
-          booking.department === "Other" && booking.otherDepartment
-            ? booking.otherDepartment
-            : booking.department,
-        "Role (Affiliation)": booking.role,
-        "Room(s)": booking.roomId,
-        "Booking Start Date": safeFormat(booking.startDate, "M/d/yyyy"),
-        "Booking End Date": safeFormat(booking.endDate, "M/d/yyyy"),
-        "Booking Start Time": safeFormat(booking.startDate, "h:mm a"),
-        "Booking End Time": safeFormat(booking.endDate, "h:mm a"),
-        "Time In Use, Hours": timeInUse,
-        "# rooms used": roomCount,
-        "ACTUAL hours": timeInUse * roomCount,
-        "Reservation Title": booking.title,
-        "Reservation Description": booking.description,
-        "Expected Attendance": booking.expectedAttendance,
-        "Reservation Origin": booking.origin ? formatOrigin(booking.origin) : "",
-        "Booking Type": booking.bookingType,
-        "Attendee Affiliation(s)": booking.attendeeAffiliation,
-        "End Event Status": getBookingStatus(booking),
-        "Requested At": safeFormat(booking.requestedAt, "M/d/yyyy h:mm a"),
-        "First Approved At": safeFormat(booking.firstApprovedAt, "M/d/yyyy h:mm a"),
-        "Final Approved At": safeFormat(booking.finalApprovedAt, "M/d/yyyy h:mm a"),
-        "Declined At": safeFormat(booking.declinedAt, "M/d/yyyy h:mm a"),
-        "Checked In At": safeFormat(booking.checkedInAt, "M/d/yyyy h:mm a"),
-        "Checked Out At": safeFormat(booking.checkedOutAt, "M/d/yyyy h:mm a"),
-        "No Show At": safeFormat(booking.noShowedAt, "M/d/yyyy h:mm a"),
-        "Canceled At": safeFormat(booking.canceledAt, "M/d/yyyy h:mm a"),
-        "Closed At": safeFormat(booking.closedAt, "M/d/yyyy h:mm a"),
-        "Room Setup Needed (Y/N)": booking.roomSetup === "yes" ? "Yes" : "No",
-        "Room Setup Details": booking.setupDetails || "",
-        "Equipment Services (Y/N)":
-          booking.equipmentServices && booking.equipmentServices.length > 0
-            ? "Yes"
-            : "No",
-        "Equipment Service Details": booking.equipmentServicesDetails || "",
-        "Staffing Services (Y/N)":
-          booking.staffingServices && booking.staffingServices.length > 0
-            ? "Yes"
-            : "No",
-        "Staffing Service Details": booking.staffingServicesDetails || "",
-        "Catering (Y/N)": booking.catering === "yes" ? "Yes" : "No",
-        "Cleaning Services (Y/N)":
-          booking.cleaningService === "yes" ? "Yes" : "No",
-        "Hire Security (Y/N)": booking.hireSecurity === "yes" ? "Yes" : "No",
-      };
-    });
-
-  try {
-    const csv = parse(csvData);
-    const currentDate = formatInTimeZone(new Date(), TIMEZONE, "yyyy-MM-dd");
-    return new NextResponse(csv, {
-      status: 200,
-      headers: {
-        "Content-Type": "text/csv",
-        "Content-Disposition": `attachment; filename="bookings_export_${currentDate}.csv"`,
-      },
-    });
-  } catch (error) {
-    return NextResponse.json(
-      { error: "Failed to generate CSV data" },
-      { status: 400 },
-    );
-  }
+  const currentDate = formatInTimeZone(new Date(), TIMEZONE, "yyyy-MM-dd");
+  return new NextResponse(body, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="bookings_export_${currentDate}.csv"`,
+      "Cache-Control": "no-store",
+    },
+  });
 }


### PR DESCRIPTION
## Summary of Changes

`/api/bookings/export` returns **503 (\"upstream connect error\" → `SyntaxError: Unexpected token 'u'`)** in production when an MC admin clicks Export.

Root cause is OOM on the App Engine F1 instance, **not** a timeout. App Engine logs show:

> "the process that handled this request was found to be using too much memory and was terminated"

The route previously:
1. Loaded the entire `{tenant}-bookings` collection (~6,200 docs in MC prod) into memory via `serverFetchAllDataFromCollection`
2. Built a second array of the same size via `.map()`
3. Handed it to `json2csv.parse()` which serializes the whole CSV string at once

All three sit in memory simultaneously at peak. F1 (256 MB) can't hold it once the collection grew past a certain size — the instance gets killed mid-response.

This change reads docs one at a time using the Firestore admin SDK's `.stream()`, ordered by `requestNumber`, and writes rows directly into a `ReadableStream<Uint8Array>` using a small inline CSV escape helper. Peak in-memory state drops from \"whole collection + mapped array + full CSV string\" to \"one row\".

Behavior preserved:
- Same columns (including the per-status timestamp columns added in #1467)
- Same `safeFormat` / `formatOrigin` / status detection / time-in-use logic
- Filename / `Content-Disposition` unchanged
- Added `Cache-Control: no-store` since this is an authenticated export

Behavior change worth flagging:
- Ordering now comes from Firestore (`orderBy(\"requestNumber\")`) instead of a JS in-memory `.sort()`. Docs missing the `requestNumber` field would be silently excluded by Firestore. All real prod bookings carry the field, so this is a no-op in practice.
- `json2csv` is no longer referenced in source. Dependency removal is out of scope for this PR.

## Schema Changes

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [ ] I thoroughly tested this feature locally
- [ ] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [ ] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

No unit tests added: the route has no existing test scaffold and the change is mostly streaming rewiring of the same column logic.

## Screenshots / Video

To be verified against staging / prod once deployed.