### PR TITLE
security: stop exposing server secrets through next.config env

### DIFF
--- a/booking-app/next.config.mjs
+++ b/booking-app/next.config.mjs
@@ -22,32 +22,17 @@ const nextConfig = {
     ignoreDuringBuilds: true,
   },
   serverExternalPackages: ["newrelic"],
+  // Only non-secret, browser-facing values belong here. Next.js inlines every
+  // `env` entry into any bundle that references it (including client bundles),
+  // so server secrets must NOT be listed — a single client `process.env.X`
+  // reference would ship them to the browser. Server code reads secrets from
+  // `process.env` directly at runtime (loaded from the deploy-time env file),
+  // which does not require an `env` entry.
   env: {
     NEXT_PUBLIC_IS_TEST_ENV: isTestEnv ? "true" : "false",
-    FIREBASE_PROJECT_ID: process.env.FIREBASE_PROJECT_ID,
-    FIREBASE_PRIVATE_KEY_ID: process.env.FIREBASE_PRIVATE_KEY_ID,
-    FIREBASE_PRIVATE_KEY: process.env.FIREBASE_PRIVATE_KEY,
-    FIREBASE_CLIENT_EMAIL: process.env.FIREBASE_CLIENT_EMAIL,
-    FIREBASE_CLIENT_ID: process.env.FIREBASE_CLIENT_ID,
-    FIREBASE_AUTH_URI: process.env.FIREBASE_AUTH_URI,
-    FIREBASE_TOKEN_URI: process.env.FIREBASE_TOKEN_URI,
-    FIREBASE_AUTH_PROVIDER_X509_CERT_URL:
-      process.env.FIREBASE_AUTH_PROVIDER_X509_CERT_URL,
-    FIREBASE_CLIENT_X509_CERT_URL: process.env.FIREBASE_CLIENT_X509_CERT_URL,
     NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL,
     NEXT_PUBLIC_BRANCH_NAME: process.env.NEXT_PUBLIC_BRANCH_NAME,
     NEXT_PUBLIC_GCP_LOG_NAME: process.env.NEXT_PUBLIC_GCP_LOG_NAME,
-    GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
-    GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
-    GOOGLE_REDIRECT_URI: process.env.GOOGLE_REDIRECT_URI,
-    GOOGLE_REFRESH_TOKEN: process.env.GOOGLE_REFRESH_TOKEN,
-    GOOGLE_SHEET_ID: process.env.GOOGLE_SHEET_ID,
-    GOOGLE_SPREADSHEET_ID: process.env.GOOGLE_SPREADSHEET_ID,
-    GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
-    NYU_API_CLIENT_ID: process.env.NYU_API_CLIENT_ID,
-    NYU_API_CLIENT_SECRET: process.env.NYU_API_CLIENT_SECRET,
-    NYU_API_USER_NAME: process.env.NYU_API_USER_NAME,
-    NYU_API_PASSWORD: process.env.NYU_API_PASSWORD,
   },
   compiler: {
     styledComponents: true,


### PR DESCRIPTION
## Summary of Changes

The `env` block in `next.config.mjs` listed server-only secrets. Next.js inlines every `env` entry into any bundle that references it — **including client bundles** — so listing secrets there means a single client-side `process.env.X` reference would ship that secret to the browser.

This PR keeps only the browser-facing `NEXT_PUBLIC_*` values in `env` and removes the server secrets:

- Firebase admin service account: `FIREBASE_PRIVATE_KEY`, `FIREBASE_PRIVATE_KEY_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_CLIENT_ID`, `FIREBASE_PROJECT_ID`, `FIREBASE_AUTH_URI`, `FIREBASE_TOKEN_URI`, `FIREBASE_AUTH_PROVIDER_X509_CERT_URL`, `FIREBASE_CLIENT_X509_CERT_URL`
- Google OAuth / API: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`, `GOOGLE_REFRESH_TOKEN`, `GOOGLE_SHEET_ID`, `GOOGLE_SPREADSHEET_ID`, `GOOGLE_API_KEY`
- NYU API: `NYU_API_CLIENT_ID`, `NYU_API_CLIENT_SECRET`, `NYU_API_USER_NAME`, `NYU_API_PASSWORD`

**Why this is safe:** server code reads these from `process.env` directly at runtime (they are loaded from the deploy-time env file), which does not require an `env` entry. I verified no client-reachable file references any of the removed variables (all reads are in `lib/server/*`, `lib/googleClient.ts`, `scripts/*`, API routes, and tests). `next build` passes with the change.

**Verification requested on merge:** confirm on a development deploy that the runtime env still provides these variables to server code (they are written to the deploy-time env file by the deploy workflow, so this is expected to be a no-op at runtime).

### Not included here (flagged separately, need a decision)

These were surfaced in the same review but are intentionally **out of scope** for this PR because they carry breaking risk or require an ops/design decision:

- **App-wide API auth**: there is no `middleware.ts`; most `/api/*` routes are unauthenticated. A blanket `requireSession()` gate would break the internal unauthenticated self-calls to `/api/*-processing` and the client-SDK read in `/api/getData`, so it needs a designed allowlist (cron/scheduler secret) rather than a mechanical change.
- **Firestore security rules**: none exist in the repo; adding a deny-all would break `/api/getData`, which currently reads via the browser client SDK. Needs a design pass.

## Schema Changes

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [ ] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [ ] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

Unit tests: not added — this is a build-config change; correctness is validated by `next build` passing and by confirming no client-reachable references to the removed variables.

## Screenshots / Video

No UI change. This is a build-configuration change that removes server secrets from the client-inlinable `env` map.
