### PR TITLE
Fix reset service status on edit

### DIFF
--- a/booking-app/app/api/bookings/edit/route.ts
+++ b/booking-app/app/api/bookings/edit/route.ts
@@ -343,16 +343,16 @@ export async function PUT(request: NextRequest) {
     // treat services as already decided (e.g. declined) and immediately
     // re-decline the edited request.
     //
-    // This is intentionally tenant-agnostic: clearing fields that don't exist
-    // is harmless, and it future-proofs tenants that add per-service approvals.
-    if (wasDeclined) {
-      updatedData.staffServiceApproved = null;
-      updatedData.equipmentServiceApproved = null;
-      updatedData.cateringServiceApproved = null;
-      updatedData.cleaningServiceApproved = null;
-      updatedData.securityServiceApproved = null;
-      updatedData.setupServiceApproved = null;
-    }
+    // Firestore fields are deleted (not nulled) after the booking update so
+    // restoreXStateFromFirestore does not rehydrate stale declined decisions.
+    const SERVICE_APPROVAL_FIELDS = [
+      "staffServiceApproved",
+      "equipmentServiceApproved",
+      "cateringServiceApproved",
+      "cleaningServiceApproved",
+      "securityServiceApproved",
+      "setupServiceApproved",
+    ];
 
     // If booking was declined, clear the declinedAt timestamp to ensure status shows as REQUESTED
     if (existingContents.declinedAt) {
@@ -381,6 +381,15 @@ export async function PUT(request: NextRequest) {
       updatedData,
       tenant,
     );
+
+    if (wasDeclined) {
+      await serverDeleteFieldsByCalendarEventId(
+        TableNames.BOOKING,
+        newCalendarEventId,
+        SERVICE_APPROVAL_FIELDS,
+        tenant,
+      );
+    }
 
     // If booking was declined, trigger XState edit transition on the NEW calendarEventId
     // This moves the booking from DECLINED to REQUESTED state

--- a/booking-app/lib/stateMachines/mcBookingMachine.ts
+++ b/booking-app/lib/stateMachines/mcBookingMachine.ts
@@ -393,6 +393,9 @@ export const mcBookingMachine = setup({
     // Service approval/decline actions generated from config
     ...createServiceActions(SERVICE_CONFIGS),
     // Auto-approve all requested services for pregame bookings
+    resetServiceDecisionsOnEdit: assign({
+      servicesApproved: () => ({}),
+    }),
     approveAllPregameServices: assign({
       servicesApproved: ({ context }) => {
         const approved: any = {};
@@ -746,6 +749,7 @@ export const mcBookingMachine = setup({
         },
         edit: {
           target: "Requested",
+          actions: "resetServiceDecisionsOnEdit",
         },
         approve: {
           target: "Pre-approved",
@@ -825,6 +829,7 @@ export const mcBookingMachine = setup({
         },
         edit: {
           target: "Requested",
+          actions: "resetServiceDecisionsOnEdit",
         },
       },
       after: {

--- a/booking-app/lib/stateMachines/xstatePersistence.ts
+++ b/booking-app/lib/stateMachines/xstatePersistence.ts
@@ -14,6 +14,37 @@ import { itpBookingMachine } from "./itpBookingMachine";
 import { mcBookingMachine } from "./mcBookingMachine";
 import type { PersistedXStateData } from "./xstateTypes";
 
+const SERVICE_APPROVAL_FIELD_MAP = {
+  staff: "staffServiceApproved",
+  equipment: "equipmentServiceApproved",
+  catering: "cateringServiceApproved",
+  cleaning: "cleaningServiceApproved",
+  security: "securityServiceApproved",
+  setup: "setupServiceApproved",
+} as const;
+
+/**
+ * Build XState servicesApproved context from Firestore booking fields.
+ * Only explicit boolean decisions are included so cleared/null fields do not
+ * retain a prior declined state after edit/resubmission.
+ */
+export function getServicesApprovedFromBookingData(
+  bookingData: any,
+): Record<string, boolean> {
+  const servicesApproved: Record<string, boolean> = {};
+
+  for (const [serviceKey, fieldName] of Object.entries(
+    SERVICE_APPROVAL_FIELD_MAP,
+  )) {
+    const value = bookingData?.[fieldName];
+    if (typeof value === "boolean") {
+      servicesApproved[serviceKey] = value;
+    }
+  }
+
+  return servicesApproved;
+}
+
 /**
  * Map booking status to XState state
  */
@@ -116,14 +147,7 @@ export async function createXStateDataFromBookingStatus(
         email: bookingData.email,
         isVip: bookingData.isVip || false,
         servicesRequested,
-        servicesApproved: {
-          staff: bookingData.staffServiceApproved,
-          equipment: bookingData.equipmentServiceApproved,
-          catering: bookingData.cateringServiceApproved,
-          cleaning: bookingData.cleaningServiceApproved,
-          security: bookingData.securityServiceApproved,
-          setup: bookingData.setupServiceApproved,
-        },
+        servicesApproved: getServicesApprovedFromBookingData(bookingData),
         // Flag to indicate this XState was created from existing booking without prior xstateData
         _restoredFromStatus: true,
       }
@@ -451,14 +475,8 @@ export async function restoreXStateFromFirestore(
       // Update MC-specific services data
       if (isMediaCommons(tenant)) {
         const currentServicesRequested = getMediaCommonsServices(bookingData);
-        const currentServicesApproved = {
-          staff: (bookingData as any).staffServiceApproved,
-          equipment: (bookingData as any).equipmentServiceApproved,
-          catering: (bookingData as any).cateringServiceApproved,
-          cleaning: (bookingData as any).cleaningServiceApproved,
-          security: (bookingData as any).securityServiceApproved,
-          setup: (bookingData as any).setupServiceApproved,
-        };
+        const currentServicesApproved =
+          getServicesApprovedFromBookingData(bookingData);
 
         updatedSnapshot.context = {
           ...updatedSnapshot.context,

--- a/booking-app/tests/unit/booking-edit-resubmission-resets-services.unit.test.ts
+++ b/booking-app/tests/unit/booking-edit-resubmission-resets-services.unit.test.ts
@@ -155,14 +155,21 @@ describe("Edit resubmission resets declined services", () => {
 
     const updatedData = updateArgs[2];
     expect(updatedData.calendarEventId).toBe("new-cal-456");
+    expect(updatedData.staffServiceApproved).toBeUndefined();
 
-    // Critical: reset service decisions
-    expect(updatedData.staffServiceApproved).toBeNull();
-    expect(updatedData.equipmentServiceApproved).toBeNull();
-    expect(updatedData.cateringServiceApproved).toBeNull();
-    expect(updatedData.cleaningServiceApproved).toBeNull();
-    expect(updatedData.securityServiceApproved).toBeNull();
-    expect(updatedData.setupServiceApproved).toBeNull();
+    expect(mockServerDeleteFieldsByCalendarEventId).toHaveBeenCalledWith(
+      "bookings",
+      "new-cal-456",
+      [
+        "staffServiceApproved",
+        "equipmentServiceApproved",
+        "cateringServiceApproved",
+        "cleaningServiceApproved",
+        "securityServiceApproved",
+        "setupServiceApproved",
+      ],
+      "mc",
+    );
 
     // Still runs XState edit transition for declined bookings
     expect(mockCallXStateTransitionAPI).toHaveBeenCalledWith(

--- a/booking-app/tests/unit/mc-booking-machine.unit.test.ts
+++ b/booking-app/tests/unit/mc-booking-machine.unit.test.ts
@@ -474,6 +474,33 @@ describe("mcBookingMachine", () => {
     await waitForCondition(actor, (snapshot) => snapshot.matches("Declined"));
   });
 
+  it("clears declined service decisions after edit and re-approves into Services Request", async () => {
+    const actor = createTestActor({
+      selectedRooms: [{ roomId: 202 }],
+      servicesRequested: { staff: true },
+    });
+
+    actor.send({ type: "approve" });
+    expect(actor.getSnapshot().matches("Pre-approved")).toBe(true);
+
+    actor.send({ type: "approve" });
+    expect(actor.getSnapshot().matches("Services Request")).toBe(true);
+
+    actor.send({ type: "declineStaff" });
+    await waitForCondition(actor, (snapshot) => snapshot.matches("Declined"));
+    expect(actor.getSnapshot().context.servicesApproved?.staff).toBe(false);
+
+    actor.send({ type: "edit" });
+    expect(actor.getSnapshot().matches("Requested")).toBe(true);
+    expect(actor.getSnapshot().context.servicesApproved).toEqual({});
+
+    actor.send({ type: "approve" });
+    expect(actor.getSnapshot().matches("Pre-approved")).toBe(true);
+
+    actor.send({ type: "approve" });
+    expect(actor.getSnapshot().matches("Services Request")).toBe(true);
+  });
+
   it("emits the official guideline state sequence for manual service approvals", async () => {
     const actor = createTestActor({
       selectedRooms: [{ roomId: 202 }], // No autoApproval = disabled


### PR DESCRIPTION
## Summary of Changes

https://github.com/ITPNYU/booking-app/issues/1486

When a booking is declined because a service was declined, then edited and resubmitted, the per-service declined state sticks around. After re-approval (Declined → Edited → Pre-approved), the request can still behave as if services are already declined — wrong actions in the UI and immediate re-decline via XState.

As [nopivnick noted](https://github.com/ITPNYU/booking-app/issues/1486#issuecomment-4709278858), the stale servicesApproved values in the XState snapshot are the likely cause. A partial fix on main cleared Firestore fields on edit, but did not fully reset XState context.

**Changes**:

- mcBookingMachine.ts — edit from Declined (and Requested) now runs resetServiceDecisionsOnEdit, clearing servicesApproved in XState context.
- xstatePersistence.ts — Added getServicesApprovedFromBookingData() so only explicit boolean Firestore values are restored; cleared/null fields no longer rehydrate as declined.
- app/api/bookings/edit/route.ts — On declined resubmission, deletes per-service approval fields from Firestore (instead of setting them to null) before the XState edit transition.
- Tests — Updated the edit-route unit test and added an MC machine test for decline → edit → re-approve → Services Request.

## Schema Changes

<!-- Required for every PR. Pick exactly one. -->

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

<!-- If schema changed, list affected tenants and what changed.
Example:
- mc: added `showCleaning` flag
- itp: added new resource (roomId 999)
-->

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [x] I requested a code review from at least one other teammate

## Screenshots / Video

<img width="557" height="647" alt="image" src="https://github.com/user-attachments/assets/a7feecc3-5133-4c76-b2b2-1e3e181e10e6" />

