### PR TITLE
ci(firestore): drive index deploy from firestore.indexes.json (single source)

### DIFF
--- a/.github/workflows/deploy_development_app_engine.yml
+++ b/.github/workflows/deploy_development_app_engine.yml
@@ -82,55 +82,17 @@ jobs:
           cd booking-app
           npm run build
 
-      # Sync Firestore composite indexes for this environment's database.
-      # Uses gcloud directly (not `firebase deploy`) because firebase-tools
-      # 15.x throws TypeError on the multi-database `firestore` array in
-      # firebase.json, masking real failures behind a generic wrapper.
+      # Sync Firestore composite indexes for this environment's database from
+      # firestore.indexes.json (single source of truth — add indexes there, not
+      # here). Uses gcloud directly (not `firebase deploy`) because
+      # firebase-tools 15.x throws TypeError on the multi-database `firestore`
+      # array in firebase.json, masking real failures behind a generic wrapper.
       # gcloud is already authenticated via setup-gcloud above.
       - name: Deploy Firestore indexes
         timeout-minutes: 20
         run: |
-          DB='(default)'
-          PROJECT="${{ secrets.GCP_PROJECT_ID }}"
-
-          create_index() {
-            local CG="$1"
-            shift
-            echo "Ensuring composite index on $CG in $DB..."
-            set +e
-            OUTPUT=$(gcloud firestore indexes composite create \
-              --collection-group="$CG" \
-              --database="$DB" \
-              --project="$PROJECT" \
-              "$@" \
-              --quiet 2>&1)
-            EXIT=$?
-            set -e
-            if [ $EXIT -ne 0 ]; then
-              if echo "$OUTPUT" | grep -qi "ALREADY_EXISTS"; then
-                echo "Index already exists for $CG, skipping"
-                return 0
-              fi
-              echo "Failed to create index for $CG:"
-              echo "$OUTPUT"
-              return 1
-            fi
-            echo "$OUTPUT"
-          }
-
-          BOOKINGS_FIELDS=(
-            --field-config=field-path=email,order=ascending
-            --field-config=field-path=startDate,order=descending
-          )
-          BOOKING_LOGS_FIELDS=(
-            --field-config=field-path=calendarEventId,order=ascending
-            --field-config=field-path=status,order=ascending
-          )
-
-          create_index mc-bookings "${BOOKINGS_FIELDS[@]}"
-          create_index itp-bookings "${BOOKINGS_FIELDS[@]}"
-          create_index mc-bookingLogs "${BOOKING_LOGS_FIELDS[@]}"
-          create_index itp-bookingLogs "${BOOKING_LOGS_FIELDS[@]}"
+          bash booking-app/scripts/deploy-firestore-indexes.sh \
+            '(default)' "${{ secrets.GCP_PROJECT_ID }}"
 
       - name: Deploy to App Engine
         run: |

--- a/.github/workflows/deploy_production_app_engine.yml
+++ b/.github/workflows/deploy_production_app_engine.yml
@@ -82,55 +82,17 @@ jobs:
           cd booking-app
           npm run build
 
-      # Sync Firestore composite indexes for this environment's database.
-      # Uses gcloud directly (not `firebase deploy`) because firebase-tools
-      # 15.x throws TypeError on the multi-database `firestore` array in
-      # firebase.json, masking real failures behind a generic wrapper.
+      # Sync Firestore composite indexes for this environment's database from
+      # firestore.indexes.json (single source of truth — add indexes there, not
+      # here). Uses gcloud directly (not `firebase deploy`) because
+      # firebase-tools 15.x throws TypeError on the multi-database `firestore`
+      # array in firebase.json, masking real failures behind a generic wrapper.
       # gcloud is already authenticated via setup-gcloud above.
       - name: Deploy Firestore indexes
         timeout-minutes: 20
         run: |
-          DB='booking-app-prod'
-          PROJECT="${{ secrets.GCP_PROJECT_ID }}"
-
-          create_index() {
-            local CG="$1"
-            shift
-            echo "Ensuring composite index on $CG in $DB..."
-            set +e
-            OUTPUT=$(gcloud firestore indexes composite create \
-              --collection-group="$CG" \
-              --database="$DB" \
-              --project="$PROJECT" \
-              "$@" \
-              --quiet 2>&1)
-            EXIT=$?
-            set -e
-            if [ $EXIT -ne 0 ]; then
-              if echo "$OUTPUT" | grep -qi "ALREADY_EXISTS"; then
-                echo "Index already exists for $CG, skipping"
-                return 0
-              fi
-              echo "Failed to create index for $CG:"
-              echo "$OUTPUT"
-              return 1
-            fi
-            echo "$OUTPUT"
-          }
-
-          BOOKINGS_FIELDS=(
-            --field-config=field-path=email,order=ascending
-            --field-config=field-path=startDate,order=descending
-          )
-          BOOKING_LOGS_FIELDS=(
-            --field-config=field-path=calendarEventId,order=ascending
-            --field-config=field-path=status,order=ascending
-          )
-
-          create_index mc-bookings "${BOOKINGS_FIELDS[@]}"
-          create_index itp-bookings "${BOOKINGS_FIELDS[@]}"
-          create_index mc-bookingLogs "${BOOKING_LOGS_FIELDS[@]}"
-          create_index itp-bookingLogs "${BOOKING_LOGS_FIELDS[@]}"
+          bash booking-app/scripts/deploy-firestore-indexes.sh \
+            'booking-app-prod' "${{ secrets.GCP_PROJECT_ID }}"
 
       - name: Deploy to App Engine
         run: |

