### PR TITLE
Reapply "feat(schema): migrate tenant resources to string resource IDs"

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,9 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd booking-app
-          # Clean install to avoid optional dependencies issues
-          rm -rf node_modules package-lock.json
-          npm install --force
+          npm ci
 
       - name: Run unit tests
         env:

--- a/booking-app/app/api/bookings/edit/route.ts
+++ b/booking-app/app/api/bookings/edit/route.ts
@@ -251,7 +251,7 @@ export async function PUT(request: NextRequest) {
     );
 
     const selectedRoomIds = selectedRooms
-      .map((r: { roomId: number }) => r.roomId)
+      .map((r: { roomId: string }) => r.roomId)
       .join(", ");
 
     console.log("✏️ EDIT: Deleting old calendar events");

--- a/booking-app/app/api/bookings/export/route.ts
+++ b/booking-app/app/api/bookings/export/route.ts
@@ -169,7 +169,7 @@ export async function GET(request: NextRequest) {
     : [];
   const rooms: RoomSetting[] = resourcesWithCorrectCalendarIds.map(
     (resource: any) => ({
-      roomId: resource.roomId,
+      roomId: String(resource.resourceId ?? resource.roomId),
       name: resource.name,
       capacity: resource.capacity.toString(),
       calendarId: resource.calendarId,

--- a/booking-app/app/api/bookings/modification/route.ts
+++ b/booking-app/app/api/bookings/modification/route.ts
@@ -124,7 +124,7 @@ export async function PUT(request: NextRequest) {
     );
 
     const selectedRoomIds = selectedRooms
-      .map((r: { roomId: number }) => r.roomId)
+      .map((r: { roomId: string }) => r.roomId)
       .join(", ");
 
     console.log("🔧 MODIFICATION: Deleting old calendar events");

--- a/booking-app/app/api/bookings/request-limits/route.ts
+++ b/booking-app/app/api/bookings/request-limits/route.ts
@@ -18,10 +18,10 @@ export async function POST(request: NextRequest) {
     const formContext = body?.formContext as FormContextLevel | undefined;
     const roomIdsRaw = body?.roomIds;
 
-    const roomIds: number[] = Array.isArray(roomIdsRaw)
+    const roomIds: string[] = Array.isArray(roomIdsRaw)
       ? roomIdsRaw
-          .map((x: unknown) => Number(x))
-          .filter((n: number) => Number.isFinite(n))
+          .map((x: unknown) => (x == null ? "" : String(x).trim()))
+          .filter((resourceId: string) => resourceId.length > 0)
       : [];
 
     const tenant = extractTenantFromRequest(request);

--- a/booking-app/app/api/bookings/route.ts
+++ b/booking-app/app/api/bookings/route.ts
@@ -165,7 +165,7 @@ const getTenantRooms = async (tenant?: string) => {
     );
 
     return resourcesWithCorrectCalendarIds.map((resource: any) => ({
-      roomId: resource.roomId,
+      roomId: String(resource.resourceId ?? resource.roomId),
       name: resource.name,
       capacity: resource.capacity?.toString(),
       calendarId: resource.calendarId,
@@ -233,9 +233,7 @@ async function createBookingCalendarEvent(
     throw Error(`calendarId not found for room ${room.roomId}`);
   }
 
-  const selectedRoomIds = selectedRooms.map(
-    (r: { roomId: number }) => r.roomId,
-  );
+  const selectedRoomIds = selectedRooms.map((r) => r.roomId);
   const otherRoomEmails = otherRooms.map(
     (r: { calendarId: string }) => r.calendarId,
   );
@@ -578,13 +576,18 @@ export async function POST(request: NextRequest) {
       FormContextLevel.FULL_FORM,
       bookingRoleField,
     );
-    const selectedRoomIdsNums: number[] = Array.isArray(selectedRooms)
+    const selectedRoomIdsForLimits: string[] = Array.isArray(selectedRooms)
       ? selectedRooms
-          .map((r: any) => Number(r?.roomId))
-          .filter((n: number) => Number.isFinite(n))
+          .map((r: any) => (r?.roomId == null ? "" : String(r.roomId).trim()))
+          .filter((resourceId: string) => resourceId.length > 0)
       : [];
 
-    if (tenant && email && bookingRoleField && selectedRoomIdsNums.length > 0) {
+    if (
+      tenant &&
+      email &&
+      bookingRoleField &&
+      selectedRoomIdsForLimits.length > 0
+    ) {
       const tenantSchema = await serverGetDocumentById<SchemaContextType>(
         TableNames.TENANT_SCHEMA,
         tenant,
@@ -596,7 +599,7 @@ export async function POST(request: NextRequest) {
         email,
         bookingRoleField,
         limitRoleKey,
-        selectedRoomIds: selectedRoomIdsNums,
+        selectedRoomIds: selectedRoomIdsForLimits,
         schema: tenantSchema,
       });
 
@@ -817,12 +820,10 @@ export async function POST(request: NextRequest) {
   // Generate Sequential ID early so it can be used in calendar description
   const sequentialId = await serverGetNextSequentialId("bookings", tenant);
 
-  const selectedRoomIds = selectedRooms
-    .map((r: { roomId: number }) => r.roomId)
-    .join(", ");
   const selectedRoomIdsArray = selectedRooms
-    .map((r: { roomId: number | string }) => Number((r as any)?.roomId))
-    .filter((n: number) => Number.isFinite(n));
+    .map((r: { roomId: number | string }) => String(r.roomId).trim())
+    .filter((resourceId: string) => resourceId.length > 0);
+  const selectedRoomIds = selectedRoomIdsArray.join(", ");
 
   // Build booking contents for description
   const startDateObj = new Date(bookingCalendarInfo.startStr);

--- a/booking-app/app/api/bookings/shared.ts
+++ b/booking-app/app/api/bookings/shared.ts
@@ -104,7 +104,7 @@ export const getTenantRooms = async (tenant?: string) => {
     );
 
     return resourcesWithCorrectCalendarIds.map((resource: any) => ({
-      roomId: resource.roomId,
+      roomId: String(resource.resourceId ?? resource.roomId),
       name: resource.name,
       capacity: resource.capacity?.toString(),
       calendarId: resource.calendarId,

--- a/booking-app/app/api/bookingsDirect/route.ts
+++ b/booking-app/app/api/bookingsDirect/route.ts
@@ -98,9 +98,7 @@ export async function POST(request: NextRequest) {
   const { departmentDisplay, schoolDisplay } =
     getAffiliationDisplayValues(data);
   const [room, ...otherRooms] = selectedRooms;
-  const selectedRoomIds = selectedRooms.map(
-    (r: { roomId: number }) => r.roomId,
-  );
+  const selectedRoomIds = selectedRooms.map((r: { roomId: string }) => r.roomId);
   const otherRoomIds = otherRooms.map(
     (r: { calendarId: string }) => r.calendarId,
   );

--- a/booking-app/app/api/cancel-processing/route.ts
+++ b/booking-app/app/api/cancel-processing/route.ts
@@ -55,7 +55,8 @@ export async function POST(req: NextRequest) {
 
           const roomIds = booking.roomId.split(",").map(x => x.trim());
           const rooms = resourcesWithCorrectCalendarIds.filter(
-            (resource: any) => roomIds.includes(`${resource.roomId}`),
+            (resource: any) =>
+              roomIds.includes(String(resource.resourceId ?? resource.roomId)),
           );
 
           console.log(
@@ -64,7 +65,7 @@ export async function POST(req: NextRequest) {
               calendarEventId,
               roomIds,
               rooms: rooms.map((r: any) => ({
-                roomId: r.roomId,
+                roomId: String(r.resourceId ?? r.roomId),
                 calendarId: r.calendarId,
               })),
             },

--- a/booking-app/app/api/inviteUser/route.ts
+++ b/booking-app/app/api/inviteUser/route.ts
@@ -15,7 +15,7 @@ export async function POST(request: NextRequest) {
     await inviteUserToCalendarEvent(
       calendarEventId,
       guestEmail,
-      parseInt(roomId, 10),
+      String(roomId),
       tenant,
     );
     return NextResponse.json({ calendarEventId }, { status: 200 });

--- a/booking-app/app/api/safety_training_form/route.ts
+++ b/booking-app/app/api/safety_training_form/route.ts
@@ -37,9 +37,7 @@ export async function GET(request: NextRequest) {
     let formId: string | null = null;
 
     if (resourceId) {
-      const resource = schema.resources?.find(
-        (r) => r.roomId?.toString() === resourceId.toString(),
-      );
+      const resource = schema.resources?.find(r => r.resourceId === resourceId);
       const resourceForm = resource?.training?.formId;
       if (resourceForm) {
         formId = extractGoogleFormId(resourceForm);

--- a/booking-app/app/api/syncCalendars/route.ts
+++ b/booking-app/app/api/syncCalendars/route.ts
@@ -99,20 +99,20 @@ const findRoomIds = (event: any, resources: any[]): string => {
     r => r.calendarId === event.organizer.email,
   );
   if (currentResource) {
-    roomIds.add(currentResource.roomId);
+    roomIds.add(String(currentResource.resourceId ?? currentResource.roomId));
   }
 
   // Add other room IDs
   attendees.forEach((attendee: any) => {
     const resource = resources.find(r => r.calendarId === attendee.email);
     if (resource) {
-      roomIds.add(resource.roomId);
+      roomIds.add(String(resource.resourceId ?? resource.roomId));
     }
   });
 
-  // Convert to array, sort numerically, and join
+  // Resource IDs are opaque strings; numeric sorting is only a display aid.
   return Array.from(roomIds)
-    .sort((a, b) => parseInt(a) - parseInt(b))
+    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
     .join(",");
 };
 
@@ -135,9 +135,9 @@ export async function POST(request: Request) {
       : [];
 
     const resources = resourcesWithCorrectCalendarIds.map((resource: any) => ({
-      id: resource.roomId.toString(),
+      id: String(resource.resourceId ?? resource.roomId),
       calendarId: resource.calendarId,
-      roomId: resource.roomId,
+      roomId: String(resource.resourceId ?? resource.roomId),
     }));
 
     let totalNewBookings = 0;

--- a/booking-app/app/api/syncSemesterPregameBookings/route.ts
+++ b/booking-app/app/api/syncSemesterPregameBookings/route.ts
@@ -594,9 +594,9 @@ export async function POST(request: NextRequest) {
       : [];
 
     const resources = resourcesWithCorrectCalendarIds.map((resource: any) => ({
-      id: resource.roomId.toString(),
+      id: String(resource.resourceId ?? resource.roomId),
       calendarId: resource.calendarId,
-      roomId: resource.roomId,
+      roomId: String(resource.resourceId ?? resource.roomId),
     }));
 
     if (testMode) {

--- a/booking-app/components/src/client/routes/admin/components/policySettings/BookingBlackoutPeriods.tsx
+++ b/booking-app/components/src/client/routes/admin/components/policySettings/BookingBlackoutPeriods.tsx
@@ -62,6 +62,13 @@ type RoomApplicationType =
   | "multi"
   | "specific";
 
+type RuntimeBlackoutPeriod = Omit<BlackoutPeriod, "roomIds"> & {
+  roomIds?: string[];
+};
+
+const sortResourceIds = (resourceIds: string[]) =>
+  resourceIds.sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+
 /**
  * Check if two sorted arrays are equal
  */
@@ -74,16 +81,17 @@ function areSortedArraysEqual<T>(arr1: T[], arr2: T[]): boolean {
 
 export default function BookingBlackoutPeriods() {
   const { roomSettings } = useContext(DatabaseContext);
-  const [blackoutPeriods, setBlackoutPeriods] = useState<BlackoutPeriod[]>([]);
+  const [blackoutPeriods, setBlackoutPeriods] = useState<
+    RuntimeBlackoutPeriod[]
+  >([]);
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState<{
     type: "success" | "error";
     text: string;
   } | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [editingPeriod, setEditingPeriod] = useState<BlackoutPeriod | null>(
-    null,
-  );
+  const [editingPeriod, setEditingPeriod] =
+    useState<RuntimeBlackoutPeriod | null>(null);
 
   // Form state
   const [periodName, setPeriodName] = useState("");
@@ -91,7 +99,7 @@ export default function BookingBlackoutPeriods() {
   const [endDate, setEndDate] = useState<Dayjs | null>(null);
   const [startTime, setStartTime] = useState<Dayjs | null>(null);
   const [endTime, setEndTime] = useState<Dayjs | null>(null);
-  const [selectedRooms, setSelectedRooms] = useState<number[]>([]);
+  const [selectedRooms, setSelectedRooms] = useState<string[]>([]);
   const [roomApplicationType, setRoomApplicationType] =
     useState<RoomApplicationType>("all");
 
@@ -106,6 +114,15 @@ export default function BookingBlackoutPeriods() {
     });
   }, [roomSettings]);
 
+  const getCategoryResourceIds = (legacyRoomIds: readonly number[]) => {
+    const legacyIds = new Set(legacyRoomIds.map(String));
+    return sortResourceIds(
+      roomSettings
+        .filter((room) => legacyIds.has(room.roomId))
+        .map((room) => room.roomId),
+    );
+  };
+
   const fetchBlackoutPeriods = async () => {
     try {
       const fetchedData =
@@ -113,17 +130,22 @@ export default function BookingBlackoutPeriods() {
           TableNames.BLACKOUT_PERIODS,
         );
       setBlackoutPeriods(
-        fetchedData.sort(
-          (a, b) =>
-            a.startDate.toDate().getTime() - b.startDate.toDate().getTime(),
-        ),
+        fetchedData
+          .map((period) => ({
+            ...period,
+            roomIds: period.roomIds?.map(String),
+          }))
+          .sort(
+            (a, b) =>
+              a.startDate.toDate().getTime() - b.startDate.toDate().getTime(),
+          ),
       );
     } catch (error) {
       console.error("Error fetching blackout periods:", error);
     }
   };
 
-  const handleOpenDialog = (period?: BlackoutPeriod) => {
+  const handleOpenDialog = (period?: RuntimeBlackoutPeriod) => {
     if (period) {
       setEditingPeriod(period);
       setPeriodName(period.name);
@@ -147,19 +169,13 @@ export default function BookingBlackoutPeriods() {
 
       if (period.roomIds && period.roomIds.length > 0) {
         // Check what type of room application this is
-        const allRoomIds = roomSettings
-          .map((room) => room.roomId)
-          .sort((a, b) => a - b);
-        const periodRoomIds = [...period.roomIds].sort((a, b) => a - b);
-        const productionRoomIds = PRODUCTION_ROOMS.filter((roomId) =>
-          roomSettings.some((room) => room.roomId === roomId),
-        ).sort((a, b) => a - b);
-        const eventRoomIds = EVENT_ROOMS.filter((roomId) =>
-          roomSettings.some((room) => room.roomId === roomId),
-        ).sort((a, b) => a - b);
-        const multiRoomIds = MULTI_ROOMS.filter((roomId) =>
-          roomSettings.some((room) => room.roomId === roomId),
-        ).sort((a, b) => a - b);
+        const allRoomIds = sortResourceIds(
+          roomSettings.map((room) => room.roomId),
+        );
+        const periodRoomIds = sortResourceIds([...period.roomIds]);
+        const productionRoomIds = getCategoryResourceIds(PRODUCTION_ROOMS);
+        const eventRoomIds = getCategoryResourceIds(EVENT_ROOMS);
+        const multiRoomIds = getCategoryResourceIds(MULTI_ROOMS);
 
         const isAllRooms =
           allRoomIds.length === periodRoomIds.length &&
@@ -259,32 +275,26 @@ export default function BookingBlackoutPeriods() {
 
     try {
       // Determine which rooms to apply the blackout to
-      let roomIds: number[] = [];
+      let roomIds: string[] = [];
       switch (roomApplicationType) {
         case "all":
           roomIds = roomSettings.map((room) => room.roomId);
           break;
         case "production":
-          roomIds = PRODUCTION_ROOMS.filter((roomId) =>
-            roomSettings.some((room) => room.roomId === roomId),
-          );
+          roomIds = getCategoryResourceIds(PRODUCTION_ROOMS);
           break;
         case "event":
-          roomIds = EVENT_ROOMS.filter((roomId) =>
-            roomSettings.some((room) => room.roomId === roomId),
-          );
+          roomIds = getCategoryResourceIds(EVENT_ROOMS);
           break;
         case "multi":
-          roomIds = MULTI_ROOMS.filter((roomId) =>
-            roomSettings.some((room) => room.roomId === roomId),
-          );
+          roomIds = getCategoryResourceIds(MULTI_ROOMS);
           break;
         case "specific":
           roomIds = selectedRooms;
           break;
       }
 
-      const periodData: Omit<BlackoutPeriod, "id"> = {
+      const periodData: Omit<RuntimeBlackoutPeriod, "id"> = {
         name: periodName.trim(),
         startDate: Timestamp.fromDate(startDate.toDate()),
         endDate: Timestamp.fromDate(endDate.toDate()),
@@ -330,7 +340,7 @@ export default function BookingBlackoutPeriods() {
     }
   };
 
-  const handleDeletePeriod = async (period: BlackoutPeriod) => {
+  const handleDeletePeriod = async (period: RuntimeBlackoutPeriod) => {
     if (!window.confirm(`Are you sure you want to delete "${period.name}"?`)) {
       return;
     }
@@ -368,25 +378,17 @@ export default function BookingBlackoutPeriods() {
     return dateStr;
   };
 
-  const getRoomNames = (period: BlackoutPeriod) => {
+  const getRoomNames = (period: RuntimeBlackoutPeriod) => {
     if (!period.roomIds || period.roomIds.length === 0) {
       return "All Rooms";
     }
 
     // Check if this matches any of our predefined categories
-    const allRoomIds = roomSettings
-      .map((room) => room.roomId)
-      .sort((a, b) => a - b);
-    const periodRoomIds = [...period.roomIds].sort((a, b) => a - b);
-    const productionRoomIds = PRODUCTION_ROOMS.filter((roomId) =>
-      roomSettings.some((room) => room.roomId === roomId),
-    ).sort((a, b) => a - b);
-    const eventRoomIds = EVENT_ROOMS.filter((roomId) =>
-      roomSettings.some((room) => room.roomId === roomId),
-    ).sort((a, b) => a - b);
-    const multiRoomIds = MULTI_ROOMS.filter((roomId) =>
-      roomSettings.some((room) => room.roomId === roomId),
-    ).sort((a, b) => a - b);
+    const allRoomIds = sortResourceIds(roomSettings.map((room) => room.roomId));
+    const periodRoomIds = sortResourceIds([...period.roomIds]);
+    const productionRoomIds = getCategoryResourceIds(PRODUCTION_ROOMS);
+    const eventRoomIds = getCategoryResourceIds(EVENT_ROOMS);
+    const multiRoomIds = getCategoryResourceIds(MULTI_ROOMS);
 
     const isAllRooms = areSortedArraysEqual(allRoomIds, periodRoomIds);
     const isProductionRooms = areSortedArraysEqual(
@@ -418,19 +420,13 @@ export default function BookingBlackoutPeriods() {
   };
 
   const getProductionRoomNumbers = () =>
-    PRODUCTION_ROOMS.filter((roomId) =>
-      roomSettings.some((room) => room.roomId === roomId),
-    ).join(", ");
+    getCategoryResourceIds(PRODUCTION_ROOMS).join(", ");
 
   const getEventRoomNumbers = () =>
-    EVENT_ROOMS.filter((roomId) =>
-      roomSettings.some((room) => room.roomId === roomId),
-    ).join(", ");
+    getCategoryResourceIds(EVENT_ROOMS).join(", ");
 
   const getMultiRoomNumbers = () =>
-    MULTI_ROOMS.filter((roomId) =>
-      roomSettings.some((room) => room.roomId === roomId),
-    ).join(", ");
+    getCategoryResourceIds(MULTI_ROOMS).join(", ");
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
@@ -631,7 +627,7 @@ export default function BookingBlackoutPeriods() {
                     multiple
                     value={selectedRooms}
                     onChange={(e) => {
-                      const value = e.target.value as number[];
+                      const value = e.target.value as string[];
                       setSelectedRooms(value);
                     }}
                     input={<OutlinedInput label="Select Rooms" />}

--- a/booking-app/components/src/client/routes/admin/components/policySettings/OperationalHours.tsx
+++ b/booking-app/components/src/client/routes/admin/components/policySettings/OperationalHours.tsx
@@ -34,10 +34,15 @@ const MenuProps = {
 
 export default function OperationalHours() {
   const { operationHours, roomSettings } = useContext(DatabaseContext);
-  const [specialHourRooms, setSpecialHourRooms] = useState<number[]>(
+  const [specialHourRooms, setSpecialHourRooms] = useState<string[]>(
     Array.from(
-      new Set(operationHours.map((x) => x.roomId).filter((x) => x != null)),
-    ).sort((a, b) => a - b),
+      new Set(
+        operationHours
+          .map((x) => x.roomId)
+          .filter((x) => x != null)
+          .map(String),
+      ),
+    ).sort((a, b) => a.localeCompare(b, undefined, { numeric: true })),
   ); // roomIds
 
   const handleChange = (event: SelectChangeEvent<typeof specialHourRooms>) => {
@@ -45,11 +50,10 @@ export default function OperationalHours() {
       target: { value },
     } = event;
     // On autofill we get a stringified value.
-    const list =
-      typeof value === "string"
-        ? value.split(",").map((x) => Number(x))
-        : value;
-    setSpecialHourRooms(list.sort((a, b) => a - b));
+    const list = typeof value === "string" ? value.split(",") : value;
+    setSpecialHourRooms(
+      list.sort((a, b) => a.localeCompare(b, undefined, { numeric: true })),
+    );
   };
 
   return (
@@ -121,7 +125,7 @@ export default function OperationalHours() {
                     <OperationalHoursRow
                       day={day}
                       setting={operationHours.find(
-                        (x) => x.day === day && x.roomId === roomId,
+                        (x) => x.day === day && String(x.roomId) === roomId,
                       )}
                       roomId={roomId}
                       key={day}

--- a/booking-app/components/src/client/routes/admin/components/policySettings/OperationalHoursRow.tsx
+++ b/booking-app/components/src/client/routes/admin/components/policySettings/OperationalHoursRow.tsx
@@ -18,11 +18,18 @@ const Row = styled(Box)`
 interface Props {
   day: Days;
   setting: OperationHours;
-  roomId?: number;
+  roomId?: string;
 }
 
 export default function OperationalHoursRow({ day, setting, roomId }: Props) {
   const { reloadOperationHours } = useContext(DatabaseContext);
+  const updateResourceOperationHours = updateOperationHours as unknown as (
+    day: Days,
+    open: number,
+    close: number,
+    isClosed: boolean,
+    roomId?: string,
+  ) => Promise<void>;
 
   const [closed, setClosed] = useState(setting?.isClosed || false);
   const [openDate, setOpenDate] = useState(
@@ -34,7 +41,7 @@ export default function OperationalHoursRow({ day, setting, roomId }: Props) {
 
   const handleSwitch = (e) => {
     setClosed(!e.target.checked);
-    updateOperationHours(
+    updateResourceOperationHours(
       day,
       openDate.hour(),
       closeDate.hour(),
@@ -45,12 +52,12 @@ export default function OperationalHoursRow({ day, setting, roomId }: Props) {
 
   const handleOpenChange = (e) => {
     setOpenDate(e);
-    updateOperationHours(day, e.$H, closeDate.hour(), closed, roomId);
+    updateResourceOperationHours(day, e.$H, closeDate.hour(), closed, roomId);
   };
 
   const handleCloseChange = (e) => {
     setCloseDate(e);
-    updateOperationHours(day, openDate.hour(), e.$H, closed, roomId);
+    updateResourceOperationHours(day, openDate.hour(), e.$H, closed, roomId);
   };
 
   // when we leave the page, the app reloads the newly set operation hours.

--- a/booking-app/components/src/client/routes/admin/hooks/useExistingBooking.tsx
+++ b/booking-app/components/src/client/routes/admin/hooks/useExistingBooking.tsx
@@ -25,7 +25,7 @@ export default function useExistingBooking() {
     setDepartment(booking.department as Department);
     setRole(booking.role as Role);
 
-    const roomIds = booking.roomId.split(", ").map((x) => Number(x));
+    const roomIds = booking.roomId.split(",").map((roomId) => roomId.trim());
     const rooms = roomSettings.filter((roomSetting) =>
       roomIds.includes(roomSetting.roomId),
     );

--- a/booking-app/components/src/client/routes/booking/bookingProvider.tsx
+++ b/booking-app/components/src/client/routes/booking/bookingProvider.tsx
@@ -161,9 +161,13 @@ export function BookingProvider({ children }) {
     const bookingStart = dayjs(bookingCalendarInfo.start);
     const bookingEnd = dayjs(bookingCalendarInfo.end);
     const selectedRoomIds = selectedRooms.map((room) => room.roomId);
+    const stringIdBlackoutPeriods = blackoutPeriods.map((period) => ({
+      ...period,
+      roomIds: period.roomIds?.map(String),
+    }));
 
     const affectingPeriods = getAffectingBlackoutPeriods(
-      blackoutPeriods,
+      stringIdBlackoutPeriods,
       bookingStart,
       bookingEnd,
       selectedRoomIds,

--- a/booking-app/components/src/client/routes/booking/components/BookingFormMediaServices.tsx
+++ b/booking-app/components/src/client/routes/booking/components/BookingFormMediaServices.tsx
@@ -51,11 +51,11 @@ export default function BookingFormMediaServices(props: Props) {
     // Check for specific room services
     selectedRooms.forEach((room) => {
       if (showStaffing) {
-        if (room.roomId === 103) {
+        if (room.roomId === "103") {
           options.push(MediaServices.AUDIO_TECH_103);
           options.push(MediaServices.LIGHTING_TECH_103);
         }
-        if (room.roomId === 230) {
+        if (room.roomId === "230") {
           options.push(MediaServices.AUDIO_TECH_230);
         }
         if (room.services?.includes("campus-media")) {

--- a/booking-app/components/src/client/routes/booking/components/CalendarVerticalResource.tsx
+++ b/booking-app/components/src/client/routes/booking/components/CalendarVerticalResource.tsx
@@ -141,11 +141,17 @@ export default function CalendarVerticalResource({
 
   const resources = useMemo(
     () =>
-      rooms.map((room) => ({
-        id: `${room.roomId}`,
-        title: `${room.roomId} ${room.name}`,
-        index: Number(room.roomId),
-      })),
+      [...rooms]
+        .sort((a, b) =>
+          String(a.roomId).localeCompare(String(b.roomId), undefined, {
+            numeric: true,
+          }),
+        )
+        .map((room, index) => ({
+          id: room.roomId,
+          title: `${room.roomId} ${room.name}`,
+          index,
+        })),
     [rooms],
   );
 
@@ -169,7 +175,7 @@ export default function CalendarVerticalResource({
             start: blackoutRange.start.toISOString(),
             end: blackoutRange.end.toISOString(),
             id: `blackout-${room.roomId}-${period.id}`,
-            resourceId: `${room.roomId}`,
+            resourceId: room.roomId,
             title: blackoutRange.title,
             overlap: false,
             display: "background",
@@ -208,12 +214,11 @@ export default function CalendarVerticalResource({
       start: bookingCalendarInfo.startStr,
       end: bookingCalendarInfo.endStr,
       id: room.roomId + bookingCalendarInfo.startStr,
-      resourceId: `${room.roomId}`,
+      resourceId: room.roomId,
       title: NEW_TITLE_TAG,
       overlap: true,
       durationEditable: true,
-      startEditable:
-        formContext !== FormContextLevel.MODIFICATION || isAdmin,
+      startEditable: formContext !== FormContextLevel.MODIFICATION || isAdmin,
       groupId: "new",
       url: `${index}:${rooms.length}`, // some hackiness to let us render multiple events visually as one big block
     }));
@@ -241,11 +246,9 @@ export default function CalendarVerticalResource({
     const selectedResourceId = selectInfo.resource?.id;
 
     if (!isAdmin && selectedResourceId) {
-      const roomId = parseInt(selectedResourceId);
-
       // Use the new time-aware blackout checking
       const { inBlackout } = isBookingTimeInBlackout(bookingStart, bookingEnd, [
-        roomId,
+        selectedResourceId,
       ]);
 
       if (inBlackout) {
@@ -267,11 +270,9 @@ export default function CalendarVerticalResource({
     const selectedResourceId = selectInfo.resource?.id;
 
     if (!isAdmin && selectedResourceId) {
-      const roomId = parseInt(selectedResourceId);
-
       // Use the new time-aware blackout checking
       const { inBlackout } = isBookingTimeInBlackout(bookingStart, bookingEnd, [
-        roomId,
+        selectedResourceId,
       ]);
 
       if (inBlackout) {
@@ -407,9 +408,7 @@ export default function CalendarVerticalResource({
           googleCalendarPlugin,
           interactionPlugin,
         ]}
-        selectable={
-          formContext !== FormContextLevel.MODIFICATION || isAdmin
-        }
+        selectable={formContext !== FormContextLevel.MODIFICATION || isAdmin}
         select={handleEventSelect}
         selectAllow={handleEventSelecting}
         selectOverlap={handleSelectOverlap}

--- a/booking-app/components/src/client/routes/booking/components/SelectRooms.tsx
+++ b/booking-app/components/src/client/routes/booking/components/SelectRooms.tsx
@@ -32,13 +32,18 @@ export const SelectRooms = ({
   } = useContext(BookingContext);
   const { isBookingTimeInBlackout } = useBookingDateRestrictions();
   const { resources, calendarConfig } = useTenantSchema();
-  const selectedIds = selected.map((room) => room.roomId);
+  const selectedIds = selected.map((room) => String(room.roomId));
   const allowMultipleResourceSelect =
     calendarConfig?.multipleResourceSelect ?? true;
 
   // Sort rooms by room number for consistent display order
   const sortedRooms = useMemo(
-    () => [...allRooms].sort((a, b) => a.roomId - b.roomId),
+    () =>
+      [...allRooms].sort((a, b) =>
+        String(a.roomId).localeCompare(String(b.roomId), undefined, {
+          numeric: true,
+        }),
+      ),
     [allRooms],
   );
 
@@ -53,7 +58,7 @@ export const SelectRooms = ({
 
   // Check if a room is in blackout for the selected booking time
   const isRoomInBlackout = (
-    roomId: number,
+    roomId: string,
   ): { inBlackout: boolean; periods: any[] } => {
     if (!bookingCalendarInfo) return { inBlackout: false, periods: [] };
 
@@ -69,7 +74,7 @@ export const SelectRooms = ({
   };
 
   // walk-ins can only book 1 room unless it's 2 ballroom bays (221-224)
-  const isDisabled = (roomId: number) => {
+  const isDisabled = (roomId: string) => {
     if (!allowMultipleResourceSelect) {
       if (selectedIds.length === 0) return false;
       if (selectedIds.includes(roomId)) return false;
@@ -85,9 +90,11 @@ export const SelectRooms = ({
 
     // Check if both selected room and current room can book two
     const selectedRoom = resources.find(
-      (r: any) => r.roomId === selectedIds[0],
+      (resource) => resource.resourceId === selectedIds[0],
     );
-    const currentRoom = resources.find((r: any) => r.roomId === roomId);
+    const currentRoom = resources.find(
+      (resource) => resource.resourceId === roomId,
+    );
 
     if (selectedRoom?.isWalkInCanBookTwo && currentRoom?.isWalkInCanBookTwo) {
       return false;
@@ -95,7 +102,7 @@ export const SelectRooms = ({
     return true;
   };
 
-  const getDisabledReason = (roomId: number): string | null => {
+  const getDisabledReason = (roomId: string): string | null => {
     const blackoutInfo = isRoomInBlackout(roomId);
     if (blackoutInfo.inBlackout) {
       const periodNames = blackoutInfo.periods.map((p) => p.name).join(", ");
@@ -111,9 +118,11 @@ export const SelectRooms = ({
 
     // Check if both selected room and current room can book two
     const selectedRoom = resources.find(
-      (r: any) => r.roomId === selectedIds[0],
+      (resource) => resource.resourceId === selectedIds[0],
     );
-    const currentRoom = resources.find((r: any) => r.roomId === roomId);
+    const currentRoom = resources.find(
+      (resource) => resource.resourceId === roomId,
+    );
 
     if (selectedRoom?.isWalkInCanBookTwo && currentRoom?.isWalkInCanBookTwo) {
       return null;
@@ -124,22 +133,27 @@ export const SelectRooms = ({
 
   const handleCheckChange = (e: any, room: RoomSetting) => {
     const newVal: boolean = e.target.checked;
+    const normalizedRoom = { ...room, roomId: String(room.roomId) };
     setSelected((prev: RoomSetting[]) => {
       if (newVal) {
         if (
           !allowMultipleResourceSelect &&
           prev.length > 0 &&
-          !prev.some((r) => r.roomId === room.roomId)
+          !prev.some((r) => String(r.roomId) === normalizedRoom.roomId)
         ) {
           return prev;
         }
 
-        const newSelection = [...prev, room].sort(
-          (a, b) => a.roomId - b.roomId,
+        const newSelection = [...prev, normalizedRoom].sort((a, b) =>
+          String(a.roomId).localeCompare(String(b.roomId), undefined, {
+            numeric: true,
+          }),
         );
         return newSelection;
       }
-      const newSelection = prev.filter((r) => r.roomId !== room.roomId);
+      const newSelection = prev.filter(
+        (r) => String(r.roomId) !== normalizedRoom.roomId,
+      );
       if (newSelection.length === 0) {
         setBookingCalendarInfo(null);
       }
@@ -150,17 +164,20 @@ export const SelectRooms = ({
   return (
     <FormGroup>
       {sortedRooms.map((room: RoomSetting) => {
-        const disabled = isDisabled(room.roomId);
-        const disabledReason = getDisabledReason(room.roomId);
+        const roomId = String(room.roomId);
+        const disabled = isDisabled(roomId);
+        const disabledReason = getDisabledReason(roomId);
 
         const checkbox = (
           <FormControlLabel
             control={
               <Checkbox
-                checked={selectedIds.includes(room.roomId)}
+                checked={selectedIds.includes(roomId)}
                 onChange={(e) => handleCheckChange(e, room)}
                 icon={
-                  allowMultipleResourceSelect ? undefined : <RadioButtonUncheckedIcon />
+                  allowMultipleResourceSelect ? undefined : (
+                    <RadioButtonUncheckedIcon />
+                  )
                 }
                 checkedIcon={
                   allowMultipleResourceSelect ? undefined : <CheckCircleIcon />

--- a/booking-app/components/src/client/routes/booking/formPages/SelectRoomPage.tsx
+++ b/booking-app/components/src/client/routes/booking/formPages/SelectRoomPage.tsx
@@ -47,7 +47,7 @@ export default function SelectRoomPage({
     // Convert schema resources to RoomSetting format for compatibility
     const convertedResources = resources.map((resource) => ({
       ...resource,
-      roomId: resource.roomId,
+      roomId: resource.resourceId,
       name: resource.name,
       capacity: resource.capacity.toString(),
       calendarId: resource.calendarId,
@@ -68,12 +68,7 @@ export default function SelectRoomPage({
 
     const allRooms = !isWalkIn
       ? convertedResources
-      : convertedResources.filter((room) => {
-          const resource = schema.resources.find(
-            (r: any) => r.roomId === room.roomId,
-          );
-          return resource?.isWalkIn || false;
-        });
+      : convertedResources.filter((room) => room.isWalkIn);
 
     return allRooms;
   }, [schema.resources, isWalkIn]);

--- a/booking-app/components/src/client/routes/booking/hooks/useBookingDateRestrictions.tsx
+++ b/booking-app/components/src/client/routes/booking/hooks/useBookingDateRestrictions.tsx
@@ -16,6 +16,15 @@ export const useBookingDateRestrictions = () => {
     return blackoutPeriods.filter((period) => period.isActive);
   }, [blackoutPeriods]);
 
+  const stringIdBlackoutPeriods = useMemo(
+    () =>
+      activeBlackoutPeriods.map((period) => ({
+        ...period,
+        roomIds: period.roomIds?.map(String),
+      })),
+    [activeBlackoutPeriods],
+  );
+
   const isDateDisabled = (date: Dayjs) => {
     // Always disable past dates
     if (date.isBefore(dayjs(), "day")) {
@@ -33,8 +42,12 @@ export const useBookingDateRestrictions = () => {
       if (roomSettings && roomSettings.length > 0 && period.roomIds) {
         const allRoomIds = roomSettings
           .map((room) => room.roomId)
-          .sort((a, b) => a - b);
-        const periodRoomIds = [...period.roomIds].sort((a, b) => a - b);
+          .sort((a, b) =>
+            String(a).localeCompare(String(b), undefined, { numeric: true }),
+          );
+        const periodRoomIds = period.roomIds
+          .map(String)
+          .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
         const isAllRooms =
           allRoomIds.length === periodRoomIds.length &&
           allRoomIds.every((id, index) => id === periodRoomIds[index]);
@@ -48,7 +61,9 @@ export const useBookingDateRestrictions = () => {
   };
 
   // Check if a specific date is disabled for specific rooms
-  const isDateDisabledForRooms = (date: Dayjs, roomIds: number[]) => {
+  const isDateDisabledForRooms = (date: Dayjs, roomIds: string[]) => {
+    const normalizedRoomIds = roomIds.map(String);
+
     // Always disable past dates
     if (date.isBefore(dayjs(), "day")) {
       return true;
@@ -63,7 +78,10 @@ export const useBookingDateRestrictions = () => {
 
       // If period has roomIds, check if any of the selected rooms are in the blackout period
       if (period.roomIds) {
-        return roomIds.some((roomId) => period.roomIds.includes(roomId));
+        const periodRoomIds = period.roomIds.map(String);
+        return normalizedRoomIds.some((roomId) =>
+          periodRoomIds.includes(roomId),
+        );
       }
 
       // If no roomIds, treat as global blackout that applies to all rooms
@@ -78,8 +96,9 @@ export const useBookingDateRestrictions = () => {
     });
 
   // Get blackout periods that apply to specific rooms for a specific date
-  const getBlackoutPeriodsForDateAndRooms = (date: Dayjs, roomIds: number[]) =>
+  const getBlackoutPeriodsForDateAndRooms = (date: Dayjs, roomIds: string[]) =>
     activeBlackoutPeriods.filter((period) => {
+      const normalizedRoomIds = roomIds.map(String);
       const blackoutRange = getBlackoutTimeRangeForDate(period, date);
       if (!blackoutRange) {
         return false; // Date not in blackout period
@@ -87,7 +106,10 @@ export const useBookingDateRestrictions = () => {
 
       // If period has roomIds, check if any of the selected rooms are in the blackout period
       if (period.roomIds) {
-        return roomIds.some((roomId) => period.roomIds.includes(roomId));
+        const periodRoomIds = period.roomIds.map(String);
+        return normalizedRoomIds.some((roomId) =>
+          periodRoomIds.includes(roomId),
+        );
       }
 
       // Include global blackout periods (those without roomIds)
@@ -98,17 +120,17 @@ export const useBookingDateRestrictions = () => {
   const isBookingTimeInBlackout = (
     bookingStart: Dayjs,
     bookingEnd: Dayjs,
-    roomIds: number[],
+    roomIds: string[],
   ): { inBlackout: boolean; affectedPeriods: any[] } => {
     if (!roomIds || roomIds.length === 0) {
       return { inBlackout: false, affectedPeriods: [] };
     }
 
     const affectedPeriods = getAffectingBlackoutPeriods(
-      activeBlackoutPeriods,
+      stringIdBlackoutPeriods,
       bookingStart,
       bookingEnd,
-      roomIds,
+      roomIds.map(String),
     );
 
     return {
@@ -121,17 +143,17 @@ export const useBookingDateRestrictions = () => {
   const getBlackoutPeriodsForBookingTime = (
     bookingStart: Dayjs,
     bookingEnd: Dayjs,
-    roomIds: number[],
+    roomIds: string[],
   ) =>
     getAffectingBlackoutPeriods(
-      activeBlackoutPeriods,
+      stringIdBlackoutPeriods,
       bookingStart,
       bookingEnd,
-      roomIds,
+      roomIds.map(String),
     );
 
   const shouldDisableDate = (date: Dayjs) => isDateDisabled(date);
-  const shouldDisableDateForRooms = (date: Dayjs, roomIds: number[]) =>
+  const shouldDisableDateForRooms = (date: Dayjs, roomIds: string[]) =>
     isDateDisabledForRooms(date, roomIds);
 
   return {

--- a/booking-app/components/src/client/routes/booking/hooks/useCalculateOverlap.tsx
+++ b/booking-app/components/src/client/routes/booking/hooks/useCalculateOverlap.tsx
@@ -21,10 +21,10 @@ export default function useCalculateOverlap() {
       calendarEventId = segments[segments.length - 1];
     }
 
-    const selectedRoomIds = selectedRooms.map((x) => x.roomId);
+    const selectedRoomIds = selectedRooms.map((x) => String(x.roomId));
     return existingCalendarEvents
       .map((event) => {
-        if (!selectedRoomIds.includes(Number(event.resourceId))) return false;
+        if (!selectedRoomIds.includes(String(event.resourceId))) return false;
         // for edit/modification mode, don't overlap with existing booking
         if (
           calendarEventId &&

--- a/booking-app/components/src/client/routes/booking/hooks/useCheckAutoApproval.tsx
+++ b/booking-app/components/src/client/routes/booking/hooks/useCheckAutoApproval.tsx
@@ -13,7 +13,7 @@ import { BookingContext } from "../bookingProvider";
 import { getBookingHourLimits } from "../utils/bookingHourLimits";
 
 export function selectedAutoApprovalRooms(
-  selectedRoomIds: number[],
+  selectedRoomIds: string[],
   selectedRooms: any[],
 ) {
   if (selectedRoomIds.length < 2) return true;
@@ -47,7 +47,10 @@ export default function useCheckAutoApproval(isWalkIn = false, isVIP = false) {
 
   useEffect(() => {
     // For ITP and Media Commons tenants, use XState machine for auto-approval logic
-    if (schema.tenantId === TENANTS.ITP || isMediaCommonsTenant(schema.tenantId)) {
+    if (
+      schema.tenantId === TENANTS.ITP ||
+      isMediaCommonsTenant(schema.tenantId)
+    ) {
       console.log(
         `🎭 CLIENT-SIDE XSTATE CHECK [${schema.tenantId?.toUpperCase()}]:`,
         {
@@ -72,7 +75,9 @@ export default function useCheckAutoApproval(isWalkIn = false, isVIP = false) {
       try {
         // Choose the appropriate machine based on tenant
         const machine =
-          schema.tenantId === TENANTS.ITP ? itpBookingMachine : mcBookingMachine;
+          schema.tenantId === TENANTS.ITP
+            ? itpBookingMachine
+            : mcBookingMachine;
 
         // For Media Commons, prepare services data
         const servicesRequested = isMediaCommonsTenant(schema.tenantId)

--- a/booking-app/components/src/client/routes/booking/hooks/useCheckDurationLimits.tsx
+++ b/booking-app/components/src/client/routes/booking/hooks/useCheckDurationLimits.tsx
@@ -5,7 +5,7 @@ import { Role } from "../../../../types";
 import { getBookingHourLimits } from "../utils/bookingHourLimits";
 
 interface DurationLimitError {
-  roomId: number;
+  roomId: string;
   roomName: string;
   currentDuration: number;
   maxDuration: number;

--- a/booking-app/components/src/client/routes/booking/hooks/useCheckRequestLimits.tsx
+++ b/booking-app/components/src/client/routes/booking/hooks/useCheckRequestLimits.tsx
@@ -52,9 +52,7 @@ export default function useCheckRequestLimits(formContext: FormContextLevel) {
       email = userEmail || formData?.missingEmail;
     }
 
-    const roomIds = selectedRooms
-      .map((r) => Number(r.roomId))
-      .filter((n) => Number.isFinite(n));
+    const roomIds = selectedRooms.map((room) => room.roomId);
 
     if (!email?.trim() || roomIds.length === 0) {
       setRequestLimitChecking(false);

--- a/booking-app/components/src/client/routes/booking/utils/buildBlockPastTimes.ts
+++ b/booking-app/components/src/client/routes/booking/utils/buildBlockPastTimes.ts
@@ -25,7 +25,7 @@ export interface BlockPastTimeEvent {
  *                     as a parameter so unit tests can control the clock.
  */
 export function buildBlockPastTimes(
-  rooms: Array<{ roomId: number | string }>,
+  rooms: Array<{ roomId: string }>,
   dateView: Date,
   startHour: string | undefined,
   slotUnit: number,
@@ -96,7 +96,7 @@ export function buildBlockPastTimes(
     start: blockStart.toISOString(),
     end: blockEnd.toISOString(),
     id: `${room.roomId}bg`,
-    resourceId: `${room.roomId}`,
+    resourceId: String(room.roomId),
     overlap: false,
     display: "background",
     classNames: ["disabled"],

--- a/booking-app/components/src/client/routes/components/Provider.tsx
+++ b/booking-app/components/src/client/routes/components/Provider.tsx
@@ -314,6 +314,7 @@ export const DatabaseProvider = ({
       const rooms: RoomSetting[] = schemaContext.resources
         .map((resource) => ({
           ...resource,
+          roomId: resource.resourceId,
           capacity: String(resource.capacity),
           needsSafetyTraining: resource.training?.required || false,
           trainingFormUrl: resource.training?.formId || undefined,
@@ -323,7 +324,9 @@ export const DatabaseProvider = ({
           isEquipment: resource.isEquipment || false,
           services: resource.services || [],
         }))
-        .sort((a, b) => a.roomId - b.roomId);
+        .sort((a, b) =>
+          a.roomId.localeCompare(b.roomId, undefined, { numeric: true }),
+        );
       setRoomSettings(rooms);
     }
   }, [schemaContext?.resources]);

--- a/booking-app/components/src/client/routes/components/schemaTypes.ts
+++ b/booking-app/components/src/client/routes/components/schemaTypes.ts
@@ -37,7 +37,7 @@ export type RequestLimits = Partial<
 export type Resource = {
   capacity: number;
   name: string;
-  roomId: number;
+  resourceId: string;
   isEquipment: boolean;
   calendarId: string;
   training?: ResourceTraining;
@@ -246,7 +246,7 @@ export const defaultAttestation: Attestation = {
 export const defaultResource: Resource = {
   capacity: 0,
   name: "",
-  roomId: 0,
+  resourceId: "",
   isEquipment: false,
   calendarId: "",
   training: {

--- a/booking-app/components/src/client/routes/super/schemaEditor.tsx
+++ b/booking-app/components/src/client/routes/super/schemaEditor.tsx
@@ -478,7 +478,7 @@ function AttestationsSection({
 }
 
 // ─── Section: Resources ───
-function ResourceEditor({
+export function ResourceEditor({
   resource,
   index,
   onUpdate,
@@ -505,7 +505,7 @@ function ResourceEditor({
         <Box display="flex" alignItems="center" gap={1} width="100%">
           <Typography variant="subtitle2">
             {resource.name || `Resource ${index + 1}`}
-            {resource.roomId ? ` (Room ${resource.roomId})` : ""}
+            {resource.resourceId ? ` (${resource.resourceId})` : ""}
           </Typography>
         </Box>
       </AccordionSummary>
@@ -518,12 +518,11 @@ function ResourceEditor({
             size="small"
           />
           <TextField
-            label="Room ID"
-            type="number"
-            value={resource.roomId ?? 0}
-            onChange={(e) => set("roomId", Number(e.target.value))}
+            label="Resource ID"
+            value={resource.resourceId ?? ""}
+            onChange={(e) => set("resourceId", e.target.value)}
             size="small"
-            sx={{ width: 120 }}
+            sx={{ width: 180 }}
           />
           <TextField
             label="Capacity"
@@ -823,7 +822,7 @@ function ResourcesSection({
     <>
       {resources.map((r, i) => (
         <ResourceEditor
-          key={r.roomId || `resource-${i}`}
+          key={r.resourceId || `resource-${i}`}
           resource={r}
           index={i}
           onUpdate={updateResource}

--- a/booking-app/components/src/server/admin.ts
+++ b/booking-app/components/src/server/admin.ts
@@ -850,7 +850,7 @@ export const firstApproverEmails = async (department: string) => {
 };
 
 export const serverGetRoomCalendarIds = async (
-  roomId: number,
+  roomId: string | number,
   tenant?: string,
 ): Promise<string[]> => {
   try {
@@ -871,7 +871,8 @@ export const serverGetRoomCalendarIds = async (
     );
 
     const rooms = resourcesWithCorrectCalendarIds.filter(
-      (resource: any) => resource.roomId === roomId,
+      (resource: any) =>
+        String(resource.resourceId ?? resource.roomId) === String(roomId),
     );
 
     console.log(`Rooms: ${JSON.stringify(rooms)}`);
@@ -889,7 +890,7 @@ export const serverGetRoomCalendarIds = async (
 };
 
 export const serverGetRoomCalendarId = async (
-  roomId: number,
+  roomId: string | number,
   tenant?: string,
 ): Promise<string | null> => {
   try {
@@ -910,7 +911,8 @@ export const serverGetRoomCalendarId = async (
     );
 
     const rooms = resourcesWithCorrectCalendarIds.filter(
-      (resource: any) => resource.roomId === roomId,
+      (resource: any) =>
+        String(resource.resourceId ?? resource.roomId) === String(roomId),
     );
 
     if (rooms.length > 0) {

--- a/booking-app/components/src/server/calendars.ts
+++ b/booking-app/components/src/server/calendars.ts
@@ -30,7 +30,7 @@ export const patchCalendarEvent = async (
 export const inviteUserToCalendarEvent = async (
   calendarEventId: string,
   guestEmail: string,
-  roomId: number,
+  roomId: string,
   tenant?: string,
 ) => {
   const roomCalendarIds = await serverGetRoomCalendarIds(roomId, tenant);
@@ -326,9 +326,7 @@ export const updateCalendarEvent = async (
   }
 
   const roomCalendarIds = await serverGetRoomCalendarIds(
-    typeof bookingContents.roomId === "string"
-      ? parseInt(bookingContents.roomId, 10)
-      : bookingContents.roomId,
+    String(bookingContents.roomId).split(",")[0].trim(),
     tenant,
   );
   console.log(`Room Calendar Ids: ${roomCalendarIds}`);

--- a/booking-app/components/src/server/db.ts
+++ b/booking-app/components/src/server/db.ts
@@ -813,15 +813,17 @@ export const updateOperationHours = async (
   open: number,
   close: number,
   isClosed: boolean,
-  roomId?: string,
+  roomId?: string | number,
 ) => {
   const docs = await clientFetchAllDataFromCollection<
     OperationHours & { id: string }
   >(TableNames.OPERATION_HOURS);
 
+  const normalizedRoomId =
+    roomId === undefined || roomId === null ? undefined : String(roomId);
   const match = docs.find((x) => {
-    if (roomId) {
-      return x.day === day && x.roomId === roomId;
+    if (normalizedRoomId) {
+      return x.day === day && String(x.roomId) === normalizedRoomId;
     }
     return x.day === day;
   });
@@ -835,7 +837,7 @@ export const updateOperationHours = async (
       isClosed,
     });
   } else {
-    const r = roomId ? { roomId } : {};
+    const r = normalizedRoomId ? { roomId: normalizedRoomId } : {};
     clientSaveDataToFirestore(TableNames.OPERATION_HOURS, {
       day: day.toString(),
       open,

--- a/booking-app/components/src/server/db.ts
+++ b/booking-app/components/src/server/db.ts
@@ -813,7 +813,7 @@ export const updateOperationHours = async (
   open: number,
   close: number,
   isClosed: boolean,
-  roomId?: number,
+  roomId?: string,
 ) => {
   const docs = await clientFetchAllDataFromCollection<
     OperationHours & { id: string }

--- a/booking-app/components/src/testHelpers/testTenantSchemas.ts
+++ b/booking-app/components/src/testHelpers/testTenantSchemas.ts
@@ -81,7 +81,7 @@ const baseMediaCommonsSchema: SchemaContextType = {
     {
       capacity: 30,
       name: "Lecture Hall 202",
-      roomId: 202,
+      resourceId: "202",
       isEquipment: false,
       calendarId: "mock-calendar-202",
       training: { required: false, formId: "", infoUrl: "" },
@@ -114,7 +114,7 @@ const baseMediaCommonsSchema: SchemaContextType = {
     {
       capacity: 20,
       name: "Studio 220",
-      roomId: 220,
+      resourceId: "220",
       isEquipment: false,
       calendarId: "mock-calendar-220",
       training: { required: false, formId: "", infoUrl: "" },
@@ -147,7 +147,7 @@ const baseMediaCommonsSchema: SchemaContextType = {
     {
       capacity: 15,
       name: "Training Room 230",
-      roomId: 230,
+      resourceId: "230",
       isEquipment: false,
       calendarId: "mock-calendar-230",
       training: { required: true, formId: "https://docs.google.com/forms/d/e/mock/viewform", infoUrl: "" },

--- a/booking-app/components/src/types.ts
+++ b/booking-app/components/src/types.ts
@@ -251,7 +251,7 @@ export type OperationHours = {
   open: number;
   close: number;
   isClosed: boolean;
-  roomId?: number;
+  roomId?: string;
 };
 
 export type PaUser = {
@@ -286,7 +286,7 @@ export type BlackoutPeriod = {
   isActive: boolean;
   createdAt: Timestamp;
   updatedAt?: Timestamp;
-  roomIds?: number[]; // Optional array of room IDs - if empty/undefined, applies to all rooms
+  roomIds?: string[]; // Optional resource IDs; empty/undefined applies to all resources
 };
 
 export type PolicySettings = {
@@ -310,7 +310,7 @@ export enum Role {
 }
 
 export type RoomSetting = {
-  roomId: number;
+  roomId: string;
   name: string;
   capacity: string;
   calendarId: string;

--- a/booking-app/components/src/utils/blackoutUtils.ts
+++ b/booking-app/components/src/utils/blackoutUtils.ts
@@ -133,7 +133,7 @@ export function isBookingInBlackoutPeriod(
   period: BlackoutPeriod,
   bookingStart: Dayjs,
   bookingEnd: Dayjs,
-  selectedRoomIds: number[],
+  selectedRoomIds: string[],
 ): boolean {
   const startDate = dayjs(period.startDate.toDate());
   const endDate = dayjs(period.endDate.toDate());
@@ -209,7 +209,7 @@ export function getAffectingBlackoutPeriods(
   blackoutPeriods: BlackoutPeriod[],
   bookingStart: Dayjs,
   bookingEnd: Dayjs,
-  selectedRoomIds: number[],
+  selectedRoomIds: string[],
 ): BlackoutPeriod[] {
   const activeBlackoutPeriods = blackoutPeriods.filter(
     (period) => period.isActive,

--- a/booking-app/lib/bookingRequestLimits.ts
+++ b/booking-app/lib/bookingRequestLimits.ts
@@ -30,13 +30,14 @@ function nyCalendarParts(now: Date) {
 
 /** Start of that calendar date at 00:00 in {@link REQUEST_LIMITS_TIME_ZONE} (UTC instant). */
 function nyMidnight(y: number, monthIndex0: number, day: number): Date {
-  return toDate(
-    `${y}-${pad2(monthIndex0 + 1)}-${pad2(day)}T00:00:00.000`,
-    { timeZone: REQUEST_LIMITS_TIME_ZONE },
-  );
+  return toDate(`${y}-${pad2(monthIndex0 + 1)}-${pad2(day)}T00:00:00.000`, {
+    timeZone: REQUEST_LIMITS_TIME_ZONE,
+  });
 }
 
-export function parseRoleEnumFromLabel(label: string | undefined): Role | undefined {
+export function parseRoleEnumFromLabel(
+  label: string | undefined,
+): Role | undefined {
   if (!label) return undefined;
   const normalized = label.trim().toLowerCase();
   const entries = Object.values(Role) as string[];
@@ -170,19 +171,29 @@ export function getNewYorkWindowForPeriod(
 /** @deprecated Use {@link getNewYorkWindowForPeriod} */
 export const getLocalWindowForPeriod = getNewYorkWindowForPeriod;
 
-export function parseRoomIdsFromBooking(doc: any): number[] {
+function normalizeResourceId(value: unknown): string | null {
+  if (value == null) return null;
+  const resourceId = String(value).trim();
+  return resourceId || null;
+}
+
+export function parseRoomIdsFromBooking(doc: any): string[] {
   if (Array.isArray(doc?.roomIds)) {
     return doc.roomIds
-      .map((x: any) => Number(x))
-      .filter((n: number) => Number.isFinite(n));
+      .map((x: unknown) => normalizeResourceId(x))
+      .filter(
+        (resourceId: string | null): resourceId is string => resourceId != null,
+      );
   }
 
   const raw = doc?.roomId;
-  if (typeof raw === "string") {
-    return raw
+  if (raw != null) {
+    return String(raw)
       .split(",")
-      .map((s) => Number(String(s).trim()))
-      .filter((n) => Number.isFinite(n));
+      .map((s) => normalizeResourceId(s))
+      .filter(
+        (resourceId: string | null): resourceId is string => resourceId != null,
+      );
   }
 
   return [];
@@ -285,8 +296,9 @@ function isActiveBookingByLastLog({
   latestLogStatusByRequestNumber: Map<number, string>;
 }): boolean {
   const req = Number(booking?.requestNumber);
-  const last =
-    Number.isFinite(req) ? latestLogStatusByRequestNumber.get(req) ?? null : null;
+  const last = Number.isFinite(req)
+    ? (latestLogStatusByRequestNumber.get(req) ?? null)
+    : null;
 
   // Strict "last-log wins": if we have a last log, use it.
   if (last) return !isTerminalInactiveStatus(last);
@@ -309,17 +321,18 @@ export async function enforceRequestLimits({
   bookingRoleField: string;
   /** Key used in `resource.requestLimits` maps: `student` | `faculty` | `admin` (no origin suffix). */
   limitRoleKey: RequestLimitBucketKey;
-  selectedRoomIds: number[];
+  selectedRoomIds: string[];
   schema: SchemaContextType | null;
 }): Promise<{ ok: true } | { ok: false; message: string }> {
   if (!schema?.resources || schema.resources.length === 0)
     return { ok: true } as const;
 
-  const resourcesByRoomId = new Map<number, any>();
+  const resourcesByRoomId = new Map<string, any>();
   for (const r of schema.resources) {
-    if (typeof (r as any)?.roomId === "number") {
-      resourcesByRoomId.set((r as any).roomId, r);
-    }
+    const resourceId =
+      normalizeResourceId((r as any)?.resourceId) ??
+      normalizeResourceId((r as any)?.roomId);
+    if (resourceId) resourcesByRoomId.set(resourceId, r);
   }
 
   const now = new Date();
@@ -345,7 +358,7 @@ export async function enforceRequestLimits({
   if (periodsToQuery.length === 0) return { ok: true } as const;
 
   const countsByPeriod: Partial<
-    Record<RequestLimitPeriod, Map<number, number>>
+    Record<RequestLimitPeriod, Map<string, number>>
   > = {};
 
   // Pre-compute windows so we can bound the Firestore query by the earliest
@@ -394,7 +407,10 @@ export async function enforceRequestLimits({
 
   const relevant = allByEmail.filter((d: any) => {
     if (d?.role !== bookingRoleField) return false;
-    return isActiveBookingByLastLog({ booking: d, latestLogStatusByRequestNumber });
+    return isActiveBookingByLastLog({
+      booking: d,
+      latestLogStatusByRequestNumber,
+    });
   });
 
   for (const period of periodsToQuery) {
@@ -402,7 +418,7 @@ export async function enforceRequestLimits({
     const startMs = start.getTime();
     const endMs = end.getTime();
 
-    const roomCounts = new Map<number, number>();
+    const roomCounts = new Map<string, number>();
     for (const doc of relevant) {
       const ms = getRequestedAtMillis(doc);
       if (ms == null) continue;
@@ -433,7 +449,9 @@ export async function enforceRequestLimits({
       // For limit 0, count < 0 is impossible, so booking is always blocked.
       if (count < limit) continue;
 
-      const resourceName = resource.name ? `"${resource.name}"` : `Room ${roomId}`;
+      const resourceName = resource.name
+        ? `"${resource.name}"`
+        : `Room ${roomId}`;
       return {
         ok: false,
         message: `Request limit reached for ${resourceName} (${period}). Limit: ${limit}.`,

--- a/booking-app/lib/tenant/coerceTenantSchema.ts
+++ b/booking-app/lib/tenant/coerceTenantSchema.ts
@@ -5,6 +5,66 @@ import type {
 } from "@/components/src/client/routes/components/schemaTypes";
 import { generateDefaultSchema } from "@/components/src/client/routes/components/schemaTypes";
 
+function normalizeResourceId(value: unknown, field: string): string {
+  if (
+    (typeof value !== "string" && typeof value !== "number") ||
+    (typeof value === "number" && !Number.isFinite(value))
+  ) {
+    throw new Error(`${field} must be a string or finite number`);
+  }
+  const resourceId = String(value);
+  if (!resourceId.trim()) {
+    throw new Error(`${field} must be non-empty`);
+  }
+  if (resourceId.includes(",")) {
+    throw new Error(`${field} must not contain commas`);
+  }
+  return resourceId;
+}
+
+function coerceResource(
+  rawResource: Resource | Record<string, unknown>,
+  index: number,
+): Resource {
+  const {
+    roomId,
+    resourceId,
+    ...resource
+  } = rawResource as Record<string, unknown>;
+  const canonicalId =
+    resourceId === undefined
+      ? normalizeResourceId(roomId, `resources[${index}].roomId`)
+      : normalizeResourceId(resourceId, `resources[${index}].resourceId`);
+
+  if (
+    roomId !== undefined &&
+    normalizeResourceId(roomId, `resources[${index}].roomId`) !== canonicalId
+  ) {
+    throw new Error(
+      `resources[${index}] has conflicting resourceId and roomId`,
+    );
+  }
+
+  return {
+    ...resource,
+    resourceId: canonicalId,
+  } as Resource;
+}
+
+function coerceResources(
+  resources: Array<Resource | Record<string, unknown>>,
+): Resource[] {
+  const seen = new Set<string>();
+  return resources.map((resource, index) => {
+    const coerced = coerceResource(resource, index);
+    if (seen.has(coerced.resourceId)) {
+      throw new Error(`resources has duplicate resourceId "${coerced.resourceId}"`);
+    }
+    seen.add(coerced.resourceId);
+    return coerced;
+  });
+}
+
 /**
  * Normalizes a tenant schema document from Firestore into SchemaContextType by
  * merging the stored (canonical nested-shape) document over the tenant
@@ -61,7 +121,9 @@ export function coerceTenantSchema(
       },
     },
     resources: Array.isArray(raw.resources)
-      ? (raw.resources as Resource[])
+      ? coerceResources(
+          raw.resources as Array<Resource | Record<string, unknown>>,
+        )
       : base.resources,
     attestations: Array.isArray(raw.attestations)
       ? (raw.attestations as SchemaContextType["attestations"])

--- a/booking-app/lib/utils/testTenantSchema.ts
+++ b/booking-app/lib/utils/testTenantSchema.ts
@@ -83,7 +83,7 @@ function getMcTestSchema(tenant: string): SchemaContextType {
       resource({
         capacity: 30,
         name: "Lecture Hall 202",
-        roomId: 202,
+        resourceId: "202",
         calendarId: "mock-calendar-202",
         isWalkIn: false,
         autoApproval: { shouldAutoApprove: true },
@@ -91,7 +91,7 @@ function getMcTestSchema(tenant: string): SchemaContextType {
       resource({
         capacity: 20,
         name: "Studio 220",
-        roomId: 220,
+        resourceId: "220",
         calendarId: "mock-calendar-220",
         isWalkIn: true,
         autoApproval: { shouldAutoApprove: false },
@@ -99,7 +99,7 @@ function getMcTestSchema(tenant: string): SchemaContextType {
       resource({
         capacity: 25,
         name: "Seminar 203",
-        roomId: 203,
+        resourceId: "203",
         calendarId: "mock-calendar-203",
         isWalkIn: false,
         maxHour: { ...defaultResource.maxHour, faculty: 0.5 },
@@ -108,7 +108,7 @@ function getMcTestSchema(tenant: string): SchemaContextType {
       resource({
         capacity: 15,
         name: "Workshop 230",
-        roomId: 230,
+        resourceId: "230",
         calendarId: "mock-calendar-230",
         isWalkIn: false,
         training: {
@@ -186,7 +186,7 @@ function getItpTestSchema(): SchemaContextType {
       resource({
         capacity: 20,
         name: "Room 408",
-        roomId: 408,
+        resourceId: "408",
         calendarId: "mock-calendar-408",
         isWalkIn: false,
         autoApproval: {
@@ -198,7 +198,7 @@ function getItpTestSchema(): SchemaContextType {
       resource({
         capacity: 10,
         name: "Room 410",
-        roomId: 410,
+        resourceId: "410",
         calendarId: "mock-calendar-410",
         isWalkIn: true,
         autoApproval: {

--- a/booking-app/package.json
+++ b/booking-app/package.json
@@ -18,7 +18,9 @@
     "copy:production:dry-run": "node scripts/copyCollection.js --source-database development --target-database production --source-collection tenantSchema --target-collection tenantSchema --dry-run --report-file dry-run-production-details.json",
     "mergeUsers": "node scripts/mergeUsersCollections.js",
     "sync:schemas": "npx ts-node -r tsconfig-paths/register --transpile-only --compiler-options '{\"module\":\"commonjs\",\"jsx\":\"react\"}' scripts/syncTenantSchemas.ts",
-    "sync:schemas:dry-run": "npx ts-node -r tsconfig-paths/register --transpile-only --compiler-options '{\"module\":\"commonjs\",\"jsx\":\"react\"}' scripts/syncTenantSchemas.ts --dry-run"
+    "sync:schemas:dry-run": "npx ts-node -r tsconfig-paths/register --transpile-only --compiler-options '{\"module\":\"commonjs\",\"jsx\":\"react\"}' scripts/syncTenantSchemas.ts --dry-run",
+    "migrate:tenant-resource-ids": "node scripts/migrateTenantResourceIds.js",
+    "migrate:tenant-resource-ids:dry-run": "node scripts/migrateTenantResourceIds.js --dry-run"
   },
   "dependencies": {
     "@emotion/styled": "^11.13.0",

--- a/booking-app/scripts/migrateTenantResourceIds.js
+++ b/booking-app/scripts/migrateTenantResourceIds.js
@@ -1,0 +1,251 @@
+//@ts-nocheck
+require("dotenv").config({ path: ".env.local" });
+const admin = require("firebase-admin");
+const {
+  TENANT_SCHEMA_COLLECTION,
+  backupTenantSchemaDocument,
+} = require("./tenantSchemaBackup");
+
+const BACKUP_TYPE = "resource-id-string";
+const DATABASES = {
+  development: "default",
+  staging: "booking-app-staging",
+  production: "booking-app-prod",
+};
+
+const hasOwn = (value, key) =>
+  Object.prototype.hasOwnProperty.call(value, key);
+
+const validateId = (id, path) => {
+  if (typeof id !== "string") {
+    throw new Error(`${path} must be a string`);
+  }
+  if (id.trim().length === 0) {
+    throw new Error(`${path} must be non-empty`);
+  }
+  if (id.includes(",")) {
+    throw new Error(`${path} must not contain commas`);
+  }
+};
+
+const migrateTenantSchemaData = (schema, tenantId = "unknown") => {
+  if (schema === null || typeof schema !== "object" || Array.isArray(schema)) {
+    throw new Error(`tenantSchema/${tenantId} must be an object`);
+  }
+  if (!hasOwn(schema, "resources")) {
+    return { schema, changed: false };
+  }
+  if (!Array.isArray(schema.resources)) {
+    throw new Error(`tenantSchema/${tenantId}.resources must be an array`);
+  }
+
+  let changed = false;
+  const seenIds = new Set();
+  const resources = schema.resources.map((resource, index) => {
+    const path = `tenantSchema/${tenantId}.resources[${index}]`;
+    if (resource === null || typeof resource !== "object" || Array.isArray(resource)) {
+      throw new Error(`${path} must be an object`);
+    }
+
+    const hasResourceId = hasOwn(resource, "resourceId");
+    const hasRoomId = hasOwn(resource, "roomId");
+    let resourceId;
+
+    if (hasResourceId) {
+      resourceId = resource.resourceId;
+      validateId(resourceId, `${path}.resourceId`);
+    }
+
+    if (hasRoomId) {
+      const roomId = resource.roomId;
+      if (
+        (typeof roomId !== "string" && typeof roomId !== "number") ||
+        (typeof roomId === "number" && !Number.isFinite(roomId))
+      ) {
+        throw new Error(`${path}.roomId must be a string or finite number`);
+      }
+
+      const legacyResourceId = String(roomId);
+      validateId(legacyResourceId, `${path}.roomId`);
+      if (hasResourceId && resourceId !== legacyResourceId) {
+        throw new Error(
+          `${path} has conflicting resourceId "${resourceId}" and roomId "${legacyResourceId}"`
+        );
+      }
+      resourceId = legacyResourceId;
+    }
+
+    if (!hasResourceId && !hasRoomId) {
+      throw new Error(`${path} must have resourceId or legacy roomId`);
+    }
+    if (seenIds.has(resourceId)) {
+      throw new Error(
+        `tenantSchema/${tenantId}.resources has duplicate resourceId "${resourceId}"`
+      );
+    }
+    seenIds.add(resourceId);
+
+    if (!hasRoomId) {
+      return resource;
+    }
+
+    const { roomId: _legacyRoomId, ...withoutRoomId } = resource;
+    changed = true;
+    return { ...withoutRoomId, resourceId };
+  });
+
+  return {
+    schema: changed ? { ...schema, resources } : schema,
+    changed,
+  };
+};
+
+const getTenantDocuments = async (db, tenant) => {
+  if (tenant) {
+    const snapshot = await db.collection(TENANT_SCHEMA_COLLECTION).doc(tenant).get();
+    if (!snapshot.exists) {
+      throw new Error(`No tenant schema found for "${tenant}"`);
+    }
+    return [{ id: tenant, data: () => snapshot.data() }];
+  }
+
+  const snapshot = await db.collection(TENANT_SCHEMA_COLLECTION).get();
+  return snapshot.docs;
+};
+
+const migrateTenantResourceIds = async (
+  db,
+  { dryRun = false, tenant } = {}
+) => {
+  const documents = await getTenantDocuments(db, tenant);
+
+  // Preflight every selected document so validation failures cannot cause a
+  // partially applied migration.
+  const migrations = documents.map((doc) => {
+    const existingSchema = doc.data();
+    return {
+      tenantId: doc.id,
+      existingSchema,
+      ...migrateTenantSchemaData(existingSchema, doc.id),
+    };
+  });
+  const changedMigrations = migrations.filter((migration) => migration.changed);
+
+  if (!dryRun) {
+    for (const migration of changedMigrations) {
+      await backupTenantSchemaDocument(
+        db,
+        migration.tenantId,
+        migration.existingSchema,
+        BACKUP_TYPE
+      );
+      await db
+        .collection(TENANT_SCHEMA_COLLECTION)
+        .doc(migration.tenantId)
+        .set(migration.schema, { merge: false });
+    }
+  }
+
+  return {
+    dryRun,
+    scanned: migrations.length,
+    changed: changedMigrations.length,
+    unchanged: migrations.length - changedMigrations.length,
+    tenants: changedMigrations.map((migration) => migration.tenantId),
+  };
+};
+
+const parseArgs = (args = process.argv.slice(2)) => {
+  const options = { dryRun: false, database: "development" };
+  for (let index = 0; index < args.length; index++) {
+    switch (args[index]) {
+      case "--dry-run":
+        options.dryRun = true;
+        break;
+      case "--database":
+        options.database = args[++index];
+        break;
+      case "--tenant":
+        options.tenant = args[++index];
+        break;
+      case "--help":
+        options.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${args[index]}`);
+    }
+  }
+  if (!DATABASES[options.database]) {
+    throw new Error(
+      `Invalid database "${options.database}". Expected one of: ${Object.keys(DATABASES).join(", ")}`
+    );
+  }
+  return options;
+};
+
+const initializeDb = (databaseId) => {
+  if (!admin.apps.length) {
+    admin.initializeApp({
+      credential: admin.credential.cert({
+        projectId: process.env.FIREBASE_PROJECT_ID,
+        clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+        privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n"),
+      }),
+    });
+  }
+  const db = admin.firestore();
+  if (databaseId !== "default") {
+    db.settings({ databaseId });
+  }
+  return db;
+};
+
+const main = async () => {
+  const options = parseArgs();
+  if (options.help) {
+    console.log(`Usage: node scripts/migrateTenantResourceIds.js [options]
+
+Options:
+  --dry-run              Validate and report without writing
+  --database <env>       development, staging, or production
+  --tenant <tenant>      Migrate one tenant instead of the whole collection
+  --help                 Show this help message`);
+    return;
+  }
+
+  const result = await migrateTenantResourceIds(
+    initializeDb(DATABASES[options.database]),
+    options
+  );
+  console.log(
+    `${options.dryRun ? "[DRY RUN] " : ""}Scanned ${result.scanned}; ` +
+      `${result.changed} ${options.dryRun ? "would change" : "changed"}; ` +
+      `${result.unchanged} unchanged.`
+  );
+  if (result.tenants.length > 0) {
+    console.log(`Tenants: ${result.tenants.join(", ")}`);
+  }
+};
+
+if (require.main === module) {
+  main()
+    .catch((error) => {
+      console.error(`Migration failed: ${error.message}`);
+      process.exitCode = 1;
+    })
+    .finally(async () => {
+      for (const app of admin.apps) {
+        if (app) {
+          await app.delete();
+        }
+      }
+    });
+}
+
+module.exports = {
+  BACKUP_TYPE,
+  DATABASES,
+  migrateTenantSchemaData,
+  migrateTenantResourceIds,
+  parseArgs,
+};

--- a/booking-app/scripts/migrateTenantResourceIds.js
+++ b/booking-app/scripts/migrateTenantResourceIds.js
@@ -16,16 +16,21 @@ const DATABASES = {
 const hasOwn = (value, key) =>
   Object.prototype.hasOwnProperty.call(value, key);
 
-const validateId = (id, path) => {
-  if (typeof id !== "string") {
-    throw new Error(`${path} must be a string`);
+const normalizeId = (id, path) => {
+  if (
+    (typeof id !== "string" && typeof id !== "number") ||
+    (typeof id === "number" && !Number.isFinite(id))
+  ) {
+    throw new Error(`${path} must be a string or finite number`);
   }
-  if (id.trim().length === 0) {
+  const normalizedId = String(id);
+  if (normalizedId.trim().length === 0) {
     throw new Error(`${path} must be non-empty`);
   }
-  if (id.includes(",")) {
+  if (normalizedId.includes(",")) {
     throw new Error(`${path} must not contain commas`);
   }
+  return normalizedId;
 };
 
 const migrateTenantSchemaData = (schema, tenantId = "unknown") => {
@@ -50,23 +55,15 @@ const migrateTenantSchemaData = (schema, tenantId = "unknown") => {
     const hasResourceId = hasOwn(resource, "resourceId");
     const hasRoomId = hasOwn(resource, "roomId");
     let resourceId;
+    let resourceIdChanged = false;
 
     if (hasResourceId) {
-      resourceId = resource.resourceId;
-      validateId(resourceId, `${path}.resourceId`);
+      resourceId = normalizeId(resource.resourceId, `${path}.resourceId`);
+      resourceIdChanged = resource.resourceId !== resourceId;
     }
 
     if (hasRoomId) {
-      const roomId = resource.roomId;
-      if (
-        (typeof roomId !== "string" && typeof roomId !== "number") ||
-        (typeof roomId === "number" && !Number.isFinite(roomId))
-      ) {
-        throw new Error(`${path}.roomId must be a string or finite number`);
-      }
-
-      const legacyResourceId = String(roomId);
-      validateId(legacyResourceId, `${path}.roomId`);
+      const legacyResourceId = normalizeId(resource.roomId, `${path}.roomId`);
       if (hasResourceId && resourceId !== legacyResourceId) {
         throw new Error(
           `${path} has conflicting resourceId "${resourceId}" and roomId "${legacyResourceId}"`
@@ -85,7 +82,7 @@ const migrateTenantSchemaData = (schema, tenantId = "unknown") => {
     }
     seenIds.add(resourceId);
 
-    if (!hasRoomId) {
+    if (!hasRoomId && !resourceIdChanged) {
       return resource;
     }
 

--- a/booking-app/tests/unit/coerce-tenant-schema.unit.test.ts
+++ b/booking-app/tests/unit/coerce-tenant-schema.unit.test.ts
@@ -34,3 +34,68 @@ describe("coerceTenantSchema — timeSensitiveRequestWarning", () => {
     expect(c.calendarConfig?.timeSensitiveRequestWarning?.hours).toBe(99);
   });
 });
+
+describe("coerceTenantSchema — resources", () => {
+  it.each([
+    ["number", 202, "202"],
+    ["string", "studio-a", "studio-a"],
+  ])("coerces a legacy %s roomId to resourceId", (_, roomId, resourceId) => {
+    const resource = {
+      roomId,
+      name: "Studio",
+      capacity: 12,
+      customField: { keep: true },
+    };
+
+    const coerced = coerceTenantSchema({ resources: [resource] }, "mc");
+
+    expect(coerced.resources[0]).toEqual({
+      resourceId,
+      name: "Studio",
+      capacity: 12,
+      customField: { keep: true },
+    });
+    expect(coerced.resources[0]).not.toHaveProperty("roomId");
+  });
+
+  it("keeps a canonical resourceId and removes a matching legacy roomId", () => {
+    const coerced = coerceTenantSchema(
+      {
+        resources: [
+          {
+            resourceId: "canonical-id",
+            roomId: "canonical-id",
+            name: "Canonical resource",
+          },
+        ],
+      },
+      "mc",
+    );
+
+    expect(coerced.resources[0].resourceId).toBe("canonical-id");
+    expect(coerced.resources[0]).not.toHaveProperty("roomId");
+  });
+
+  it("rejects conflicting legacy and canonical IDs", () => {
+    expect(() =>
+      coerceTenantSchema(
+        { resources: [{ resourceId: "studio-a", roomId: 202 }] },
+        "mc",
+      ),
+    ).toThrow("conflicting resourceId and roomId");
+  });
+
+  it("rejects duplicate canonical IDs", () => {
+    expect(() =>
+      coerceTenantSchema(
+        {
+          resources: [
+            { resourceId: "studio-a" },
+            { roomId: "studio-a" },
+          ],
+        },
+        "mc",
+      ),
+    ).toThrow('duplicate resourceId "studio-a"');
+  });
+});

--- a/booking-app/tests/unit/migrate-tenant-resource-ids.unit.test.ts
+++ b/booking-app/tests/unit/migrate-tenant-resource-ids.unit.test.ts
@@ -1,0 +1,175 @@
+import { createRequire } from "module";
+import { describe, expect, it } from "vitest";
+
+type DocumentData = Record<string, any>;
+
+class MockFirestoreDb {
+  private collections = new Map<string, Map<string, DocumentData>>();
+  readonly writes: Array<{
+    collection: string;
+    id: string;
+    options: Record<string, any> | undefined;
+  }> = [];
+
+  constructor(seed: Record<string, Array<{ id: string; data: DocumentData }>>) {
+    for (const [name, documents] of Object.entries(seed)) {
+      this.collections.set(
+        name,
+        new Map(
+          documents.map(({ id, data }) => [id, structuredClone(data)]),
+        ),
+      );
+    }
+  }
+
+  private getCollection(name: string) {
+    if (!this.collections.has(name)) {
+      this.collections.set(name, new Map());
+    }
+    return this.collections.get(name)!;
+  }
+
+  collection(name: string) {
+    return {
+      get: async () => ({
+        docs: Array.from(this.getCollection(name), ([id, data]) => ({
+          id,
+          data: () => structuredClone(data),
+        })),
+      }),
+      doc: (id: string) => ({
+        get: async () => {
+          const data = this.getCollection(name).get(id);
+          return {
+            exists: data !== undefined,
+            data: () => structuredClone(data),
+          };
+        },
+        set: async (data: DocumentData, options?: Record<string, any>) => {
+          this.writes.push({ collection: name, id, options });
+          this.getCollection(name).set(id, structuredClone(data));
+        },
+      }),
+    };
+  }
+
+  read(name: string, id: string) {
+    return structuredClone(this.getCollection(name).get(id));
+  }
+
+  readCollection(name: string) {
+    return Array.from(this.getCollection(name), ([id, data]) => ({
+      id,
+      data: structuredClone(data),
+    }));
+  }
+}
+
+const requireModule = createRequire(import.meta.url);
+const { migrateTenantSchemaData, migrateTenantResourceIds } = requireModule(
+  "../../scripts/migrateTenantResourceIds.js",
+) as {
+  migrateTenantSchemaData: (
+    schema: DocumentData,
+    tenantId?: string,
+  ) => { schema: DocumentData; changed: boolean };
+  migrateTenantResourceIds: (
+    db: MockFirestoreDb,
+    options?: { dryRun?: boolean; tenant?: string },
+  ) => Promise<any>;
+};
+
+describe("scripts/migrateTenantResourceIds", () => {
+  it("converts legacy numeric/string roomIds, removes roomId, and is idempotent", () => {
+    const existing = {
+      tenant: "mc",
+      resources: [
+        { roomId: 101, name: "One" },
+        { roomId: "room-two", name: "Two" },
+        { resourceId: "canonical", name: "Three" },
+        { resourceId: "same", roomId: "same", name: "Four" },
+      ],
+    };
+
+    const first = migrateTenantSchemaData(existing, "mc");
+    expect(first.changed).toBe(true);
+    expect(first.schema.resources).toEqual([
+      { resourceId: "101", name: "One" },
+      { resourceId: "room-two", name: "Two" },
+      { resourceId: "canonical", name: "Three" },
+      { resourceId: "same", name: "Four" },
+    ]);
+
+    const second = migrateTenantSchemaData(first.schema, "mc");
+    expect(second).toEqual({ schema: first.schema, changed: false });
+  });
+
+  it.each([
+    [
+      "conflicting IDs",
+      [{ resourceId: "new", roomId: "old" }],
+      /conflicting resourceId/,
+    ],
+    ["empty IDs", [{ roomId: " " }], /must be non-empty/],
+    ["comma-containing IDs", [{ resourceId: "one,two" }], /must not contain commas/],
+    [
+      "duplicate canonical IDs",
+      [{ roomId: 1 }, { resourceId: "1" }],
+      /duplicate resourceId "1"/,
+    ],
+  ])("rejects %s", (_label, resources, message) => {
+    expect(() =>
+      migrateTenantSchemaData({ resources }, "mc"),
+    ).toThrow(message);
+  });
+
+  it("backs up and replacement-writes only changed schemas", async () => {
+    const db = new MockFirestoreDb({
+      tenantSchema: [
+        { id: "mc", data: { resources: [{ roomId: 1, name: "One" }] } },
+        { id: "itp", data: { resources: [{ resourceId: "existing" }] } },
+      ],
+    });
+
+    const result = await migrateTenantResourceIds(db);
+
+    expect(result).toMatchObject({ scanned: 2, changed: 1, unchanged: 1 });
+    expect(db.read("tenantSchema", "mc")).toEqual({
+      resources: [{ resourceId: "1", name: "One" }],
+    });
+    expect(db.readCollection("tenantSchemaBackup")).toHaveLength(1);
+    expect(db.readCollection("tenantSchemaBackup")[0].data).toEqual({
+      resources: [{ roomId: 1, name: "One" }],
+    });
+    expect(
+      db.writes.find(
+        (write) => write.collection === "tenantSchema" && write.id === "mc",
+      )?.options,
+    ).toEqual({ merge: false });
+    expect(
+      db.writes.some(
+        (write) => write.collection === "tenantSchema" && write.id === "itp",
+      ),
+    ).toBe(false);
+  });
+
+  it("performs no writes in dry-run mode or when preflight validation fails", async () => {
+    const dryRunDb = new MockFirestoreDb({
+      tenantSchema: [{ id: "mc", data: { resources: [{ roomId: 1 }] } }],
+    });
+    const result = await migrateTenantResourceIds(dryRunDb, { dryRun: true });
+    expect(result).toMatchObject({ dryRun: true, changed: 1 });
+    expect(dryRunDb.writes).toHaveLength(0);
+
+    const invalidDb = new MockFirestoreDb({
+      tenantSchema: [
+        { id: "mc", data: { resources: [{ roomId: 1 }] } },
+        { id: "itp", data: { resources: [{ roomId: "bad,id" }] } },
+      ],
+    });
+    await expect(migrateTenantResourceIds(invalidDb)).rejects.toThrow(
+      /must not contain commas/,
+    );
+    expect(invalidDb.writes).toHaveLength(0);
+  });
+});

--- a/booking-app/tests/unit/migrate-tenant-resource-ids.unit.test.ts
+++ b/booking-app/tests/unit/migrate-tenant-resource-ids.unit.test.ts
@@ -88,6 +88,8 @@ describe("scripts/migrateTenantResourceIds", () => {
         { roomId: "room-two", name: "Two" },
         { resourceId: "canonical", name: "Three" },
         { resourceId: "same", roomId: "same", name: "Four" },
+        { resourceId: 202, name: "Five" },
+        { resourceId: 303, roomId: 303, name: "Six" },
       ],
     };
 
@@ -98,6 +100,8 @@ describe("scripts/migrateTenantResourceIds", () => {
       { resourceId: "room-two", name: "Two" },
       { resourceId: "canonical", name: "Three" },
       { resourceId: "same", name: "Four" },
+      { resourceId: "202", name: "Five" },
+      { resourceId: "303", name: "Six" },
     ]);
 
     const second = migrateTenantSchemaData(first.schema, "mc");
@@ -112,6 +116,7 @@ describe("scripts/migrateTenantResourceIds", () => {
     ],
     ["empty IDs", [{ roomId: " " }], /must be non-empty/],
     ["comma-containing IDs", [{ resourceId: "one,two" }], /must not contain commas/],
+    ["non-finite resource IDs", [{ resourceId: Number.NaN }], /must be a string or finite number/],
     [
       "duplicate canonical IDs",
       [{ roomId: 1 }, { resourceId: "1" }],

--- a/booking-app/tests/unit/request-limits.unit.test.ts
+++ b/booking-app/tests/unit/request-limits.unit.test.ts
@@ -55,7 +55,10 @@ vi.mock("xstate", () => ({
 }));
 vi.mock("./shared", () => ({
   extractTenantFromRequest: () => "mc",
-  getAffiliationDisplayValues: () => ({ departmentDisplay: "", schoolDisplay: "" }),
+  getAffiliationDisplayValues: () => ({
+    departmentDisplay: "",
+    schoolDisplay: "",
+  }),
   getOtherDisplayFields: () => ({}),
 }));
 
@@ -82,7 +85,7 @@ describe("Request limits enforcement (POST /api/bookings)", () => {
       tenant: "mc",
       resources: [
         {
-          roomId: 1201,
+          resourceId: "room-1201",
           name: "Room 1201",
           requestLimits: {
             perSemester: { student: 1 },
@@ -95,9 +98,11 @@ describe("Request limits enforcement (POST /api/bookings)", () => {
       // Active booking in-window for same resource
       {
         id: "b1",
-        roomIds: [1201],
+        roomIds: ["room-1201"],
         role: "Student",
-        requestedAt: { toMillis: () => new Date("2026-04-13T10:00:00Z").getTime() },
+        requestedAt: {
+          toMillis: () => new Date("2026-04-13T10:00:00Z").getTime(),
+        },
         canceledAt: null,
         declinedAt: null,
       },
@@ -109,7 +114,9 @@ describe("Request limits enforcement (POST /api/bookings)", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         email: "student@nyu.edu",
-        selectedRooms: [{ roomId: 1201, calendarId: "cal-1201", name: "Room 1201" }],
+        selectedRooms: [
+          { roomId: "room-1201", calendarId: "cal-1201", name: "Room 1201" },
+        ],
         bookingCalendarInfo: {
           startStr: "2026-04-13T14:00:00Z",
           endStr: "2026-04-13T15:00:00Z",
@@ -133,13 +140,86 @@ describe("Request limits enforcement (POST /api/bookings)", () => {
     vi.useRealTimers();
   });
 
+  it("matches legacy numeric room IDs after coercing them to strings", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-13T12:00:00Z"));
+
+    mockServerGetDocumentById.mockResolvedValue({
+      tenant: "mc",
+      resources: [
+        {
+          roomId: 1201,
+          name: "Legacy Room 1201",
+          requestLimits: {
+            perDay: { student: 1 },
+          },
+        },
+      ],
+    });
+
+    mockServerFetchAllDataFromCollection.mockResolvedValue([
+      {
+        id: "b1",
+        roomIds: [1201],
+        role: "Student",
+        requestedAt: {
+          toMillis: () => new Date("2026-04-13T10:00:00Z").getTime(),
+        },
+      },
+    ]);
+
+    const { POST } = await import("@/app/api/bookings/route");
+    const req = new Request("http://localhost:3000/api/bookings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: "student@nyu.edu",
+        selectedRooms: [
+          { roomId: 1201, calendarId: "cal-1201", name: "Legacy Room 1201" },
+        ],
+        bookingCalendarInfo: {
+          startStr: "2026-04-13T14:00:00Z",
+          endStr: "2026-04-13T15:00:00Z",
+        },
+        data: { role: "Student", title: "Test", department: "ITP" },
+        isAutoApproval: false,
+      }),
+    }) as any;
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(429);
+    expect(await res.json()).toMatchObject({
+      error: expect.stringContaining("Legacy Room 1201"),
+    });
+
+    vi.useRealTimers();
+  });
+
+  it("parses opaque and legacy numeric booking resource IDs as strings", async () => {
+    const { parseRoomIdsFromBooking } =
+      await import("@/lib/bookingRequestLimits");
+
+    expect(
+      parseRoomIdsFromBooking({ roomIds: ["room-a", 1201, null] }),
+    ).toEqual(["room-a", "1201"]);
+    expect(parseRoomIdsFromBooking({ roomId: "room-a, 1201" })).toEqual([
+      "room-a",
+      "1201",
+    ]);
+  });
+
   it("uses 4-month semester windows in America/New_York (May 1 starts a new window)", async () => {
     const { getNewYorkWindowForPeriod, REQUEST_LIMITS_TIME_ZONE } =
       await import("@/lib/bookingRequestLimits");
     const { toDate } = await import("date-fns-tz");
     const tz = REQUEST_LIMITS_TIME_ZONE;
     const now = toDate("2026-05-01T12:00:00.000", { timeZone: tz });
-    const { start, end } = getNewYorkWindowForPeriod(now, "perSemester", undefined);
+    const { start, end } = getNewYorkWindowForPeriod(
+      now,
+      "perSemester",
+      undefined,
+    );
 
     expect(start.getTime()).toBe(
       toDate("2026-05-01T00:00:00.000", { timeZone: tz }).getTime(),
@@ -157,7 +237,7 @@ describe("Request limits enforcement (POST /api/bookings)", () => {
       tenant: "mc",
       resources: [
         {
-          roomId: 1201,
+          resourceId: "room-1201",
           name: "Room 1201",
           requestLimits: {
             // perDay limit forces the window to be the current calendar day,
@@ -177,7 +257,7 @@ describe("Request limits enforcement (POST /api/bookings)", () => {
       body: JSON.stringify({
         email: "student@nyu.edu",
         selectedRooms: [
-          { roomId: 1201, calendarId: "cal-1201", name: "Room 1201" },
+          { roomId: "room-1201", calendarId: "cal-1201", name: "Room 1201" },
         ],
         bookingCalendarInfo: {
           startStr: "2026-04-13T14:00:00Z",
@@ -190,9 +270,10 @@ describe("Request limits enforcement (POST /api/bookings)", () => {
 
     await POST(req);
 
-    const bookingQueryCall = mockServerFetchAllDataFromCollection.mock.calls.find(
-      (call) => call[0] === "bookings",
-    );
+    const bookingQueryCall =
+      mockServerFetchAllDataFromCollection.mock.calls.find(
+        (call) => call[0] === "bookings",
+      );
     expect(bookingQueryCall).toBeDefined();
     const constraints = bookingQueryCall![1] as Array<{
       field: string;
@@ -230,4 +311,3 @@ describe("Request limits enforcement (POST /api/bookings)", () => {
     );
   });
 });
-

--- a/booking-app/tests/unit/schema-editor-resource.unit.test.tsx
+++ b/booking-app/tests/unit/schema-editor-resource.unit.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { defaultResource } from "../../components/src/client/routes/components/schemaTypes";
+import { ResourceEditor } from "../../components/src/client/routes/super/schemaEditor";
+
+describe("SchemaEditor ResourceEditor", () => {
+  it("edits Resource ID as text without numeric coercion", () => {
+    const onUpdate = vi.fn();
+
+    render(
+      <ResourceEditor
+        resource={{ ...defaultResource, resourceId: "studio-a" }}
+        index={0}
+        onUpdate={onUpdate}
+        onRemove={vi.fn()}
+      />,
+    );
+
+    const input = screen.getByLabelText("Resource ID");
+    expect(input).not.toHaveAttribute("type", "number");
+
+    fireEvent.change(input, { target: { value: "studio-b2" } });
+
+    expect(onUpdate).toHaveBeenCalledWith(0, {
+      ...defaultResource,
+      resourceId: "studio-b2",
+    });
+  });
+});

--- a/booking-app/tests/unit/schemaDefaults.addOnly.unit.test.ts
+++ b/booking-app/tests/unit/schemaDefaults.addOnly.unit.test.ts
@@ -58,6 +58,8 @@ describe("scripts/schemaDefaults mergeSchemaDefaults (add-only)", () => {
     // Never delete extra keys (top-level and within resource items)
     expect(merged.someExtraTopLevelKey).toEqual({ keepMe: true });
     expect(merged.resources[0].extraResourceKey).toBe("keep-me");
+    expect(merged.resources[0].resourceId).toBe("999");
+    expect(merged.resources[0]).not.toHaveProperty("roomId");
 
     // Still adds missing template defaults (spot-check a known required field)
     expect(merged.tenant.contextLabels).toBeTruthy();
@@ -115,5 +117,7 @@ describe("scripts/schemaDefaults mergeSchemaDefaults (add-only)", () => {
     expect(merged.resources[0].training.infoUrl).toBe(
       "https://info.example/abc",
     );
+    expect(merged.resources[0].resourceId).toBe("1234");
+    expect(merged.resources[0]).not.toHaveProperty("roomId");
   });
 });

--- a/booking-app/tests/unit/update-operation-hours.unit.test.ts
+++ b/booking-app/tests/unit/update-operation-hours.unit.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  clientFetchAllDataFromCollection: vi.fn(),
+  clientSaveDataToFirestore: vi.fn(),
+  clientUpdateDataInFirestore: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase/firebase", () => ({
+  clientFetchAllDataFromCollection: mocks.clientFetchAllDataFromCollection,
+  clientGetDataByCalendarEventId: vi.fn(),
+  clientSaveDataToFirestore: mocks.clientSaveDataToFirestore,
+  clientUpdateDataInFirestore: mocks.clientUpdateDataInFirestore,
+  getPaginatedData: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase/client/clientDb", () => ({
+  clientUpdateDataByCalendarEventId: vi.fn(),
+}));
+
+vi.mock("@/components/src/server/ui", () => ({
+  getBookingToolDeployUrl: vi.fn(),
+}));
+
+import { updateOperationHours } from "@/components/src/server/db";
+import { TableNames } from "@/components/src/policy";
+import { Days } from "@/components/src/types";
+
+describe("updateOperationHours", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("matches legacy numeric operation-hours roomId values by normalized string", async () => {
+    mocks.clientFetchAllDataFromCollection.mockResolvedValue([
+      {
+        id: "existing-id",
+        day: Days.Monday,
+        open: 9,
+        close: 17,
+        isClosed: false,
+        roomId: 101,
+      },
+    ]);
+
+    await updateOperationHours(Days.Monday, 10, 18, false, "101");
+
+    expect(mocks.clientUpdateDataInFirestore).toHaveBeenCalledWith(
+      TableNames.OPERATION_HOURS,
+      "existing-id",
+      {
+        day: Days.Monday,
+        open: 10,
+        close: 18,
+        isClosed: false,
+        roomId: 101,
+      },
+    );
+    expect(mocks.clientSaveDataToFirestore).not.toHaveBeenCalled();
+  });
+
+  it("stores new operation-hours roomId values as strings", async () => {
+    mocks.clientFetchAllDataFromCollection.mockResolvedValue([]);
+
+    await updateOperationHours(Days.Tuesday, 8, 16, false, 202);
+
+    expect(mocks.clientSaveDataToFirestore).toHaveBeenCalledWith(
+      TableNames.OPERATION_HOURS,
+      {
+        day: Days.Tuesday,
+        open: 8,
+        close: 16,
+        isClosed: false,
+        roomId: "202",
+      },
+    );
+  });
+});


### PR DESCRIPTION


## Summary of Changes

Migrates tenant schema resource identifiers from legacy `roomId` numbers to string `resourceId` values.

Adds migration support for existing tenant schema documents:
- Converts `resources[].roomId` to `resources[].resourceId`
- Converts numeric IDs to strings
- Removes legacy `roomId` from tenant schema resources
- Backs up changed tenant schema docs before writing
- Updates app code/tests to read schema resources by `resourceId`

## Schema Changes


- [ ] No tenant schema changes
- [x] Schema changed (describe below)

- itp: `tenantSchema.resources[].roomId` -> `resourceId` string
- mc: `tenantSchema.resources[].roomId` -> `resourceId` string

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [x] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [x] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [x] I requested a code review from at least one other teammate

## Screenshots / Video
<img width="601" height="243" alt="image" src="https://github.com/user-attachments/assets/f9ccb6ab-6877-4471-971d-331cc74390df" />

