### PR TITLE
feat(schema): tenantSchema Firestore shape migration (Phase 2 of #1238)

### DIFF
--- a/booking-app/docs/SCHEMA_SYNC_GUIDE.md
+++ b/booking-app/docs/SCHEMA_SYNC_GUIDE.md
@@ -55,3 +55,7 @@ resources: defineObjectArrayWithDefaults(defaultResource),
 ```
 
 This allows the merge process to automatically apply defaults to each item in the array.
+
+## Related: one-time nested shape migration
+
+To **rewrite** stored documents from the legacy flat field layout to the nested canonical shape (and drop stale top-level keys), use the Firestore migration script described in [TENANT_SCHEMA_FIRESTORE_MIGRATION.md](./TENANT_SCHEMA_FIRESTORE_MIGRATION.md). That is separate from this add-only sync.

--- a/booking-app/docs/TENANT_SCHEMA_FIRESTORE_MIGRATION.md
+++ b/booking-app/docs/TENANT_SCHEMA_FIRESTORE_MIGRATION.md
@@ -1,0 +1,69 @@
+# Tenant schema Firestore shape migration
+
+This guide covers **`scripts/migrateTenantSchemaFirestore.ts`**, which rewrites `tenantSchema/{tenantId}` documents in Firestore to the **canonical nested tenant schema** (for example `tenant.name`, `mappings.role`, `form.services`, `emailNotifications`, `origins.walkIn`).
+
+Runtime reads already normalize legacy and new shapes via **`coerceTenantSchema`** (`lib/tenant/coerceTenantSchema.ts`). This script persists that normalized shape in the database so:
+
+- Legacy top-level fields (`name`, `emailMessages`, `programMapping`, …) are **removed** after migration.
+- Backups exist in **`tenantSchemaBackup`** before each destructive replace (unless you opt out).
+
+This is different from **`npm run sync:schemas`**, which **adds missing keys** with defaults and uses `merge: true`. The migration script uses **`set(..., { merge: false })`** and replaces the whole document with the coerced JSON.
+
+## Prerequisites
+
+- From the **`booking-app`** directory (where `package.json` lives).
+- **`.env.local`** with the same Firebase Admin variables used by other scripts (`FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY`). See also [SCHEMA_SYNC_GUIDE.md](./SCHEMA_SYNC_GUIDE.md) if you use the schema sync flow.
+- The **`npm run migrate:tenant-schema*`** scripts load **`tsconfig-paths/register`** so `@/` imports inside `coerceTenantSchema` resolve the same way as in the app.
+
+## Commands
+
+Dry run (no Firestore writes; writes preview JSON under `scripts/output/`):
+
+```bash
+npm run migrate:tenant-schema:dry-run
+```
+
+Same with explicit database (default is `development`):
+
+```bash
+npm run migrate:tenant-schema:dry-run -- --database staging
+```
+
+Apply migration (backs up each touched document, then replaces it):
+
+```bash
+npm run migrate:tenant-schema
+```
+
+Single tenant document id:
+
+```bash
+npm run migrate:tenant-schema -- --tenant mc --database production
+```
+
+## Flags
+
+| Flag | Meaning |
+|------|--------|
+| `--dry-run` | Do not write to Firestore; emit `scripts/output/migrate-tenant-schema-{id}-{database}.json` previews. |
+| `--database <env>` | `development` (default), `staging`, or `production` (same mapping as `syncTenantSchemas.ts`). |
+| `--tenant <id>` | Only process `tenantSchema/<id>`. Default: all documents in the `tenantSchema` collection. |
+| `--force-all` | Consider every document eligible even if it already looks nested with no stale legacy keys; still skips if coerced JSON is identical to stored JSON. |
+| `--skip-backup` | Do **not** write to `tenantSchemaBackup` before replace. Not recommended. |
+
+## What gets migrated
+
+Coercion matches app behavior: flat fields map into nested structures (see `coerceTenantSchema` and `STALE_LEGACY_TOP_LEVEL_TENANT_SCHEMA_KEYS` in the same module).
+
+By default, a document is migrated only if **`tenantSchemaFirestoreDocNeedsShapeMigration`** says so (legacy shape, `tenant` stored as a string, or nested document that still has stale top-level legacy keys). If nothing would change, the script **skips** the write.
+
+## Suggested rollout
+
+1. Run **`migrate:tenant-schema:dry-run`** against **development** and inspect `scripts/output/*.json`.
+2. Run **`migrate:tenant-schema`** on development and smoke-test the app.
+3. Repeat dry-run then apply for **staging**, then **production**, with the appropriate `--database` value.
+
+## Related docs and scripts
+
+- [SCHEMA_SYNC_GUIDE.md](./SCHEMA_SYNC_GUIDE.md) — syncing / merging default schema fields.
+- `scripts/syncTenantSchemas.ts` — add-only merge of new defaults (does not remove legacy top-level keys by itself).

--- a/booking-app/lib/tenant/coerceTenantSchema.ts
+++ b/booking-app/lib/tenant/coerceTenantSchema.ts
@@ -108,6 +108,82 @@ function isNewSchemaShape(raw: Record<string, unknown>): boolean {
 }
 
 /**
+ * Top-level keys from the legacy flat schema. If any are still present on a
+ * document that otherwise looks "nested", Firestore should be rewritten so the
+ * canonical nested-only shape is stored (avoids ambiguous round-trips).
+ */
+export const STALE_LEGACY_TOP_LEVEL_TENANT_SCHEMA_KEYS = [
+  "name",
+  "logo",
+  "nameForPolicy",
+  "permissionLabels",
+  "programMapping",
+  "roleMapping",
+  "schoolMapping",
+  "showBookingTypes",
+  "showNNumber",
+  "showSponsor",
+  "showCatering",
+  "showEquipment",
+  "showHireSecurity",
+  "showSetup",
+  "showStaffing",
+  "supportVIP",
+  "supportWalkIn",
+  "safetyTrainingGoogleFormId",
+  "timeSensitiveRequestWarning",
+  "emailMessages",
+  "agreements",
+] as const;
+
+/** Legacy field names that may still live inside a `resources[]` entry. */
+const STALE_LEGACY_RESOURCE_KEYS = [
+  "needsSafetyTraining",
+  "trainingFormUrl",
+  "trainingInfoUrl",
+] as const;
+
+/** True when the stored document already matches the nested tenant schema shape. */
+export function isNestedTenantSchemaDocument(
+  raw: Record<string, unknown> | null | undefined,
+): boolean {
+  return Boolean(raw && typeof raw === "object" && isNewSchemaShape(raw));
+}
+
+/**
+ * Whether a Firestore tenantSchema document should be rewritten to the canonical
+ * nested shape (coerce + full replace). Used by one-off migration tooling.
+ */
+export function tenantSchemaFirestoreDocNeedsShapeMigration(
+  raw: Record<string, unknown> | null | undefined,
+): boolean {
+  if (!raw || typeof raw !== "object") return false;
+  if (typeof raw.tenant === "string") return true;
+  if (!isNewSchemaShape(raw)) return true;
+  const hasStaleTopLevel = STALE_LEGACY_TOP_LEVEL_TENANT_SCHEMA_KEYS.some(
+    (k) =>
+      Object.prototype.hasOwnProperty.call(raw, k) &&
+      raw[k as string] !== undefined,
+  );
+  if (hasStaleTopLevel) return true;
+  // A doc may be nested at the top level but still carry legacy fields inside
+  // its resource entries (e.g. needsSafetyTraining / trainingFormUrl). Those
+  // also need canonicalizing, so flag them too.
+  const resources = raw.resources;
+  if (Array.isArray(resources)) {
+    return resources.some(
+      (r) =>
+        r &&
+        typeof r === "object" &&
+        STALE_LEGACY_RESOURCE_KEYS.some((k) =>
+          Object.prototype.hasOwnProperty.call(r, k),
+        ),
+    );
+  }
+  return false;
+}
+
+/**
  * Normalizes a tenant schema document from Firestore (new or legacy shape)
  * into SchemaContextType.
  */

--- a/booking-app/package.json
+++ b/booking-app/package.json
@@ -17,8 +17,10 @@
     "copy:staging:dry-run": "node scripts/copyCollection.js --source-database development --target-database staging --source-collection tenantSchema --target-collection tenantSchema --dry-run --report-file dry-run-staging-details.json",
     "copy:production:dry-run": "node scripts/copyCollection.js --source-database development --target-database production --source-collection tenantSchema --target-collection tenantSchema --dry-run --report-file dry-run-production-details.json",
     "mergeUsers": "node scripts/mergeUsersCollections.js",
-    "sync:schemas": "npx ts-node --transpile-only --compiler-options '{\"module\":\"commonjs\",\"jsx\":\"react\"}' scripts/syncTenantSchemas.ts",
-    "sync:schemas:dry-run": "npx ts-node --transpile-only --compiler-options '{\"module\":\"commonjs\",\"jsx\":\"react\"}' scripts/syncTenantSchemas.ts --dry-run"
+    "sync:schemas": "npx ts-node -r tsconfig-paths/register --transpile-only --compiler-options '{\"module\":\"commonjs\",\"jsx\":\"react\"}' scripts/syncTenantSchemas.ts",
+    "sync:schemas:dry-run": "npx ts-node -r tsconfig-paths/register --transpile-only --compiler-options '{\"module\":\"commonjs\",\"jsx\":\"react\"}' scripts/syncTenantSchemas.ts --dry-run",
+    "migrate:tenant-schema": "npx ts-node -r tsconfig-paths/register --transpile-only --compiler-options '{\"module\":\"commonjs\",\"jsx\":\"react\"}' scripts/migrateTenantSchemaFirestore.ts",
+    "migrate:tenant-schema:dry-run": "npx ts-node -r tsconfig-paths/register --transpile-only --compiler-options '{\"module\":\"commonjs\",\"jsx\":\"react\"}' scripts/migrateTenantSchemaFirestore.ts --dry-run"
   },
   "dependencies": {
     "@emotion/styled": "^11.13.0",

--- a/booking-app/scripts/migrateTenantSchemaFirestore.ts
+++ b/booking-app/scripts/migrateTenantSchemaFirestore.ts
@@ -1,0 +1,274 @@
+/**
+ * Migrate Firestore tenantSchema documents to the canonical nested shape.
+ *
+ * Uses the same coercion rules as runtime (lib/tenant/coerceTenantSchema.ts):
+ * flat legacy fields become tenant, mappings, form, origins, emailNotifications, etc.
+ *
+ * Writes the full document with merge: false so legacy top-level keys are removed.
+ * By default only documents that need migration are touched; use --force-all to
+ * rewrite every document through coercion (for example after tweaking coerce logic).
+ */
+
+require("dotenv").config({ path: ".env.local" });
+import * as admin from "firebase-admin";
+import * as fs from "fs";
+import * as path from "path";
+import {
+  coerceTenantSchema,
+  tenantSchemaFirestoreDocNeedsShapeMigration,
+} from "../lib/tenant/coerceTenantSchema";
+
+const { backupTenantSchemaDocument } = require("./tenantSchemaBackup");
+
+const TENANT_SCHEMA_COLLECTION = "tenantSchema";
+const BACKUP_TYPE = "shape-migration";
+
+const DATABASES = {
+  development: "default",
+  staging: "booking-app-staging",
+  production: "booking-app-prod",
+} as const;
+
+type DatabaseEnv = keyof typeof DATABASES;
+
+interface MigrateOptions {
+  dryRun: boolean;
+  tenant?: string;
+  database: DatabaseEnv;
+  /** Rewrite every document even if it already looks nested and has no stale keys */
+  forceAll: boolean;
+  /** Do not write to tenantSchemaBackup before replacing (not recommended) */
+  skipBackup: boolean;
+}
+
+function serializeForFirestore<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function sortKeysDeep(value: unknown): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  const o = value as Record<string, unknown>;
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(o).sort()) {
+    sorted[key] = sortKeysDeep(o[key]);
+  }
+  return sorted;
+}
+
+function stableStringify(obj: unknown): string {
+  return JSON.stringify(sortKeysDeep(obj));
+}
+
+function parseArgs(): MigrateOptions {
+  const args = process.argv.slice(2);
+  const options: MigrateOptions = {
+    dryRun: false,
+    database: "development",
+    forceAll: false,
+    skipBackup: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--dry-run":
+        options.dryRun = true;
+        break;
+      case "--tenant":
+        options.tenant = args[++i];
+        break;
+      case "--database":
+        options.database = (args[++i] || "development") as DatabaseEnv;
+        break;
+      case "--force-all":
+        options.forceAll = true;
+        break;
+      case "--skip-backup":
+        options.skipBackup = true;
+        break;
+      case "--help":
+        console.log(`
+Usage: npm run migrate:tenant-schema -- [options]
+   (or: npx ts-node -r tsconfig-paths/register ... scripts/migrateTenantSchemaFirestore.ts)
+
+Rewrites tenantSchema/{tenantId} to the nested canonical shape (coerceTenantSchema).
+Backs up the previous document to tenantSchemaBackup unless --dry-run or --skip-backup.
+
+Options:
+  --dry-run              Preview only; writes JSON under scripts/output/
+  --tenant <id>          Migrate a single document id (default: all docs in collection)
+  --database <env>       development | staging | production (default: development)
+  --force-all            Rewrite every document even if no stale legacy keys remain
+  --skip-backup          Do not copy current doc to tenantSchemaBackup before replace
+  --help                 Show this message
+
+Examples:
+  npm run migrate:tenant-schema:dry-run
+  npm run migrate:tenant-schema -- --tenant mc --database staging
+  npm run migrate:tenant-schema -- --database production --force-all
+`);
+        process.exit(0);
+        break;
+      default:
+        console.error(`Unknown argument: ${args[i]}`);
+        process.exit(1);
+    }
+  }
+
+  return options;
+}
+
+function initializeDb(databaseName: string) {
+  if (!admin.apps.length) {
+    admin.initializeApp({
+      credential: admin.credential.cert({
+        projectId: process.env.FIREBASE_PROJECT_ID,
+        clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+        privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n"),
+      }),
+    });
+  }
+
+  const db = admin.firestore();
+  if (databaseName !== "default") {
+    db.settings({ databaseId: databaseName });
+  }
+  return db;
+}
+
+function saveMigratedPreview(
+  tenantId: string,
+  database: string,
+  payload: Record<string, unknown>,
+): void {
+  const outputDir = path.join(__dirname, "output");
+  if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+  }
+  const filepath = path.join(
+    outputDir,
+    `migrate-tenant-schema-${tenantId}-${database}.json`,
+  );
+  fs.writeFileSync(filepath, JSON.stringify(payload, null, 2), "utf-8");
+  console.log(`  💾 Wrote preview: ${filepath}`);
+}
+
+async function migrateOne(
+  db: admin.firestore.Firestore,
+  tenantId: string,
+  raw: Record<string, unknown>,
+  options: MigrateOptions,
+): Promise<"skipped" | "would" | "written"> {
+  const eligible =
+    options.forceAll || tenantSchemaFirestoreDocNeedsShapeMigration(raw);
+  if (!eligible) {
+    console.log(`  ⏭️  Skip ${tenantId}: already canonical nested shape`);
+    return "skipped";
+  }
+
+  const migrated = coerceTenantSchema(raw, tenantId);
+  const payload = serializeForFirestore(migrated) as Record<string, unknown>;
+  const unchanged = stableStringify(raw) === stableStringify(payload);
+
+  if (unchanged) {
+    console.log(
+      `  ⏭️  Skip ${tenantId}: coerced JSON matches stored data (nothing to rewrite)`,
+    );
+    return "skipped";
+  }
+
+  if (options.dryRun) {
+    console.log(
+      `  🔍 [DRY RUN] Would replace ${tenantId} with coerced nested schema`,
+    );
+    saveMigratedPreview(tenantId, options.database, payload);
+    return "would";
+  }
+
+  if (!options.skipBackup) {
+    const { backupDocId, backupCollection } = await backupTenantSchemaDocument(
+      db,
+      tenantId,
+      raw,
+      BACKUP_TYPE,
+    );
+    console.log(`  📦 Backup ${backupCollection}/${backupDocId}`);
+  }
+
+  await db
+    .collection(TENANT_SCHEMA_COLLECTION)
+    .doc(tenantId)
+    .set(payload, { merge: false });
+  console.log(`  ✅ Replaced ${tenantId} (merge: false)`);
+  return "written";
+}
+
+async function main() {
+  const options = parseArgs();
+
+  if (!DATABASES[options.database]) {
+    console.error(`Invalid --database: ${options.database}`);
+    console.error(`Valid: ${Object.keys(DATABASES).join(", ")}`);
+    process.exit(1);
+  }
+
+  const dbName = DATABASES[options.database];
+  const db = initializeDb(dbName);
+
+  console.log("🚀 Tenant schema shape migration");
+  console.log({
+    dryRun: options.dryRun,
+    database: options.database,
+    firestoreDatabaseId: dbName,
+    tenant: options.tenant ?? "(all documents in tenantSchema)",
+    forceAll: options.forceAll,
+    skipBackup: options.skipBackup,
+  });
+
+  let docEntries: { id: string; raw: Record<string, unknown> }[];
+  if (options.tenant) {
+    const snap = await db
+      .collection(TENANT_SCHEMA_COLLECTION)
+      .doc(options.tenant)
+      .get();
+    if (!snap.exists) {
+      console.error(`No document tenantSchema/${options.tenant}`);
+      process.exit(1);
+    }
+    docEntries = [
+      { id: snap.id, raw: snap.data() as Record<string, unknown> },
+    ];
+  } else {
+    const snap = await db.collection(TENANT_SCHEMA_COLLECTION).get();
+    docEntries = snap.docs.map((d) => ({
+      id: d.id,
+      raw: d.data() as Record<string, unknown>,
+    }));
+  }
+
+  const counts = { skipped: 0, would: 0, written: 0 };
+
+  for (const { id, raw } of docEntries) {
+    console.log(`\n📄 ${id}`);
+    const result = await migrateOne(db, id, raw, options);
+    counts[result]++;
+  }
+
+  console.log("\n📊 Summary:", counts);
+  if (options.dryRun) {
+    console.log("\n💡 Run without --dry-run to apply (after reviewing scripts/output/).");
+  }
+}
+
+if (require.main === module) {
+  main()
+    .catch((e) => {
+      console.error(e);
+      process.exit(1);
+    })
+    .finally(async () => {
+      for (const app of admin.apps) {
+        if (app) await app.delete();
+      }
+    });
+}