--- a/.github/workflows/deploy_staging_app_engine.yml
+++ b/.github/workflows/deploy_staging_app_engine.yml
@@ -82,55 +82,17 @@ jobs:
           cd booking-app
           npm run build
 
-      # Sync Firestore composite indexes for this environment's database.
-      # Uses gcloud directly (not `firebase deploy`) because firebase-tools
-      # 15.x throws TypeError on the multi-database `firestore` array in
-      # firebase.json, masking real failures behind a generic wrapper.
+      # Sync Firestore composite indexes for this environment's database from
+      # firestore.indexes.json (single source of truth — add indexes there, not
+      # here). Uses gcloud directly (not `firebase deploy`) because
+      # firebase-tools 15.x throws TypeError on the multi-database `firestore`
+      # array in firebase.json, masking real failures behind a generic wrapper.
       # gcloud is already authenticated via setup-gcloud above.
       - name: Deploy Firestore indexes
         timeout-minutes: 20
         run: |
-          DB='booking-app-staging'
-          PROJECT="${{ secrets.GCP_PROJECT_ID }}"
-
-          create_index() {
-            local CG="$1"
-            shift
-            echo "Ensuring composite index on $CG in $DB..."
-            set +e
-            OUTPUT=$(gcloud firestore indexes composite create \
-              --collection-group="$CG" \
-              --database="$DB" \
-              --project="$PROJECT" \
-              "$@" \
-              --quiet 2>&1)
-            EXIT=$?
-            set -e
-            if [ $EXIT -ne 0 ]; then
-              if echo "$OUTPUT" | grep -qi "ALREADY_EXISTS"; then
-                echo "Index already exists for $CG, skipping"
-                return 0
-              fi
-              echo "Failed to create index for $CG:"
-              echo "$OUTPUT"
-              return 1
-            fi
-            echo "$OUTPUT"
-          }
-
-          BOOKINGS_FIELDS=(
-            --field-config=field-path=email,order=ascending
-            --field-config=field-path=startDate,order=descending
-          )
-          BOOKING_LOGS_FIELDS=(
-            --field-config=field-path=calendarEventId,order=ascending
-            --field-config=field-path=status,order=ascending
-          )
-
-          create_index mc-bookings "${BOOKINGS_FIELDS[@]}"
-          create_index itp-bookings "${BOOKINGS_FIELDS[@]}"
-          create_index mc-bookingLogs "${BOOKING_LOGS_FIELDS[@]}"
-          create_index itp-bookingLogs "${BOOKING_LOGS_FIELDS[@]}"
+          bash booking-app/scripts/deploy-firestore-indexes.sh \
+            'booking-app-staging' "${{ secrets.GCP_PROJECT_ID }}"
 
       - name: Deploy to App Engine
         run: |

