### PR TITLE
chore(eslint): enable jsx-a11y recommended rules

### DIFF
--- a/booking-app/eslint.config.mjs
+++ b/booking-app/eslint.config.mjs
@@ -3,6 +3,7 @@ import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import prettierConfig from "eslint-config-prettier";
 import prettierPlugin from "eslint-plugin-prettier";
+import jsxA11y from "eslint-plugin-jsx-a11y";
 import globals from "globals";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -72,6 +73,17 @@ export default tseslint.config(
 
   // Prettier must be last to override formatting rules
   prettierConfig,
+
+  // jsx-a11y recommended rules for TSX/JSX
+  {
+    files: ["**/*.tsx", "**/*.jsx"],
+    plugins: { "jsx-a11y": jsxA11y },
+    rules: {
+      ...jsxA11y.configs.recommended.rules,
+      // Dialog primary buttons intentionally use autoFocus for focus management
+      "jsx-a11y/no-autofocus": "warn",
+    },
+  },
 
   // Project-wide settings and custom rules
   {

--- a/booking-app/package-lock.json
+++ b/booking-app/package-lock.json
@@ -69,6 +69,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-prettier": "^5.2.1",
         "globals": "^16.0.0",
         "jsdom": "^25.0.1",
@@ -10225,6 +10226,8 @@
     },
     "node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/booking-app/package.json
+++ b/booking-app/package.json
@@ -82,6 +82,7 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-prettier": "^5.2.1",
     "globals": "^16.0.0",
     "jsdom": "^25.0.1",


### PR DESCRIPTION
## Summary of Changes

Wires `eslint-plugin-jsx-a11y` (recommended rules) into the existing TSX/JSX lint pass so the accessibility fixes from #1483 do not silently regress. Future PRs introducing common a11y issues — missing `aria-label` on icon-only buttons, `label`/input mismatch, `<a>` without `href`, etc. — surface immediately via local `npm run lint` and IDE feedback.

Pre-existing transitive install of `eslint-plugin-jsx-a11y@6.10.2` is now promoted to an explicit `devDependency`.

`jsx-a11y/no-autofocus` is downgraded to `warn` because the project's `Dialog`/`DeclineReasonDialog` primary buttons intentionally use `autoFocus` for focus management — a recognized acceptable pattern. The 4 existing usages remain as warnings, not errors.

**Verification**
- `npx eslint "components/src/**/*.tsx" "app/**/*.tsx"` reports `0 errors, 4 warnings` for `jsx-a11y` (all the known `no-autofocus` cases).
- Overall lint count compared against `origin/main`: only the expected 4 new warnings; no new errors.

CI does not currently run `npm run lint`, so this change is purely a local / IDE signal today. It is a prerequisite for future enforcement.

## Schema Changes

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [ ] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

No screenshots — this is a lint-config-only change with no UI surface.

## Screenshots / Video

N/A