--- a/booking-app/scripts/migrateTenantSchemaFirestore.ts
+++ b/booking-app/scripts/migrateTenantSchemaFirestore.ts
@@ -69,16 +69,29 @@ function parseArgs(): MigrateOptions {
     skipBackup: false,
   };
 
+  // Consume the value following a flag, failing fast if it is missing or is
+  // actually another flag (e.g. `--tenant --database staging`).
+  const takeValue = (flag: string, i: number): string => {
+    const value = args[i + 1];
+    if (value === undefined || value.startsWith("--")) {
+      console.error(`Missing value for ${flag}`);
+      process.exit(1);
+    }
+    return value;
+  };
+
   for (let i = 0; i < args.length; i++) {
     switch (args[i]) {
       case "--dry-run":
         options.dryRun = true;
         break;
       case "--tenant":
-        options.tenant = args[++i];
+        options.tenant = takeValue("--tenant", i);
+        i++;
         break;
       case "--database":
-        options.database = (args[++i] || "development") as DatabaseEnv;
+        options.database = takeValue("--database", i) as DatabaseEnv;
+        i++;
         break;
       case "--force-all":
         options.forceAll = true;

--- a/booking-app/tests/unit/coerce-tenant-schema-migration.unit.test.ts
+++ b/booking-app/tests/unit/coerce-tenant-schema-migration.unit.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import {
+  isNestedTenantSchemaDocument,
+  tenantSchemaFirestoreDocNeedsShapeMigration,
+} from "@/lib/tenant/coerceTenantSchema";
+
+describe("tenantSchemaFirestoreDocNeedsShapeMigration", () => {
+  it("returns true for flat legacy top-level fields", () => {
+    expect(
+      tenantSchemaFirestoreDocNeedsShapeMigration({
+        name: "MC",
+        emailMessages: { requestConfirmation: "t1" },
+        resources: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when tenant is a legacy string slug", () => {
+    expect(
+      tenantSchemaFirestoreDocNeedsShapeMigration({
+        tenant: "mc",
+        resources: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when nested shape still has stale legacy keys", () => {
+    expect(
+      tenantSchemaFirestoreDocNeedsShapeMigration({
+        tenantId: "mc",
+        tenant: { name: "x", logo: "", nameForPolicy: "", contextLabels: {} },
+        mappings: { program: {}, role: {}, school: {} },
+        form: { showBookingType: true, showNNumber: true, showSponsor: true, services: {} },
+        emailMessages: { requestConfirmation: "old" },
+        emailNotifications: { requestedUser: "new" },
+      } as Record<string, unknown>),
+    ).toBe(true);
+  });
+
+  it("returns true when nested doc still has legacy fields inside resources", () => {
+    // Top-level is fully nested/canonical, but a resource entry still carries
+    // legacy training fields — those need canonicalizing too.
+    expect(
+      tenantSchemaFirestoreDocNeedsShapeMigration({
+        tenantId: "mc",
+        tenant: { name: "x", logo: "", nameForPolicy: "", contextLabels: {} },
+        mappings: { program: {}, role: {}, school: {} },
+        form: { showBookingType: true, showNNumber: true, showSponsor: true, services: {} },
+        origins: { VIP: false, walkIn: false },
+        emailNotifications: { requestedUser: "" },
+        resources: [
+          { name: "R1", roomId: 1, needsSafetyTraining: true },
+        ],
+      } as Record<string, unknown>),
+    ).toBe(true);
+  });
+
+  it("returns false for minimal nested canonical doc", () => {
+    const doc = {
+      tenantId: "mc",
+      tenant: {
+        name: "Media Commons",
+        logo: "",
+        nameForPolicy: "",
+        contextLabels: {
+          user: "User",
+          worker: "PA",
+          reviewer: "Liaison",
+          services: "Services",
+          admin: "Admin",
+        },
+      },
+      mappings: { program: {}, role: {}, school: {} },
+      form: {
+        showBookingType: true,
+        showNNumber: true,
+        showSponsor: true,
+        services: {
+          showCatering: true,
+          showEquipment: true,
+          showSecurity: true,
+          showSetup: true,
+          showStaffing: true,
+        },
+      },
+      origins: { VIP: false, walkIn: false },
+      emailNotifications: { requestedUser: "" },
+    };
+    expect(tenantSchemaFirestoreDocNeedsShapeMigration(doc)).toBe(false);
+    expect(isNestedTenantSchemaDocument(doc)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary of Changes

Phase 2 of #1238 (tenantSchema field rename/restructure). Phase 1 (#1470) shipped
read-time coercion so the app reads both the legacy flat shape and the new nested
shape. This PR adds the **one-time data migration tooling** that rewrites the
stored `tenantSchema/{id}` documents into the canonical nested shape, so the old
field names stop existing in the database.

- `scripts/migrateTenantSchemaFirestore.ts`
  - `--dry-run`: writes a preview JSON under `scripts/output/`, **no Firestore writes**.
  - apply: backs up each document to `tenantSchemaBackup`, then full-replaces it
    with `set(merge: false)` so stale legacy top-level keys are removed.
  - Uses the same `coerceTenantSchema` as runtime, so the #1470 data-loss fixes
    (coerce-before-defaults, partial-migration handling, top-level warning pickup)
    apply automatically.
  - Flags: `--tenant <id>`, `--database development|staging|production`,
    `--force-all`, `--skip-backup`.
- `coerceTenantSchema`: migration-detection helpers
  (`tenantSchemaFirestoreDocNeedsShapeMigration`, `isNestedTenantSchemaDocument`,
  `STALE_LEGACY_TOP_LEVEL_TENANT_SCHEMA_KEYS`). Detection also flags nested docs
  whose `resources[]` still carry legacy training fields.
- `package.json`: `migrate:tenant-schema[:dry-run]`; also adds
  `tsconfig-paths/register` to `sync:schemas` so `@/` imports resolve.
- Docs + unit tests.

**This PR does not migrate any data.** Merging only adds the tool. The actual
rewrite is a manual command run against a specific database.

### Rollout (ordering matters)
1. ⚠️ Run **only after Phase 1 (#1470) is fully deployed to prod** — older code
   cannot read the nested shape.
2. `npm run migrate:tenant-schema:dry-run -- --database production`, diff the
   preview JSON against live docs (verify email text / attestations / training /
   mappings / branding / time-sensitive warning are not blanked).
3. Apply per database (development → staging → production), backups written
   automatically.
4. Do **not** run `sync:schemas` between Phase 1 deploy and this migration.

Follow-up (Phase 3): once all tenants are confirmed on the new names, remove the
coerce legacy branch and deprecated types.

## Schema Changes

- [x] Schema changed (describe below)

Rewrites stored `tenantSchema` documents for **mc** and **itp** from the flat
legacy field layout to the nested canonical shape (e.g. `emailMessages →
emailNotifications`, `agreements → attestations`, `needsSafetyTraining →
resources[].training.required`, `name → tenant.name`, `programMapping →
mappings.program`). No values are added or removed — only renamed/restructured.
Stale legacy top-level keys are dropped. Backups are written to
`tenantSchemaBackup` before each replace.

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [ ] I thoroughly tested this feature locally
- [x] I added or updated unit tests
- [ ] I attached screenshots or a video demonstrating the feature (CLI tooling — N/A; dry-run diff to be attached at rollout)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [ ] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

Local verification: `tsc --noEmit` passes; migration + coerce unit tests pass.

## Screenshots / Video

<!-- CLI migration tooling. A production dry-run diff will be attached before applying. -->