--- a/booking-app/scripts/deploy-firestore-indexes.sh
+++ b/booking-app/scripts/deploy-firestore-indexes.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Provision Firestore composite indexes for a single environment database.
+#
+# Single source of truth: firestore.indexes.json (the Firebase-native index
+# format). To add or change an index, edit that file only — the deploy
+# workflows do not need to change.
+#
+# We drive `gcloud firestore indexes composite create` rather than
+# `firebase deploy --only firestore:indexes` because firebase-tools 15.x
+# throws a TypeError on the multi-database `firestore` array in firebase.json,
+# masking real failures. gcloud must already be authenticated by the caller.
+#
+# Usage: deploy-firestore-indexes.sh <database> <project> [indexes-file]
+#   <database>     Firestore database id (e.g. '(default)', 'booking-app-prod')
+#   <project>      GCP project id
+#   [indexes-file] defaults to firestore.indexes.json next to this script's dir
+#
+set -euo pipefail
+
+DB="${1:?database id required}"
+PROJECT="${2:?project id required}"
+INDEXES_FILE="${3:-$(dirname "$0")/../firestore.indexes.json}"
+
+command -v jq >/dev/null 2>&1 || { echo "jq is required but not installed" >&2; exit 1; }
+[ -f "$INDEXES_FILE" ] || { echo "Indexes file not found: $INDEXES_FILE" >&2; exit 1; }
+
+echo "Provisioning Firestore indexes from '$INDEXES_FILE' into database '$DB' (project $PROJECT)"
+
+COUNT=$(jq '.indexes | length' "$INDEXES_FILE")
+FAILED=0
+
+for i in $(seq 0 $((COUNT - 1))); do
+  CG=$(jq -r ".indexes[$i].collectionGroup" "$INDEXES_FILE")
+  SCOPE=$(jq -r ".indexes[$i].queryScope // \"COLLECTION\"" "$INDEXES_FILE")
+
+  ARGS=(--collection-group="$CG" --database="$DB" --project="$PROJECT")
+  if [ "$SCOPE" = "COLLECTION_GROUP" ]; then
+    ARGS+=(--query-scope=collection-group)
+  fi
+
+  # One --field-config per field: ordered fields use order=asc/desc, array
+  # fields use array-config=contains.
+  while IFS= read -r field; do
+    path=$(jq -r '.fieldPath' <<<"$field")
+    order=$(jq -r '.order // empty' <<<"$field")
+    array=$(jq -r '.arrayConfig // empty' <<<"$field")
+    if [ -n "$order" ]; then
+      ord=$(echo "$order" | tr '[:upper:]' '[:lower:]')
+      ARGS+=("--field-config=field-path=$path,order=$ord")
+    elif [ -n "$array" ]; then
+      ARGS+=("--field-config=field-path=$path,array-config=contains")
+    else
+      echo "  WARNING: field '$path' on $CG has neither order nor arrayConfig; skipping field" >&2
+    fi
+  done < <(jq -c ".indexes[$i].fields[]" "$INDEXES_FILE")
+
+  echo "Ensuring composite index on $CG ($SCOPE) in $DB..."
+  set +e
+  OUTPUT=$(gcloud firestore indexes composite create "${ARGS[@]}" --quiet 2>&1)
+  EXIT=$?
+  set -e
+
+  if [ $EXIT -ne 0 ]; then
+    if echo "$OUTPUT" | grep -qi "ALREADY_EXISTS"; then
+      echo "  already exists, skipping"
+    else
+      echo "  FAILED to create index for $CG:"
+      echo "$OUTPUT"
+      FAILED=1
+    fi
+  else
+    echo "$OUTPUT"
+  fi
+done
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "One or more indexes failed to create." >&2
+  exit 1
+fi
+
+echo "All Firestore indexes ensured for database '$DB'."


### PR DESCRIPTION
## Summary of Changes

The deploy workflows created Firestore composite indexes from a **hard-coded list duplicated across all three environment files** (`deploy_{development,staging,production}_app_engine.yml`). Every new index meant editing three files, and the list had already drifted: it omitted the `(email ASC, requestedAt ASC)` index that the request-limits feature (#1403) requires. As a result those queries failed with `FAILED_PRECONDITION`, and because enforcement runs in a fail-open `try/catch`, request limits were silently disabled (`/api/bookings/request-limits` 500s, booking allowed through).

This PR makes **`firestore.indexes.json` the single source of truth**:

- Adds `booking-app/scripts/deploy-firestore-indexes.sh`, which reads `firestore.indexes.json` and runs `gcloud firestore indexes composite create` for each index against the environment's database (`ALREADY_EXISTS` is skipped; a real failure exits non-zero).
- Each workflow's `Deploy Firestore indexes` step now just calls the script with its database id (`(default)` / `booking-app-staging` / `booking-app-prod`). The duplicated inline bash is gone (−135 / +103 lines net).

Adding or changing an index is now a one-line edit to `firestore.indexes.json` — no workflow changes. The `(email, requestedAt)` index is already in that file (added in #1403), so this PR also provisions it and fixes the original bug.

We keep `gcloud` rather than `firebase deploy --only firestore:indexes` because firebase-tools 15.x throws a `TypeError` on the multi-database `firestore` array in `firebase.json` (the reason the workflows used gcloud in the first place).

## Schema Changes

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [ ] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [ ] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

### Testing notes

This is a CI/script change; the `gcloud` calls only run on deploy. Verified locally:

- **YAML validity** of all three workflow files.
- Ran `deploy-firestore-indexes.sh` against the real `firestore.indexes.json` with a **stub `gcloud`**, confirming it emits exactly the 6 expected `composite create` commands (identical field-config to the previous hard-coded list, including the two `(email, requestedAt)` indexes).
- Verified the `ALREADY_EXISTS` path skips and exits 0, and a non-`ALREADY_EXISTS` failure exits 1.
- The same `(email, requestedAt)` index spec was created manually on the dev `(default)` database and confirmed to fix the `FAILED_PRECONDITION` (limits then enforced, returning 429).

Not yet verified: an actual CI run against staging/production databases (runs only on deploy; re-runs are safe via `ALREADY_EXISTS`).

## Screenshots / Video

N/A — CI/script change only.
