### PR TITLE
feat: annual PII anonymization script and cron (#1218)

### DIFF
--- a/.github/workflows/anonymize-pii-cron.yml
+++ b/.github/workflows/anonymize-pii-cron.yml
@@ -29,7 +29,7 @@ on:
         options: ["dev", "staging", "production"]
         default: "staging"
       before:
-        description: "Cutoff date YYYY-MM-DD (blank = Sept 1 of the current year)"
+        description: "Cutoff date YYYY-MM-DD (blank = Sept 1 of the most recently concluded academic year)"
         type: string
         default: ""
       dry_run:
@@ -82,7 +82,18 @@ jobs:
           cd booking-app
           BEFORE="${INPUT_BEFORE}"
           if [ -z "${BEFORE}" ]; then
-            BEFORE="$(date -u +%Y)-09-01"
+            # Default to the Sept 1 boundary of the most recently CONCLUDED
+            # academic year — never a future date. On the scheduled Sept 1 run
+            # this is today's Sept 1; for a manual run in Jan–Aug it is LAST
+            # year's Sept 1, so a blank cutoff can never select active/upcoming
+            # bookings (which would violate the "concluded only" invariant).
+            YEAR="$(date -u +%Y)"
+            # 10# forces base-10 so a leading-zero month (08/09) is not parsed
+            # as invalid octal.
+            if [ "$((10#$(date -u +%m)))" -lt 9 ]; then
+              YEAR=$((YEAR - 1))
+            fi
+            BEFORE="${YEAR}-09-01"
           fi
           # GitHub environment names are dev/staging/production; the script's
           # --database keys are development/staging/production.

--- a/.github/workflows/anonymize-pii-cron.yml
+++ b/.github/workflows/anonymize-pii-cron.yml
@@ -1,0 +1,172 @@
+name: Anonymize PII (annual)
+
+# Anonymizes PII (name / netId / nNumber / phone) in concluded bookings,
+# preBanLogs, and the NYU identity cache — issue #1218.
+#
+# Model (a human performs the real run; the cron just makes sure they notice):
+#   - The scheduled Sept 1 run is DRY-RUN only. It writes nothing and instead
+#     opens a GitHub Issue with the preview + instructions, so the annual task
+#     cannot be silently forgotten.
+#   - A real (writing) run is done by a human via "Run workflow" with
+#     dry_run=false. Writing to production also requires confirm_production=true.
+#   - Every real run uploads a JSON backup artifact of the original values.
+#     That artifact contains PII: download it, verify the run, then DELETE it.
+#     Retention is capped so it does not linger.
+
+permissions:
+  contents: read
+  issues: write
+
+on:
+  schedule:
+    # 06:00 UTC on September 1 — just after the academic year ends.
+    - cron: "0 6 1 9 *"
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Target environment"
+        type: choice
+        options: ["dev", "staging", "production"]
+        default: "staging"
+      before:
+        description: "Cutoff date YYYY-MM-DD (blank = Sept 1 of the current year)"
+        type: string
+        default: ""
+      dry_run:
+        description: "Dry run (report only, no writes)"
+        type: boolean
+        default: true
+      confirm_production:
+        description: "Required to actually write to production"
+        type: boolean
+        default: false
+
+jobs:
+  anonymize:
+    # Scheduled runs are dry-run against dev + production. Manual runs use the
+    # chosen environment.
+    strategy:
+      matrix:
+        env_name: ${{ github.event_name == 'schedule' && fromJSON('["dev", "production"]') || fromJSON('["placeholder"]') }}
+    environment: ${{ github.event_name == 'schedule' && matrix.env_name || inputs.environment }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: |
+          cd booking-app
+          npm ci
+
+      - name: Anonymize PII
+        env:
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+          FIREBASE_CLIENT_EMAIL: ${{ secrets.FIREBASE_CLIENT_EMAIL }}
+          FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
+          ANONYMIZATION_PEPPER: ${{ secrets.ANONYMIZATION_PEPPER }}
+          TARGET_ENV: ${{ github.event_name == 'schedule' && matrix.env_name || inputs.environment }}
+          INPUT_BEFORE: ${{ inputs.before }}
+          # Scheduled runs are always dry-run; manual runs honour the input.
+          DRY_RUN: ${{ github.event_name == 'schedule' && 'true' || inputs.dry_run }}
+          CONFIRM_PRODUCTION: ${{ inputs.confirm_production }}
+        run: |
+          set -eo pipefail
+          cd booking-app
+          BEFORE="${INPUT_BEFORE}"
+          if [ -z "${BEFORE}" ]; then
+            BEFORE="$(date -u +%Y)-09-01"
+          fi
+          # GitHub environment names are dev/staging/production; the script's
+          # --database keys are development/staging/production.
+          if [ "${TARGET_ENV}" = "dev" ]; then
+            DB_ENV="development"
+          else
+            DB_ENV="${TARGET_ENV}"
+          fi
+          echo "CUTOFF_BEFORE=${BEFORE}" >> "$GITHUB_ENV"
+          echo "Environment: ${TARGET_ENV} (db ${DB_ENV})  cutoff(before): ${BEFORE}  dry_run: ${DRY_RUN}"
+
+          ARGS="--database ${DB_ENV} --before ${BEFORE} --report-file anon-report.json"
+          if [ "${DRY_RUN}" = "true" ]; then
+            ARGS="${ARGS} --dry-run"
+          fi
+          if [ "${DB_ENV}" = "production" ] && [ "${DRY_RUN}" != "true" ]; then
+            if [ "${CONFIRM_PRODUCTION}" != "true" ]; then
+              echo "::error::Refusing to write to production without confirm_production=true"
+              exit 1
+            fi
+            ARGS="${ARGS} --confirm-production"
+          fi
+
+          node scripts/anonymizePII.js ${ARGS} | tee anon-summary.txt
+
+      - name: Open reminder issue (scheduled dry-run)
+        if: ${{ github.event_name == 'schedule' }}
+        uses: actions/github-script@v7
+        env:
+          TARGET_ENV: ${{ matrix.env_name }}
+        with:
+          script: |
+            const fs = require("fs");
+            let summary = "(summary unavailable)";
+            try {
+              summary = fs.readFileSync("booking-app/anon-summary.txt", "utf8").trim();
+            } catch (e) {}
+            const env = process.env.TARGET_ENV;
+            const before = process.env.CUTOFF_BEFORE;
+            const year = new Date().getUTCFullYear();
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              `## Annual PII anonymization is due — ${env}`,
+              "",
+              `The scheduled **dry-run** for \`${env}\` just ran (cutoff \`${before}\`). It wrote **nothing**. A human needs to review and perform the real run.`,
+              "",
+              "### Dry-run preview",
+              "```",
+              summary,
+              "```",
+              `Full report artifact + logs: ${runUrl}`,
+              "",
+              "### To perform the real anonymization",
+              "1. Review the preview above and the report artifact.",
+              "2. Actions → **Anonymize PII (annual)** → **Run workflow**:",
+              `   - environment: \`${env}\``,
+              `   - before: \`${before}\``,
+              "   - dry_run: **false**",
+              "   - confirm_production: **true** (production only)",
+              "3. After it finishes, download the backup artifact, verify, then **delete the backup** (it contains raw PII).",
+              "",
+              `Prerequisite: the \`ANONYMIZATION_PEPPER\` secret must be set for the \`${env}\` environment.`,
+              "",
+              "Close this issue once the real run is done.",
+            ].join("\n");
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Annual PII anonymization due — ${env} ${year}`,
+              body,
+            });
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: anon-report-${{ github.run_id }}-${{ strategy.job-index }}
+          path: booking-app/anon-report.json
+          retention-days: 30
+
+      - name: Upload PII backup (real runs only — delete after verifying)
+        uses: actions/upload-artifact@v4
+        if: ${{ (github.event_name != 'schedule') && (inputs.dry_run == false) }}
+        with:
+          name: anon-backup-${{ github.run_id }}-${{ strategy.job-index }}
+          path: booking-app/scripts/output/anon-backups/
+          retention-days: 7

--- a/.github/workflows/anonymize-pii-cron.yml
+++ b/.github/workflows/anonymize-pii-cron.yml
@@ -9,9 +9,11 @@ name: Anonymize PII (annual)
 #     cannot be silently forgotten.
 #   - A real (writing) run is done by a human via "Run workflow" with
 #     dry_run=false. Writing to production also requires confirm_production=true.
-#   - Every real run uploads a JSON backup artifact of the original values.
-#     That artifact contains PII: download it, verify the run, then DELETE it.
-#     Retention is capped so it does not linger.
+#   - Every real run first backs up the original values INTO Firestore
+#     (collection `piiAnonymizationBackups`, same database), where they stay
+#     behind the existing database access controls and expire automatically.
+#     Raw PII must never be written to logs or artifacts — this repo is
+#     public, and artifacts are downloadable by anyone with read access.
 
 permissions:
   contents: read
@@ -153,7 +155,7 @@ jobs:
               `   - before: \`${before}\``,
               "   - dry_run: **false**",
               "   - confirm_production: **true** (production only)",
-              "3. After it finishes, download the backup artifact, verify, then **delete the backup** (it contains raw PII).",
+              "3. After it finishes, note the backup id in the run log (`piiAnonymizationBackups/anon-...`). The backup lives in Firestore, expires automatically, and can be rolled back with `node scripts/anonymizePII.js --restore <backup-id> --database <env>`.",
               "",
               `Prerequisite: the \`ANONYMIZATION_PEPPER\` secret must be set for the \`${env}\` environment.`,
               "",
@@ -166,6 +168,10 @@ jobs:
               body,
             });
 
+      # The report is counts-only (no PII). The PII backup itself is written to
+      # Firestore by the script and is deliberately NEVER uploaded as an
+      # artifact: this repo is public and artifacts are downloadable by anyone
+      # with read access.
       - name: Upload report
         uses: actions/upload-artifact@v4
         if: always()
@@ -173,11 +179,3 @@ jobs:
           name: anon-report-${{ github.run_id }}-${{ strategy.job-index }}
           path: booking-app/anon-report.json
           retention-days: 30
-
-      - name: Upload PII backup (real runs only — delete after verifying)
-        uses: actions/upload-artifact@v4
-        if: ${{ (github.event_name != 'schedule') && (inputs.dry_run == false) }}
-        with:
-          name: anon-backup-${{ github.run_id }}-${{ strategy.job-index }}
-          path: booking-app/scripts/output/anon-backups/
-          retention-days: 7

--- a/booking-app/package.json
+++ b/booking-app/package.json
@@ -21,6 +21,8 @@
     "sync:schemas:dry-run": "npx ts-node -r tsconfig-paths/register --transpile-only --compiler-options '{\"module\":\"commonjs\",\"jsx\":\"react\"}' scripts/syncTenantSchemas.ts --dry-run",
     "migrate:tenant-resource-ids": "node scripts/migrateTenantResourceIds.js",
     "migrate:tenant-resource-ids:dry-run": "node scripts/migrateTenantResourceIds.js --dry-run",
+    "anonymize:pii": "node scripts/anonymizePII.js",
+    "anonymize:pii:dry-run": "node scripts/anonymizePII.js --dry-run",
     "backup:tenant-schema": "npx ts-node -r tsconfig-paths/register --transpile-only --compiler-options '{\"module\":\"commonjs\",\"jsx\":\"react\"}' scripts/backupTenantSchemaToDisk.ts"
   },
   "dependencies": {

--- a/booking-app/scripts/anonymizePII.js
+++ b/booking-app/scripts/anonymizePII.js
@@ -126,6 +126,7 @@ const parseArgs = (args = process.argv.slice(2)) => {
     database: "development",
     skipCache: false,
     confirmProduction: false,
+    backupOnly: false,
   };
   for (let index = 0; index < args.length; index++) {
     switch (args[index]) {
@@ -153,6 +154,12 @@ const parseArgs = (args = process.argv.slice(2)) => {
       case "--confirm-production":
         options.confirmProduction = true;
         break;
+      case "--backup-only":
+        options.backupOnly = true;
+        break;
+      case "--restore":
+        options.restore = args[++index];
+        break;
       case "--help":
         options.help = true;
         break;
@@ -169,15 +176,26 @@ const parseArgs = (args = process.argv.slice(2)) => {
       ).join(", ")}`,
     );
   }
-  if (!options.before) {
-    throw new Error("--before <YYYY-MM-DD> is required (the academic-year cutoff)");
+
+  // Restore mode reads a backup file and writes originals back; it needs no
+  // cutoff. Anonymize / backup-only mode needs the cutoff.
+  if (!options.restore) {
+    if (!options.before) {
+      throw new Error(
+        "--before <YYYY-MM-DD> is required (the academic-year cutoff)",
+      );
+    }
+    const cutoff = new Date(options.before);
+    if (Number.isNaN(cutoff.getTime())) {
+      throw new Error(`Invalid --before date: "${options.before}"`);
+    }
+    options.cutoff = cutoff;
   }
-  const cutoff = new Date(options.before);
-  if (Number.isNaN(cutoff.getTime())) {
-    throw new Error(`Invalid --before date: "${options.before}"`);
-  }
-  options.cutoff = cutoff;
-  if (options.database === "production" && !options.confirmProduction && !options.dryRun) {
+
+  // Production writes need explicit confirmation. --backup-only does not write
+  // to the database (it only reads and writes a local file), so it is exempt.
+  const willWrite = !options.dryRun && !options.backupOnly;
+  if (options.database === "production" && willWrite && !options.confirmProduction) {
     throw new Error(
       "Refusing to write to production without --confirm-production",
     );
@@ -230,6 +248,7 @@ const commitInBatches = async (db, ops) => {
     const batch = db.batch();
     for (const op of slice) {
       if (op.delete) batch.delete(op.ref);
+      else if (op.set) batch.set(op.ref, op.set);
       else batch.update(op.ref, op.patch);
     }
     await batch.commit();
@@ -237,7 +256,8 @@ const commitInBatches = async (db, ops) => {
 };
 
 const anonymize = async (db, options) => {
-  const hash = options.dryRun ? (v) => v : makeHasher(getPepper());
+  const hash =
+    options.dryRun || options.backupOnly ? (v) => v : makeHasher(getPepper());
   const cutoffTs = admin.firestore.Timestamp.fromDate(options.cutoff);
   const backup = { database: options.database, before: options.before, collections: {} };
   const report = {
@@ -316,9 +336,52 @@ const anonymize = async (db, options) => {
   if (!options.dryRun && ops.length > 0) {
     const backupPath = writeBackup(backup, options);
     console.log(`Backup written: ${backupPath}`);
-    await commitInBatches(db, ops);
+    if (!options.backupOnly) await commitInBatches(db, ops);
   }
 
+  if (options.reportFile) {
+    fs.writeFileSync(options.reportFile, JSON.stringify(report, null, 2));
+  }
+  return report;
+};
+
+/**
+ * Restore original values from a backup file produced by an earlier run.
+ * bookings / preBanLogs are patched back field-by-field; nyu_identity_cache
+ * docs (which were deleted) are re-created from the stored document data.
+ */
+const restore = async (db, options) => {
+  const backup = JSON.parse(fs.readFileSync(options.restore, "utf8"));
+  const report = {
+    database: options.database,
+    from: options.restore,
+    dryRun: options.dryRun,
+    collections: {},
+    totals: { restoredDocs: 0, restoredFields: 0 },
+  };
+  const ops = [];
+  for (const [name, docs] of Object.entries(backup.collections || {})) {
+    let restoredDocs = 0;
+    let restoredFields = 0;
+    for (const [docId, data] of Object.entries(docs)) {
+      const ref = db.collection(name).doc(docId);
+      if (name === CACHE_COLLECTION) {
+        // The cache doc was deleted; re-create it wholesale.
+        if (!options.dryRun) ops.push({ ref, set: data });
+      } else {
+        // Patch the original PII fields back onto the existing doc.
+        if (!options.dryRun) ops.push({ ref, patch: data });
+      }
+      restoredDocs += 1;
+      restoredFields += Object.keys(data).length;
+    }
+    report.collections[name] = { restoredDocs, restoredFields };
+    report.totals.restoredDocs += restoredDocs;
+    report.totals.restoredFields += restoredFields;
+  }
+  if (!options.dryRun && ops.length > 0) {
+    await commitInBatches(db, ops);
+  }
   if (options.reportFile) {
     fs.writeFileSync(options.reportFile, JSON.stringify(report, null, 2));
   }
@@ -355,10 +418,14 @@ and the NYU identity cache. Always backs up originals before writing.
 
 Options:
   --before <YYYY-MM-DD>    Academic-year cutoff; only records before this are
-                           anonymized (required)
+                           anonymized (required unless --restore)
   --database <env>         development (default), staging, or production
   --tenant <tenant>        Limit to one tenant prefix (e.g. mc, itp)
   --dry-run                Report the change set; write nothing, no backup
+  --backup-only            Write the JSON backup of the eligible records but
+                           make no changes (no hashing, no deletes, no pepper)
+  --restore <file>         Restore original values from a backup file (writes
+                           originals back; supports --dry-run)
   --backup-dir <path>      Where to write the JSON backup
                            (default scripts/output/anon-backups)
   --report-file <path>     Write a JSON summary report
@@ -366,17 +433,37 @@ Options:
   --confirm-production     Required to write when --database production
   --help                   Show this help
 
-Env: ANONYMIZATION_PEPPER (>=16 chars), FIREBASE_* (from .env.local)`);
+Env: ANONYMIZATION_PEPPER (>=16 chars, real runs only), FIREBASE_* (.env.local)`);
     return;
   }
 
-  const report = await anonymize(initializeDb(DATABASES[options.database]), options);
-  const prefix = options.dryRun ? "[DRY RUN] " : "";
+  const db = initializeDb(DATABASES[options.database]);
+
+  if (options.restore) {
+    const report = await restore(db, options);
+    console.log(
+      `${options.dryRun ? "[DRY RUN] " : ""}restore ${options.database} from ${options.restore}: ` +
+        `${report.totals.restoredDocs} docs, ${report.totals.restoredFields} fields ` +
+        `${options.dryRun ? "would be restored" : "restored"}.`,
+    );
+    for (const [name, stats] of Object.entries(report.collections)) {
+      console.log(`  ${name}: ${JSON.stringify(stats)}`);
+    }
+    return;
+  }
+
+  const report = await anonymize(db, options);
+  const willChange = options.dryRun || options.backupOnly;
+  const prefix = options.dryRun
+    ? "[DRY RUN] "
+    : options.backupOnly
+      ? "[BACKUP ONLY] "
+      : "";
   console.log(
     `${prefix}${options.database} (before ${options.before}): ` +
-      `${report.totals.docsChanged} docs ${options.dryRun ? "would change" : "changed"}, ` +
-      `${report.totals.fieldsHashed} fields hashed, ` +
-      `${report.totals.docsDeleted} cache docs ${options.dryRun ? "would be deleted" : "deleted"}.`,
+      `${report.totals.docsChanged} docs ${willChange ? "would change" : "changed"}, ` +
+      `${report.totals.fieldsHashed} fields ${willChange ? "would be hashed" : "hashed"}, ` +
+      `${report.totals.docsDeleted} cache docs ${willChange ? "would be deleted" : "deleted"}.`,
   );
   for (const [name, stats] of Object.entries(report.collections)) {
     console.log(`  ${name}: ${JSON.stringify(stats)}`);
@@ -406,4 +493,5 @@ module.exports = {
   computePreBanUpdate,
   preBanLogDateMillis,
   parseArgs,
+  restore,
 };

--- a/booking-app/scripts/anonymizePII.js
+++ b/booking-app/scripts/anonymizePII.js
@@ -387,6 +387,16 @@ const restore = async (db, options) => {
       report.skipped[name] = { docs: Object.keys(docs).length };
       continue;
     }
+    // --tenant is a hard scope boundary everywhere else in this script, so
+    // honor it here too: restoring from a full backup with --tenant mc must
+    // write back only mc-* collections, not every tenant's PII in the file.
+    if (options.tenant && !name.startsWith(`${options.tenant}-`)) {
+      report.skipped[name] = {
+        docs: Object.keys(docs).length,
+        reason: `outside --tenant ${options.tenant}`,
+      };
+      continue;
+    }
     let restoredDocs = 0;
     let restoredFields = 0;
     for (const [docId, data] of Object.entries(docs)) {

--- a/booking-app/scripts/anonymizePII.js
+++ b/booking-app/scripts/anonymizePII.js
@@ -248,7 +248,6 @@ const commitInBatches = async (db, ops) => {
     const batch = db.batch();
     for (const op of slice) {
       if (op.delete) batch.delete(op.ref);
-      else if (op.set) batch.set(op.ref, op.set);
       else batch.update(op.ref, op.patch);
     }
     await batch.commit();
@@ -347,8 +346,12 @@ const anonymize = async (db, options) => {
 
 /**
  * Restore original values from a backup file produced by an earlier run.
- * bookings / preBanLogs are patched back field-by-field; nyu_identity_cache
- * docs (which were deleted) are re-created from the stored document data.
+ * bookings / preBanLogs are patched back field-by-field.
+ *
+ * nyu_identity_cache is intentionally NOT restored: it is a regenerable 7-day
+ * TTL cache that self-populates on the next lookup, and its Timestamp fields do
+ * not survive the JSON backup round-trip. It is still captured in the backup
+ * file for reference.
  */
 const restore = async (db, options) => {
   const backup = JSON.parse(fs.readFileSync(options.restore, "utf8"));
@@ -357,21 +360,21 @@ const restore = async (db, options) => {
     from: options.restore,
     dryRun: options.dryRun,
     collections: {},
+    skipped: {},
     totals: { restoredDocs: 0, restoredFields: 0 },
   };
   const ops = [];
   for (const [name, docs] of Object.entries(backup.collections || {})) {
+    if (name === CACHE_COLLECTION) {
+      report.skipped[name] = { docs: Object.keys(docs).length };
+      continue;
+    }
     let restoredDocs = 0;
     let restoredFields = 0;
     for (const [docId, data] of Object.entries(docs)) {
       const ref = db.collection(name).doc(docId);
-      if (name === CACHE_COLLECTION) {
-        // The cache doc was deleted; re-create it wholesale.
-        if (!options.dryRun) ops.push({ ref, set: data });
-      } else {
-        // Patch the original PII fields back onto the existing doc.
-        if (!options.dryRun) ops.push({ ref, patch: data });
-      }
+      // Patch the original PII fields back onto the existing doc.
+      if (!options.dryRun) ops.push({ ref, patch: data });
       restoredDocs += 1;
       restoredFields += Object.keys(data).length;
     }
@@ -424,8 +427,9 @@ Options:
   --dry-run                Report the change set; write nothing, no backup
   --backup-only            Write the JSON backup of the eligible records but
                            make no changes (no hashing, no deletes, no pepper)
-  --restore <file>         Restore original values from a backup file (writes
-                           originals back; supports --dry-run)
+  --restore <file>         Restore original values from a backup file (bookings
+                           and preBanLogs only; the regenerable identity cache
+                           is not restored). Supports --dry-run.
   --backup-dir <path>      Where to write the JSON backup
                            (default scripts/output/anon-backups)
   --report-file <path>     Write a JSON summary report

--- a/booking-app/scripts/anonymizePII.js
+++ b/booking-app/scripts/anonymizePII.js
@@ -1,0 +1,409 @@
+//@ts-nocheck
+/**
+ * Anonymize personally identifiable information (PII) in the Firestore
+ * databases via an irreversible keyed hash (issue #1218).
+ *
+ * PII fields (from the ticket): name, netId, n-number (university id), phone.
+ * Email is intentionally OUT OF SCOPE (it is a document key / join key across
+ * the users* collections and needs a separate design).
+ *
+ * What it touches:
+ *   - `${tenant}-bookings`   name/netId/nNumber/phone fields, only for bookings
+ *                            whose `endDate` is before the --before cutoff
+ *                            (concluded bookings — active/future are never touched)
+ *   - `${tenant}-preBanLogs` `netId`, only for logs whose latest date
+ *                            (lateCancelDate/noShowDate) is before the cutoff
+ *   - `nyu_identity_cache`   shared, doc id IS a netId and the doc holds
+ *                            name + university_id; it is a 7-day TTL cache, so
+ *                            it is backed up and DELETED (regenerates on demand)
+ *
+ * Safety:
+ *   - Always writes a JSON backup of every original value BEFORE mutating.
+ *   - --dry-run reports the change set and writes no backup and no changes.
+ *   - Hashing is idempotent (already-hashed `ANON:` values are skipped), so
+ *     re-running is safe.
+ *   - Writing to production requires --confirm-production.
+ *
+ * Usage:
+ *   node scripts/anonymizePII.js --before 2026-09-01 --database development --dry-run
+ *   node scripts/anonymizePII.js --before 2026-09-01 --database staging
+ *   node scripts/anonymizePII.js --before 2026-09-01 --database production --confirm-production
+ */
+require("dotenv").config({ path: ".env.local" });
+const admin = require("firebase-admin");
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+
+const DATABASES = {
+  development: "default",
+  staging: "booking-app-staging",
+  production: "booking-app-prod",
+};
+
+const CACHE_COLLECTION = "nyu_identity_cache";
+const BATCH_SIZE = 450;
+const ANON_PREFIX = "ANON:";
+
+// Fields to hash on a booking document.
+const BOOKING_PII_FIELDS = [
+  "firstName",
+  "lastName",
+  "secondaryFirstName",
+  "secondaryLastName",
+  "secondaryName", // legacy combined name
+  "sponsorFirstName",
+  "sponsorLastName",
+  "netId",
+  "walkInNetId",
+  "nNumber",
+  "phoneNumber",
+];
+
+const PREBAN_PII_FIELDS = ["netId"];
+
+/**
+ * Irreversible keyed hash. Same input + same pepper => same output (so
+ * aggregate counts / joins survive), but the input cannot be recovered without
+ * the pepper. Non-string / empty values pass through unchanged, and values that
+ * are already hashed are left as-is (idempotent re-runs).
+ */
+const makeHasher = (pepper) => (value) => {
+  if (typeof value !== "string" || value.length === 0) return value;
+  if (value.startsWith(ANON_PREFIX)) return value;
+  const digest = crypto
+    .createHmac("sha256", pepper)
+    .update(value)
+    .digest("hex");
+  return `${ANON_PREFIX}${digest}`;
+};
+
+/**
+ * Compute the hashed field patch for one booking doc. Returns { patch, backup }
+ * where `patch` contains only the fields that actually change and `backup`
+ * holds their original values. Returns null when nothing changes.
+ */
+const computeBookingUpdate = (data, hash) => {
+  const patch = {};
+  const backup = {};
+  for (const field of BOOKING_PII_FIELDS) {
+    const original = data[field];
+    if (typeof original !== "string" || original.length === 0) continue;
+    if (original.startsWith(ANON_PREFIX)) continue;
+    patch[field] = hash(original);
+    backup[field] = original;
+  }
+  return Object.keys(patch).length > 0 ? { patch, backup } : null;
+};
+
+const computePreBanUpdate = (data, hash) => {
+  const patch = {};
+  const backup = {};
+  for (const field of PREBAN_PII_FIELDS) {
+    const original = data[field];
+    if (typeof original !== "string" || original.length === 0) continue;
+    if (original.startsWith(ANON_PREFIX)) continue;
+    patch[field] = hash(original);
+    backup[field] = original;
+  }
+  return Object.keys(patch).length > 0 ? { patch, backup } : null;
+};
+
+const toMillis = (ts) =>
+  ts && typeof ts.toMillis === "function" ? ts.toMillis() : null;
+
+/** Latest relevant date on a preBanLog, or null if none present. */
+const preBanLogDateMillis = (data) => {
+  const dates = [toMillis(data.lateCancelDate), toMillis(data.noShowDate)].filter(
+    (n) => n !== null,
+  );
+  return dates.length > 0 ? Math.max(...dates) : null;
+};
+
+const parseArgs = (args = process.argv.slice(2)) => {
+  const options = {
+    dryRun: false,
+    database: "development",
+    skipCache: false,
+    confirmProduction: false,
+  };
+  for (let index = 0; index < args.length; index++) {
+    switch (args[index]) {
+      case "--dry-run":
+        options.dryRun = true;
+        break;
+      case "--database":
+        options.database = args[++index];
+        break;
+      case "--before":
+        options.before = args[++index];
+        break;
+      case "--tenant":
+        options.tenant = args[++index];
+        break;
+      case "--backup-dir":
+        options.backupDir = args[++index];
+        break;
+      case "--report-file":
+        options.reportFile = args[++index];
+        break;
+      case "--skip-cache":
+        options.skipCache = true;
+        break;
+      case "--confirm-production":
+        options.confirmProduction = true;
+        break;
+      case "--help":
+        options.help = true;
+        break;
+      default:
+        throw new Error(`Unknown argument: ${args[index]}`);
+    }
+  }
+  if (options.help) return options;
+
+  if (!DATABASES[options.database]) {
+    throw new Error(
+      `Invalid database "${options.database}". Expected one of: ${Object.keys(
+        DATABASES,
+      ).join(", ")}`,
+    );
+  }
+  if (!options.before) {
+    throw new Error("--before <YYYY-MM-DD> is required (the academic-year cutoff)");
+  }
+  const cutoff = new Date(options.before);
+  if (Number.isNaN(cutoff.getTime())) {
+    throw new Error(`Invalid --before date: "${options.before}"`);
+  }
+  options.cutoff = cutoff;
+  if (options.database === "production" && !options.confirmProduction && !options.dryRun) {
+    throw new Error(
+      "Refusing to write to production without --confirm-production",
+    );
+  }
+  return options;
+};
+
+const initializeDb = (databaseId) => {
+  if (!admin.apps.length) {
+    admin.initializeApp({
+      credential: admin.credential.cert({
+        projectId: process.env.FIREBASE_PROJECT_ID,
+        clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+        privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n"),
+      }),
+    });
+  }
+  const db = admin.firestore();
+  if (databaseId !== "default") {
+    db.settings({ databaseId });
+  }
+  return db;
+};
+
+/** Discover the tenant-prefixed collections that hold PII. */
+const discoverCollections = async (db, tenantFilter) => {
+  const all = await db.listCollections();
+  const bookings = [];
+  const preBanLogs = [];
+  for (const ref of all) {
+    const name = ref.id;
+    if (/-bookings$/.test(name)) bookings.push(name);
+    else if (/-preBanLogs$/.test(name)) preBanLogs.push(name);
+  }
+  const matchesTenant = (name) =>
+    !tenantFilter || name.startsWith(`${tenantFilter}-`);
+  return {
+    bookings: bookings.filter(matchesTenant),
+    preBanLogs: preBanLogs.filter(matchesTenant),
+  };
+};
+
+/**
+ * Commit a set of updates in ≤500-op batches. `ops` is an array of
+ * { ref, patch } for updates or { ref, delete: true } for deletes.
+ */
+const commitInBatches = async (db, ops) => {
+  for (let i = 0; i < ops.length; i += BATCH_SIZE) {
+    const slice = ops.slice(i, i + BATCH_SIZE);
+    const batch = db.batch();
+    for (const op of slice) {
+      if (op.delete) batch.delete(op.ref);
+      else batch.update(op.ref, op.patch);
+    }
+    await batch.commit();
+  }
+};
+
+const anonymize = async (db, options) => {
+  const hash = options.dryRun ? (v) => v : makeHasher(getPepper());
+  const cutoffTs = admin.firestore.Timestamp.fromDate(options.cutoff);
+  const backup = { database: options.database, before: options.before, collections: {} };
+  const report = {
+    database: options.database,
+    before: options.before,
+    dryRun: options.dryRun,
+    collections: {},
+    totals: { docsChanged: 0, fieldsHashed: 0, docsDeleted: 0 },
+  };
+  const ops = [];
+
+  const { bookings, preBanLogs } = await discoverCollections(db, options.tenant);
+
+  // --- bookings: concluded only (endDate < cutoff) ---
+  for (const name of bookings) {
+    const snap = await db.collection(name).where("endDate", "<", cutoffTs).get();
+    let docsChanged = 0;
+    let fieldsHashed = 0;
+    const colBackup = {};
+    for (const doc of snap.docs) {
+      const result = computeBookingUpdate(doc.data(), hash);
+      if (!result) continue;
+      docsChanged += 1;
+      fieldsHashed += Object.keys(result.patch).length;
+      colBackup[doc.id] = result.backup;
+      if (!options.dryRun) ops.push({ ref: doc.ref, patch: result.patch });
+    }
+    report.collections[name] = { scanned: snap.size, docsChanged, fieldsHashed };
+    report.totals.docsChanged += docsChanged;
+    report.totals.fieldsHashed += fieldsHashed;
+    if (Object.keys(colBackup).length > 0) backup.collections[name] = colBackup;
+  }
+
+  // --- preBanLogs: netId, latest date < cutoff ---
+  for (const name of preBanLogs) {
+    const snap = await db.collection(name).get();
+    let scanned = 0;
+    let docsChanged = 0;
+    let fieldsHashed = 0;
+    const colBackup = {};
+    for (const doc of snap.docs) {
+      const data = doc.data();
+      const dateMs = preBanLogDateMillis(data);
+      if (dateMs === null || dateMs >= options.cutoff.getTime()) continue;
+      scanned += 1;
+      const result = computePreBanUpdate(data, hash);
+      if (!result) continue;
+      docsChanged += 1;
+      fieldsHashed += Object.keys(result.patch).length;
+      colBackup[doc.id] = result.backup;
+      if (!options.dryRun) ops.push({ ref: doc.ref, patch: result.patch });
+    }
+    report.collections[name] = { scanned, docsChanged, fieldsHashed };
+    report.totals.docsChanged += docsChanged;
+    report.totals.fieldsHashed += fieldsHashed;
+    if (Object.keys(colBackup).length > 0) backup.collections[name] = colBackup;
+  }
+
+  // --- nyu_identity_cache: doc id is a netId; back up + delete (regenerable) ---
+  if (!options.skipCache) {
+    const snap = await db.collection(CACHE_COLLECTION).get();
+    const colBackup = {};
+    for (const doc of snap.docs) {
+      colBackup[doc.id] = doc.data();
+      if (!options.dryRun) ops.push({ ref: doc.ref, delete: true });
+    }
+    report.collections[CACHE_COLLECTION] = {
+      scanned: snap.size,
+      docsDeleted: snap.size,
+    };
+    report.totals.docsDeleted += snap.size;
+    if (Object.keys(colBackup).length > 0) backup.collections[CACHE_COLLECTION] = colBackup;
+  }
+
+  // Write the backup fully BEFORE mutating anything.
+  if (!options.dryRun && ops.length > 0) {
+    const backupPath = writeBackup(backup, options);
+    console.log(`Backup written: ${backupPath}`);
+    await commitInBatches(db, ops);
+  }
+
+  if (options.reportFile) {
+    fs.writeFileSync(options.reportFile, JSON.stringify(report, null, 2));
+  }
+  return report;
+};
+
+const getPepper = () => {
+  const pepper = process.env.ANONYMIZATION_PEPPER;
+  if (!pepper || pepper.length < 16) {
+    throw new Error(
+      "ANONYMIZATION_PEPPER env var is required (>=16 chars) for hashing",
+    );
+  }
+  return pepper;
+};
+
+const writeBackup = (backup, options) => {
+  const dir =
+    options.backupDir || path.join(__dirname, "output", "anon-backups");
+  fs.mkdirSync(dir, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const file = path.join(dir, `anon-backup-${options.database}-${stamp}.json`);
+  fs.writeFileSync(file, JSON.stringify(backup, null, 2));
+  return file;
+};
+
+const main = async () => {
+  const options = parseArgs();
+  if (options.help) {
+    console.log(`Usage: node scripts/anonymizePII.js [options]
+
+Anonymize PII (name/netId/nNumber/phone) in concluded bookings, preBanLogs,
+and the NYU identity cache. Always backs up originals before writing.
+
+Options:
+  --before <YYYY-MM-DD>    Academic-year cutoff; only records before this are
+                           anonymized (required)
+  --database <env>         development (default), staging, or production
+  --tenant <tenant>        Limit to one tenant prefix (e.g. mc, itp)
+  --dry-run                Report the change set; write nothing, no backup
+  --backup-dir <path>      Where to write the JSON backup
+                           (default scripts/output/anon-backups)
+  --report-file <path>     Write a JSON summary report
+  --skip-cache             Do not touch nyu_identity_cache
+  --confirm-production     Required to write when --database production
+  --help                   Show this help
+
+Env: ANONYMIZATION_PEPPER (>=16 chars), FIREBASE_* (from .env.local)`);
+    return;
+  }
+
+  const report = await anonymize(initializeDb(DATABASES[options.database]), options);
+  const prefix = options.dryRun ? "[DRY RUN] " : "";
+  console.log(
+    `${prefix}${options.database} (before ${options.before}): ` +
+      `${report.totals.docsChanged} docs ${options.dryRun ? "would change" : "changed"}, ` +
+      `${report.totals.fieldsHashed} fields hashed, ` +
+      `${report.totals.docsDeleted} cache docs ${options.dryRun ? "would be deleted" : "deleted"}.`,
+  );
+  for (const [name, stats] of Object.entries(report.collections)) {
+    console.log(`  ${name}: ${JSON.stringify(stats)}`);
+  }
+};
+
+if (require.main === module) {
+  main()
+    .catch((error) => {
+      console.error(`Anonymization failed: ${error.message}`);
+      process.exitCode = 1;
+    })
+    .finally(async () => {
+      for (const app of admin.apps) {
+        if (app) await app.delete();
+      }
+    });
+}
+
+module.exports = {
+  DATABASES,
+  ANON_PREFIX,
+  BOOKING_PII_FIELDS,
+  PREBAN_PII_FIELDS,
+  makeHasher,
+  computeBookingUpdate,
+  computePreBanUpdate,
+  preBanLogDateMillis,
+  parseArgs,
+};

--- a/booking-app/scripts/anonymizePII.js
+++ b/booking-app/scripts/anonymizePII.js
@@ -15,7 +15,9 @@
  *                            (lateCancelDate/noShowDate) is before the cutoff
  *   - `nyu_identity_cache`   shared, doc id IS a netId and the doc holds
  *                            name + university_id; it is a 7-day TTL cache, so
- *                            it is backed up and DELETED (regenerates on demand)
+ *                            it is backed up and DELETED (regenerates on demand).
+ *                            It is NOT tenant-scoped, so a --tenant run leaves
+ *                            it untouched (run without --tenant to clear it).
  *
  * Safety:
  *   - Always writes a JSON backup of every original value BEFORE mutating.
@@ -316,7 +318,23 @@ const anonymize = async (db, options) => {
   }
 
   // --- nyu_identity_cache: doc id is a netId; back up + delete (regenerable) ---
-  if (!options.skipCache) {
+  // The cache is a SHARED collection: its doc ids are bare netIds, not
+  // tenant-prefixed, so it cannot be scoped to one tenant. --tenant exists to
+  // limit blast radius, so a tenant-scoped run must NOT wipe every tenant's
+  // cache entries — skip the cache pass whenever a tenant filter is set.
+  if (options.skipCache) {
+    // Cache pass explicitly disabled; nothing to do.
+  } else if (options.tenant) {
+    console.log(
+      `Skipping ${CACHE_COLLECTION}: it is a shared, non-tenant-scoped cache ` +
+        `and --tenant ${options.tenant} was given. Run without --tenant to clear it.`,
+    );
+    report.collections[CACHE_COLLECTION] = {
+      scanned: 0,
+      docsDeleted: 0,
+      skipped: "not cleared on a --tenant run (shared cache)",
+    };
+  } else {
     const snap = await db.collection(CACHE_COLLECTION).get();
     const colBackup = {};
     for (const doc of snap.docs) {
@@ -423,7 +441,9 @@ Options:
   --before <YYYY-MM-DD>    Academic-year cutoff; only records before this are
                            anonymized (required unless --restore)
   --database <env>         development (default), staging, or production
-  --tenant <tenant>        Limit to one tenant prefix (e.g. mc, itp)
+  --tenant <tenant>        Limit to one tenant prefix (e.g. mc, itp); the
+                           shared identity cache is left untouched on a
+                           tenant-scoped run
   --dry-run                Report the change set; write nothing, no backup
   --backup-only            Write the JSON backup of the eligible records but
                            make no changes (no hashing, no deletes, no pepper)
@@ -490,6 +510,7 @@ if (require.main === module) {
 module.exports = {
   DATABASES,
   ANON_PREFIX,
+  CACHE_COLLECTION,
   BOOKING_PII_FIELDS,
   PREBAN_PII_FIELDS,
   makeHasher,
@@ -497,5 +518,6 @@ module.exports = {
   computePreBanUpdate,
   preBanLogDateMillis,
   parseArgs,
+  anonymize,
   restore,
 };

--- a/booking-app/scripts/anonymizePII.js
+++ b/booking-app/scripts/anonymizePII.js
@@ -10,7 +10,10 @@
  * What it touches:
  *   - `${tenant}-bookings`   name/netId/nNumber/phone fields, only for bookings
  *                            whose `endDate` is before the --before cutoff
- *                            (concluded bookings — active/future are never touched)
+ *                            (concluded bookings — active/future are never touched).
+ *                            XState tenants also duplicate this PII inside
+ *                            xstateData.snapshot.context.formData on the same
+ *                            doc, so those nested copies are hashed as well.
  *   - `${tenant}-preBanLogs` `netId`, only for logs whose latest date
  *                            (lateCancelDate/noShowDate) is before the cutoff
  *   - `nyu_identity_cache`   shared, doc id IS a netId and the doc holds
@@ -85,15 +88,29 @@ const makeHasher = (pepper) => (value) => {
  * where `patch` contains only the fields that actually change and `backup`
  * holds their original values. Returns null when nothing changes.
  */
+// XState tenants (e.g. Media Commons) persist a full booking snapshot on the
+// same doc, and its context.formData duplicates the top-level PII as plain
+// strings. Hash those too via a Firestore dotted field path, or a plaintext
+// copy of every subject's PII survives anonymization inside the doc.
+const XSTATE_FORMDATA_PATH = "xstateData.snapshot.context.formData";
+
 const computeBookingUpdate = (data, hash) => {
   const patch = {};
   const backup = {};
+  const hashField = (original, key) => {
+    if (typeof original !== "string" || original.length === 0) return;
+    if (original.startsWith(ANON_PREFIX)) return;
+    patch[key] = hash(original);
+    backup[key] = original;
+  };
   for (const field of BOOKING_PII_FIELDS) {
-    const original = data[field];
-    if (typeof original !== "string" || original.length === 0) continue;
-    if (original.startsWith(ANON_PREFIX)) continue;
-    patch[field] = hash(original);
-    backup[field] = original;
+    hashField(data[field], field);
+  }
+  const formData = data.xstateData?.snapshot?.context?.formData;
+  if (formData && typeof formData === "object") {
+    for (const field of BOOKING_PII_FIELDS) {
+      hashField(formData[field], `${XSTATE_FORMDATA_PATH}.${field}`);
+    }
   }
   return Object.keys(patch).length > 0 ? { patch, backup } : null;
 };
@@ -177,6 +194,14 @@ const parseArgs = (args = process.argv.slice(2)) => {
         DATABASES,
       ).join(", ")}`,
     );
+  }
+
+  // --backup-only is an anonymize-mode flag (write a backup, change nothing).
+  // Combined with --restore it is meaningless AND dangerous: it flips the
+  // willWrite gate below to false, letting a real restore write to production
+  // bypass the --confirm-production check. Reject the combination outright.
+  if (options.restore && options.backupOnly) {
+    throw new Error("--backup-only cannot be combined with --restore");
   }
 
   // Restore mode reads a backup file and writes originals back; it needs no

--- a/booking-app/scripts/anonymizePII.js
+++ b/booking-app/scripts/anonymizePII.js
@@ -23,22 +23,27 @@
  *                            it untouched (run without --tenant to clear it).
  *
  * Safety:
- *   - Always writes a JSON backup of every original value BEFORE mutating.
+ *   - Always backs up every original value BEFORE mutating. The backup lives
+ *     in Firestore itself (`piiAnonymizationBackups`, same database as the
+ *     data), so raw PII never leaves the access-controlled database — no
+ *     local files, no CI artifacts. Backups carry an `expiresAt` and are
+ *     pruned automatically on the next real run (default 30 days).
  *   - --dry-run reports the change set and writes no backup and no changes.
  *   - Hashing is idempotent (already-hashed `ANON:` values are skipped), so
  *     re-running is safe.
- *   - Writing to production requires --confirm-production.
+ *   - Writing to production (including the backup docs) requires
+ *     --confirm-production.
  *
  * Usage:
  *   node scripts/anonymizePII.js --before 2026-09-01 --database development --dry-run
  *   node scripts/anonymizePII.js --before 2026-09-01 --database staging
  *   node scripts/anonymizePII.js --before 2026-09-01 --database production --confirm-production
+ *   node scripts/anonymizePII.js --restore <backup-id> --database staging
  */
 require("dotenv").config({ path: ".env.local" });
 const admin = require("firebase-admin");
 const crypto = require("crypto");
 const fs = require("fs");
-const path = require("path");
 
 const DATABASES = {
   development: "default",
@@ -47,6 +52,13 @@ const DATABASES = {
 };
 
 const CACHE_COLLECTION = "nyu_identity_cache";
+// Backups of the original values live in Firestore, in the same database as
+// the data being anonymized: one run doc + an `entries` subcollection with one
+// doc per backed-up source doc. Raw PII therefore never leaves the
+// access-controlled database. Runs expire via `expiresAt` and are pruned by
+// the next real run.
+const BACKUP_COLLECTION = "piiAnonymizationBackups";
+const BACKUP_RETENTION_DAYS_DEFAULT = 30;
 const BATCH_SIZE = 450;
 const ANON_PREFIX = "ANON:";
 
@@ -133,9 +145,10 @@ const toMillis = (ts) =>
 
 /** Latest relevant date on a preBanLog, or null if none present. */
 const preBanLogDateMillis = (data) => {
-  const dates = [toMillis(data.lateCancelDate), toMillis(data.noShowDate)].filter(
-    (n) => n !== null,
-  );
+  const dates = [
+    toMillis(data.lateCancelDate),
+    toMillis(data.noShowDate),
+  ].filter((n) => n !== null);
   return dates.length > 0 ? Math.max(...dates) : null;
 };
 
@@ -161,8 +174,8 @@ const parseArgs = (args = process.argv.slice(2)) => {
       case "--tenant":
         options.tenant = args[++index];
         break;
-      case "--backup-dir":
-        options.backupDir = args[++index];
+      case "--backup-retention-days":
+        options.backupRetentionDays = Number(args[++index]);
         break;
       case "--report-file":
         options.reportFile = args[++index];
@@ -196,16 +209,23 @@ const parseArgs = (args = process.argv.slice(2)) => {
     );
   }
 
-  // --backup-only is an anonymize-mode flag (write a backup, change nothing).
-  // Combined with --restore it is meaningless AND dangerous: it flips the
-  // willWrite gate below to false, letting a real restore write to production
-  // bypass the --confirm-production check. Reject the combination outright.
+  // --backup-only is an anonymize-mode flag (write the backup, change
+  // nothing else). Combined with --restore it is meaningless; reject it so it
+  // cannot be mistaken for a "preview restore" (that's --dry-run).
   if (options.restore && options.backupOnly) {
     throw new Error("--backup-only cannot be combined with --restore");
   }
 
-  // Restore mode reads a backup file and writes originals back; it needs no
-  // cutoff. Anonymize / backup-only mode needs the cutoff.
+  if (
+    options.backupRetentionDays !== undefined &&
+    (!Number.isInteger(options.backupRetentionDays) ||
+      options.backupRetentionDays < 1)
+  ) {
+    throw new Error("--backup-retention-days must be a positive integer");
+  }
+
+  // Restore mode reads a Firestore backup and writes originals back; it needs
+  // no cutoff. Anonymize / backup-only mode needs the cutoff.
   if (!options.restore) {
     if (!options.before) {
       throw new Error(
@@ -219,10 +239,15 @@ const parseArgs = (args = process.argv.slice(2)) => {
     options.cutoff = cutoff;
   }
 
-  // Production writes need explicit confirmation. --backup-only does not write
-  // to the database (it only reads and writes a local file), so it is exempt.
-  const willWrite = !options.dryRun && !options.backupOnly;
-  if (options.database === "production" && willWrite && !options.confirmProduction) {
+  // Production writes need explicit confirmation. Backups are written INTO
+  // Firestore, so even --backup-only writes to the database — only --dry-run
+  // is exempt.
+  const willWrite = !options.dryRun;
+  if (
+    options.database === "production" &&
+    willWrite &&
+    !options.confirmProduction
+  ) {
     throw new Error(
       "Refusing to write to production without --confirm-production",
     );
@@ -266,8 +291,9 @@ const discoverCollections = async (db, tenantFilter) => {
 };
 
 /**
- * Commit a set of updates in ≤500-op batches. `ops` is an array of
- * { ref, patch } for updates or { ref, delete: true } for deletes.
+ * Commit a set of writes in ≤500-op batches. `ops` is an array of
+ * { ref, patch } for updates, { ref, set } for creates/overwrites, or
+ * { ref, delete: true } for deletes.
  */
 const commitInBatches = async (db, ops) => {
   for (let i = 0; i < ops.length; i += BATCH_SIZE) {
@@ -275,9 +301,71 @@ const commitInBatches = async (db, ops) => {
     const batch = db.batch();
     for (const op of slice) {
       if (op.delete) batch.delete(op.ref);
+      else if (op.set) batch.set(op.ref, op.set);
       else batch.update(op.ref, op.patch);
     }
     await batch.commit();
+  }
+};
+
+/**
+ * Persist the backup into Firestore BEFORE any mutation: a run doc in
+ * `piiAnonymizationBackups` plus one `entries` subcollection doc per source
+ * doc. Field paths may contain dots (nested xstate fields), so the original
+ * values are stored as a JSON string rather than as Firestore fields.
+ * Returns the backup id.
+ */
+const writeBackupToFirestore = async (db, backup, options) => {
+  const createdAt = new Date();
+  const backupId = `anon-${options.database}-${createdAt
+    .toISOString()
+    .replace(/[:.]/g, "-")}`;
+  const runRef = db.collection(BACKUP_COLLECTION).doc(backupId);
+  const retentionDays =
+    options.backupRetentionDays ?? BACKUP_RETENTION_DAYS_DEFAULT;
+  const entryOps = [];
+  for (const [collection, docs] of Object.entries(backup.collections)) {
+    for (const [docId, fields] of Object.entries(docs)) {
+      entryOps.push({
+        ref: runRef.collection("entries").doc(`${collection}__${docId}`),
+        set: {
+          collection,
+          docId,
+          fieldsJson: JSON.stringify(fields),
+        },
+      });
+    }
+  }
+  await runRef.set({
+    database: options.database,
+    before: options.before ?? null,
+    tenant: options.tenant ?? null,
+    createdAt: admin.firestore.Timestamp.fromDate(createdAt),
+    expiresAt: admin.firestore.Timestamp.fromDate(
+      new Date(createdAt.getTime() + retentionDays * 24 * 60 * 60 * 1000),
+    ),
+    entryCount: entryOps.length,
+  });
+  await commitInBatches(db, entryOps);
+  return backupId;
+};
+
+/** Delete backup runs whose `expiresAt` has passed (entries first, then the run doc). */
+const pruneExpiredBackups = async (db) => {
+  const expired = await db
+    .collection(BACKUP_COLLECTION)
+    .where("expiresAt", "<", admin.firestore.Timestamp.now())
+    .get();
+  for (const runDoc of expired.docs) {
+    const entries = await runDoc.ref.collection("entries").get();
+    await commitInBatches(
+      db,
+      entries.docs.map((doc) => ({ ref: doc.ref, delete: true })),
+    );
+    await runDoc.ref.delete();
+  }
+  if (expired.size > 0) {
+    console.log(`Pruned ${expired.size} expired backup run(s).`);
   }
 };
 
@@ -285,21 +373,39 @@ const anonymize = async (db, options) => {
   const hash =
     options.dryRun || options.backupOnly ? (v) => v : makeHasher(getPepper());
   const cutoffTs = admin.firestore.Timestamp.fromDate(options.cutoff);
-  const backup = { database: options.database, before: options.before, collections: {} };
+  const backup = {
+    database: options.database,
+    before: options.before,
+    collections: {},
+  };
   const report = {
     database: options.database,
     before: options.before,
     dryRun: options.dryRun,
+    backupOnly: !!options.backupOnly,
+    backupId: null,
     collections: {},
     totals: { docsChanged: 0, fieldsHashed: 0, docsDeleted: 0 },
   };
   const ops = [];
 
-  const { bookings, preBanLogs } = await discoverCollections(db, options.tenant);
+  // Real runs (and backup-only runs) also clean up expired backup runs, so
+  // retention does not depend on anyone remembering to delete them.
+  if (!options.dryRun) {
+    await pruneExpiredBackups(db);
+  }
+
+  const { bookings, preBanLogs } = await discoverCollections(
+    db,
+    options.tenant,
+  );
 
   // --- bookings: concluded only (endDate < cutoff) ---
   for (const name of bookings) {
-    const snap = await db.collection(name).where("endDate", "<", cutoffTs).get();
+    const snap = await db
+      .collection(name)
+      .where("endDate", "<", cutoffTs)
+      .get();
     let docsChanged = 0;
     let fieldsHashed = 0;
     const colBackup = {};
@@ -311,7 +417,11 @@ const anonymize = async (db, options) => {
       colBackup[doc.id] = result.backup;
       if (!options.dryRun) ops.push({ ref: doc.ref, patch: result.patch });
     }
-    report.collections[name] = { scanned: snap.size, docsChanged, fieldsHashed };
+    report.collections[name] = {
+      scanned: snap.size,
+      docsChanged,
+      fieldsHashed,
+    };
     report.totals.docsChanged += docsChanged;
     report.totals.fieldsHashed += fieldsHashed;
     if (Object.keys(colBackup).length > 0) backup.collections[name] = colBackup;
@@ -371,13 +481,19 @@ const anonymize = async (db, options) => {
       docsDeleted: snap.size,
     };
     report.totals.docsDeleted += snap.size;
-    if (Object.keys(colBackup).length > 0) backup.collections[CACHE_COLLECTION] = colBackup;
+    if (Object.keys(colBackup).length > 0)
+      backup.collections[CACHE_COLLECTION] = colBackup;
   }
 
   // Write the backup fully BEFORE mutating anything.
   if (!options.dryRun && ops.length > 0) {
-    const backupPath = writeBackup(backup, options);
-    console.log(`Backup written: ${backupPath}`);
+    const backupId = await writeBackupToFirestore(db, backup, options);
+    report.backupId = backupId;
+    console.log(
+      `Backup written: ${BACKUP_COLLECTION}/${backupId} ` +
+        `(expires after ${options.backupRetentionDays ?? BACKUP_RETENTION_DAYS_DEFAULT} days; ` +
+        `restore with --restore ${backupId})`,
+    );
     if (!options.backupOnly) await commitInBatches(db, ops);
   }
 
@@ -388,16 +504,35 @@ const anonymize = async (db, options) => {
 };
 
 /**
- * Restore original values from a backup file produced by an earlier run.
- * bookings / preBanLogs are patched back field-by-field.
+ * Restore original values from a Firestore backup produced by an earlier run
+ * (`--restore <backup-id>`). bookings / preBanLogs are patched back
+ * field-by-field.
  *
  * nyu_identity_cache is intentionally NOT restored: it is a regenerable 7-day
- * TTL cache that self-populates on the next lookup, and its Timestamp fields do
- * not survive the JSON backup round-trip. It is still captured in the backup
- * file for reference.
+ * TTL cache that self-populates on the next lookup, and its Timestamp fields
+ * do not survive the JSON round-trip. It is still captured in the backup for
+ * reference.
  */
 const restore = async (db, options) => {
-  const backup = JSON.parse(fs.readFileSync(options.restore, "utf8"));
+  const runRef = db.collection(BACKUP_COLLECTION).doc(options.restore);
+  const runSnap = await runRef.get();
+  if (!runSnap.exists) {
+    throw new Error(
+      `Backup "${options.restore}" not found in ${BACKUP_COLLECTION} ` +
+        `(database ${options.database}). Note: backups expire and are pruned automatically.`,
+    );
+  }
+  // Backups live in the same database they were taken from, so a mismatch
+  // here means the run doc was written by a different-environment run with
+  // the same id — refuse rather than patch the wrong docs.
+  const meta = runSnap.data() || {};
+  if (meta.database && meta.database !== options.database) {
+    throw new Error(
+      `Backup "${options.restore}" was taken from "${meta.database}", ` +
+        `refusing to restore into "${options.database}"`,
+    );
+  }
+
   const report = {
     database: options.database,
     from: options.restore,
@@ -407,33 +542,37 @@ const restore = async (db, options) => {
     totals: { restoredDocs: 0, restoredFields: 0 },
   };
   const ops = [];
-  for (const [name, docs] of Object.entries(backup.collections || {})) {
+  const entriesSnap = await runRef.collection("entries").get();
+  for (const entryDoc of entriesSnap.docs) {
+    const entry = entryDoc.data();
+    const name = entry.collection;
+    const bump = (bucket, extra) => {
+      bucket[name] = bucket[name] || { docs: 0, ...extra };
+      bucket[name].docs += 1;
+    };
     if (name === CACHE_COLLECTION) {
-      report.skipped[name] = { docs: Object.keys(docs).length };
+      bump(report.skipped, {});
       continue;
     }
     // --tenant is a hard scope boundary everywhere else in this script, so
     // honor it here too: restoring from a full backup with --tenant mc must
-    // write back only mc-* collections, not every tenant's PII in the file.
+    // write back only mc-* collections, not every tenant's PII in the backup.
     if (options.tenant && !name.startsWith(`${options.tenant}-`)) {
-      report.skipped[name] = {
-        docs: Object.keys(docs).length,
-        reason: `outside --tenant ${options.tenant}`,
-      };
+      bump(report.skipped, { reason: `outside --tenant ${options.tenant}` });
       continue;
     }
-    let restoredDocs = 0;
-    let restoredFields = 0;
-    for (const [docId, data] of Object.entries(docs)) {
-      const ref = db.collection(name).doc(docId);
-      // Patch the original PII fields back onto the existing doc.
-      if (!options.dryRun) ops.push({ ref, patch: data });
-      restoredDocs += 1;
-      restoredFields += Object.keys(data).length;
-    }
-    report.collections[name] = { restoredDocs, restoredFields };
-    report.totals.restoredDocs += restoredDocs;
-    report.totals.restoredFields += restoredFields;
+    const data = JSON.parse(entry.fieldsJson);
+    const ref = db.collection(name).doc(entry.docId);
+    // Patch the original PII fields back onto the existing doc.
+    if (!options.dryRun) ops.push({ ref, patch: data });
+    report.collections[name] = report.collections[name] || {
+      restoredDocs: 0,
+      restoredFields: 0,
+    };
+    report.collections[name].restoredDocs += 1;
+    report.collections[name].restoredFields += Object.keys(data).length;
+    report.totals.restoredDocs += 1;
+    report.totals.restoredFields += Object.keys(data).length;
   }
   if (!options.dryRun && ops.length > 0) {
     await commitInBatches(db, ops);
@@ -454,23 +593,15 @@ const getPepper = () => {
   return pepper;
 };
 
-const writeBackup = (backup, options) => {
-  const dir =
-    options.backupDir || path.join(__dirname, "output", "anon-backups");
-  fs.mkdirSync(dir, { recursive: true });
-  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-  const file = path.join(dir, `anon-backup-${options.database}-${stamp}.json`);
-  fs.writeFileSync(file, JSON.stringify(backup, null, 2));
-  return file;
-};
-
 const main = async () => {
   const options = parseArgs();
   if (options.help) {
     console.log(`Usage: node scripts/anonymizePII.js [options]
 
 Anonymize PII (name/netId/nNumber/phone) in concluded bookings, preBanLogs,
-and the NYU identity cache. Always backs up originals before writing.
+and the NYU identity cache. Originals are always backed up first, into the
+Firestore collection "${BACKUP_COLLECTION}" in the same database (never to a
+local file or CI artifact); backups expire and are pruned automatically.
 
 Options:
   --before <YYYY-MM-DD>    Academic-year cutoff; only records before this are
@@ -480,16 +611,18 @@ Options:
                            shared identity cache is left untouched on a
                            tenant-scoped run
   --dry-run                Report the change set; write nothing, no backup
-  --backup-only            Write the JSON backup of the eligible records but
-                           make no changes (no hashing, no deletes, no pepper)
-  --restore <file>         Restore original values from a backup file (bookings
-                           and preBanLogs only; the regenerable identity cache
-                           is not restored). Supports --dry-run.
-  --backup-dir <path>      Where to write the JSON backup
-                           (default scripts/output/anon-backups)
-  --report-file <path>     Write a JSON summary report
+  --backup-only            Write the Firestore backup of the eligible records
+                           but change nothing (no hashing, no deletes, no pepper)
+  --restore <backup-id>    Restore original values from a Firestore backup run
+                           (bookings and preBanLogs only; the regenerable
+                           identity cache is not restored). Supports --dry-run.
+  --backup-retention-days <n>
+                           How long the backup run is kept before the next
+                           real run prunes it (default ${BACKUP_RETENTION_DAYS_DEFAULT})
+  --report-file <path>     Write a JSON summary report (counts only, no PII)
   --skip-cache             Do not touch nyu_identity_cache
   --confirm-production     Required to write when --database production
+                           (backups count as writes; only --dry-run is exempt)
   --help                   Show this help
 
 Env: ANONYMIZATION_PEPPER (>=16 chars, real runs only), FIREBASE_* (.env.local)`);
@@ -546,6 +679,8 @@ module.exports = {
   DATABASES,
   ANON_PREFIX,
   CACHE_COLLECTION,
+  BACKUP_COLLECTION,
+  BACKUP_RETENTION_DAYS_DEFAULT,
   BOOKING_PII_FIELDS,
   PREBAN_PII_FIELDS,
   makeHasher,
@@ -555,4 +690,5 @@ module.exports = {
   parseArgs,
   anonymize,
   restore,
+  pruneExpiredBackups,
 };

--- a/booking-app/tests/unit/anonymize-pii.unit.test.ts
+++ b/booking-app/tests/unit/anonymize-pii.unit.test.ts
@@ -1,14 +1,11 @@
 import { createRequire } from "module";
 import { describe, expect, it } from "vitest";
 
-import fs from "fs";
-import os from "os";
-import path from "path";
-
 const requireModule = createRequire(import.meta.url);
 const {
   ANON_PREFIX,
   CACHE_COLLECTION,
+  BACKUP_COLLECTION,
   makeHasher,
   computeBookingUpdate,
   computePreBanUpdate,
@@ -19,6 +16,7 @@ const {
 } = requireModule("../../scripts/anonymizePII.js") as {
   ANON_PREFIX: string;
   CACHE_COLLECTION: string;
+  BACKUP_COLLECTION: string;
   makeHasher: (pepper: string) => (value: unknown) => unknown;
   computeBookingUpdate: (
     data: Record<string, any>,
@@ -102,7 +100,11 @@ describe("scripts/anonymizePII computeBookingUpdate", () => {
   });
 
   it("returns null when there is nothing to anonymize", () => {
-    const data = { title: "meeting", firstName: `${ANON_PREFIX}x`, lastName: "" };
+    const data = {
+      title: "meeting",
+      firstName: `${ANON_PREFIX}x`,
+      lastName: "",
+    };
     expect(computeBookingUpdate(data, hash)).toBeNull();
   });
 
@@ -138,7 +140,9 @@ describe("scripts/anonymizePII computeBookingUpdate", () => {
     const data = {
       xstateData: {
         snapshot: {
-          context: { formData: { netId: `${ANON_PREFIX}deadbeef`, firstName: "" } },
+          context: {
+            formData: { netId: `${ANON_PREFIX}deadbeef`, firstName: "" },
+          },
         },
       },
     };
@@ -161,7 +165,9 @@ describe("scripts/anonymizePII computePreBanUpdate", () => {
 
 describe("scripts/anonymizePII preBanLogDateMillis", () => {
   it("returns the latest of the two dates", () => {
-    expect(preBanLogDateMillis({ lateCancelDate: ts(100), noShowDate: ts(200) })).toBe(200);
+    expect(
+      preBanLogDateMillis({ lateCancelDate: ts(100), noShowDate: ts(200) }),
+    ).toBe(200);
     expect(preBanLogDateMillis({ noShowDate: ts(50) })).toBe(50);
   });
 
@@ -176,13 +182,15 @@ describe("scripts/anonymizePII parseArgs", () => {
   });
 
   it("rejects an unknown database", () => {
-    expect(() => parseArgs(["--before", "2026-09-01", "--database", "nope"])).toThrow(
-      /Invalid database/,
-    );
+    expect(() =>
+      parseArgs(["--before", "2026-09-01", "--database", "nope"]),
+    ).toThrow(/Invalid database/);
   });
 
   it("rejects an invalid --before date", () => {
-    expect(() => parseArgs(["--before", "not-a-date"])).toThrow(/Invalid --before/);
+    expect(() => parseArgs(["--before", "not-a-date"])).toThrow(
+      /Invalid --before/,
+    );
   });
 
   it("refuses to write to production without --confirm-production", () => {
@@ -203,32 +211,55 @@ describe("scripts/anonymizePII parseArgs", () => {
     expect(opts.database).toBe("production");
   });
 
-  it("allows --backup-only on production without confirmation (no DB writes)", () => {
-    const opts = parseArgs([
-      "--before",
-      "2026-09-01",
-      "--database",
-      "production",
-      "--backup-only",
-    ]);
-    expect(opts.backupOnly).toBe(true);
+  it("requires --confirm-production for --backup-only on production (backups are DB writes)", () => {
+    expect(() =>
+      parseArgs([
+        "--before",
+        "2026-09-01",
+        "--database",
+        "production",
+        "--backup-only",
+      ]),
+    ).toThrow(/confirm-production/);
   });
 
   it("does not require --before in restore mode", () => {
-    const opts = parseArgs(["--restore", "backup.json", "--database", "development"]);
-    expect(opts.restore).toBe("backup.json");
+    const opts = parseArgs([
+      "--restore",
+      "anon-development-2026",
+      "--database",
+      "development",
+    ]);
+    expect(opts.restore).toBe("anon-development-2026");
   });
 
-  it("rejects --backup-only combined with --restore (would bypass the prod gate)", () => {
+  it("rejects --backup-only combined with --restore", () => {
     expect(() =>
-      parseArgs(["--restore", "backup.json", "--backup-only", "--database", "production"]),
+      parseArgs([
+        "--restore",
+        "anon-production-2026",
+        "--backup-only",
+        "--database",
+        "production",
+      ]),
     ).toThrow(/--backup-only cannot be combined with --restore/);
   });
 
   it("requires --confirm-production to restore to production", () => {
     expect(() =>
-      parseArgs(["--restore", "backup.json", "--database", "production"]),
+      parseArgs([
+        "--restore",
+        "anon-production-2026",
+        "--database",
+        "production",
+      ]),
     ).toThrow(/confirm-production/);
+  });
+
+  it("rejects a non-positive --backup-retention-days", () => {
+    expect(() =>
+      parseArgs(["--before", "2026-09-01", "--backup-retention-days", "0"]),
+    ).toThrow(/backup-retention-days/);
   });
 });
 
@@ -288,65 +319,225 @@ describe("scripts/anonymizePII anonymize cache scoping", () => {
   });
 });
 
-describe("scripts/anonymizePII restore", () => {
-  const stubDb = {
-    collection: (name: string) => ({ doc: (id: string) => ({ ref: `${name}/${id}` }) }),
+// Recording stub: captures every write (direct doc set/delete and committed
+// batch ops) in order, so tests can assert the backup-before-mutation
+// invariant and inspect what was written where.
+const makeRecordingDb = (collections: Record<string, Record<string, any>>) => {
+  const events: Array<{ type: string; path: string; data?: any }> = [];
+  const makeDocRef = (path: string): any => ({
+    path,
+    set: async (data: any) => {
+      events.push({ type: "set", path, data });
+    },
+    delete: async () => {
+      events.push({ type: "delete", path });
+    },
+    collection: (name: string) => makeCollection(`${path}/${name}`),
+  });
+  const docsOf = (name: string) =>
+    Object.entries(collections[name] || {}).map(([id, data]) => ({
+      id,
+      ref: makeDocRef(`${name}/${id}`),
+      data: () => data,
+    }));
+  const snapOf = (name: string) => ({
+    size: docsOf(name).length,
+    docs: docsOf(name),
+  });
+  const makeCollection = (name: string): any => ({
+    id: name,
+    doc: (id: string) => makeDocRef(`${name}/${id}`),
+    where: () => ({ get: async () => snapOf(name) }),
+    get: async () => snapOf(name),
+  });
+  return {
+    events,
+    listCollections: async () => Object.keys(collections).map((id) => ({ id })),
+    collection: (name: string) => makeCollection(name),
+    batch: () => {
+      const pending: Array<{ type: string; path: string; data?: any }> = [];
+      return {
+        update: (ref: any, patch: any) =>
+          pending.push({ type: "update", path: ref.path, data: patch }),
+        set: (ref: any, data: any) =>
+          pending.push({ type: "set", path: ref.path, data }),
+        delete: (ref: any) => pending.push({ type: "delete", path: ref.path }),
+        commit: async () => {
+          events.push(...pending);
+          pending.length = 0;
+        },
+      };
+    },
   };
+};
+
+describe("scripts/anonymizePII anonymize real run", () => {
+  it("writes the Firestore backup fully before mutating any source doc", async () => {
+    process.env.ANONYMIZATION_PEPPER = "unit-test-pepper-0123456789";
+    const db = makeRecordingDb({
+      "mc-bookings": {
+        b1: { firstName: "Ada", netId: "al123", endDate: ts(1) },
+      },
+      nyu_identity_cache: { al123: { university_id: "N1", name: "Ada" } },
+    });
+
+    const report = await anonymize(db, {
+      database: "development",
+      before: "2026-09-01",
+      dryRun: false,
+      cutoff: new Date("2026-09-01"),
+    });
+
+    expect(report.backupId).toMatch(/^anon-development-/);
+    expect(report.backupOnly).toBeFalsy();
+
+    const backupWrites = db.events.filter((e) =>
+      e.path.startsWith(`${BACKUP_COLLECTION}/`),
+    );
+    const mutations = db.events.filter(
+      (e) => !e.path.startsWith(`${BACKUP_COLLECTION}/`),
+    );
+    // Run doc + one entry per touched source doc.
+    expect(backupWrites.length).toBe(3);
+    const entry = backupWrites.find((e) => e.path.includes("mc-bookings__b1"))!;
+    expect(JSON.parse(entry.data.fieldsJson)).toEqual({
+      firstName: "Ada",
+      netId: "al123",
+    });
+    // Every backup write happens before the first mutation.
+    const firstMutation = db.events.indexOf(mutations[0]);
+    for (const write of backupWrites) {
+      expect(db.events.indexOf(write)).toBeLessThan(firstMutation);
+    }
+    // The mutations hash the booking and delete the cache doc.
+    const bookingUpdate = mutations.find((e) => e.path === "mc-bookings/b1")!;
+    expect(bookingUpdate.type).toBe("update");
+    expect(String(bookingUpdate.data.firstName).startsWith(ANON_PREFIX)).toBe(
+      true,
+    );
+    expect(mutations).toContainEqual({
+      type: "delete",
+      path: "nyu_identity_cache/al123",
+    });
+  });
+
+  it("writes the backup but no mutations in --backup-only mode", async () => {
+    const db = makeRecordingDb({
+      "mc-bookings": {
+        b1: { firstName: "Ada", endDate: ts(1) },
+      },
+    });
+
+    const report = await anonymize(db, {
+      database: "development",
+      before: "2026-09-01",
+      dryRun: false,
+      backupOnly: true,
+      cutoff: new Date("2026-09-01"),
+    });
+
+    expect(report.backupId).toMatch(/^anon-development-/);
+    expect(report.backupOnly).toBe(true);
+    expect(
+      db.events.every((e) => e.path.startsWith(`${BACKUP_COLLECTION}/`)),
+    ).toBe(true);
+  });
+});
+
+describe("scripts/anonymizePII restore", () => {
+  const makeRestoreDb = (
+    meta: Record<string, any> | null,
+    entries: Array<{ collection: string; docId: string; fields: any }>,
+  ) => ({
+    collection: (name: string) => ({
+      doc: (id: string) => {
+        if (name === BACKUP_COLLECTION) {
+          return {
+            get: async () => ({ exists: meta != null, data: () => meta }),
+            collection: () => ({
+              get: async () => ({
+                docs: entries.map((entry) => ({
+                  data: () => ({
+                    collection: entry.collection,
+                    docId: entry.docId,
+                    fieldsJson: JSON.stringify(entry.fields),
+                  }),
+                })),
+              }),
+            }),
+          };
+        }
+        return { path: `${name}/${id}` };
+      },
+    }),
+  });
+
+  const entries = [
+    {
+      collection: "mc-bookings",
+      docId: "b1",
+      fields: { firstName: "Ada", netId: "al123" },
+    },
+    { collection: "mc-preBanLogs", docId: "p1", fields: { netId: "al123" } },
+    {
+      collection: CACHE_COLLECTION,
+      docId: "al123",
+      fields: { university_id: "N1", name: "Ada" },
+    },
+  ];
 
   it("restores bookings/preBanLogs but skips the identity cache", async () => {
-    const backup = {
+    const db = makeRestoreDb({ database: "development" }, entries);
+    const report = await restore(db, {
       database: "development",
-      collections: {
-        "mc-bookings": { b1: { firstName: "Ada", netId: "al123" } },
-        "mc-preBanLogs": { p1: { netId: "al123" } },
-        nyu_identity_cache: {
-          al123: { data: {}, cachedAt: { _seconds: 1 }, expiresAt: { _seconds: 2 } },
-        },
-      },
-    };
-    const file = path.join(os.tmpdir(), `anon-restore-test-${process.pid}.json`);
-    fs.writeFileSync(file, JSON.stringify(backup));
-    try {
-      const report = await restore(stubDb, {
-        database: "development",
-        restore: file,
-        dryRun: true,
-      });
-      expect(Object.keys(report.collections).sort()).toEqual([
-        "mc-bookings",
-        "mc-preBanLogs",
-      ]);
-      expect(report.collections.nyu_identity_cache).toBeUndefined();
-      expect(report.skipped.nyu_identity_cache).toEqual({ docs: 1 });
-      expect(report.totals.restoredDocs).toBe(2);
-      expect(report.totals.restoredFields).toBe(3);
-    } finally {
-      fs.unlinkSync(file);
-    }
+      restore: "anon-development-x",
+      dryRun: true,
+    });
+    expect(Object.keys(report.collections).sort()).toEqual([
+      "mc-bookings",
+      "mc-preBanLogs",
+    ]);
+    expect(report.collections[CACHE_COLLECTION]).toBeUndefined();
+    expect(report.skipped[CACHE_COLLECTION]).toEqual({ docs: 1 });
+    expect(report.totals.restoredDocs).toBe(2);
+    expect(report.totals.restoredFields).toBe(3);
   });
 
   it("restores only the matching tenant's collections when --tenant is set", async () => {
-    const backup = {
+    const db = makeRestoreDb({ database: "development" }, [
+      { collection: "mc-bookings", docId: "b1", fields: { firstName: "Ada" } },
+      { collection: "itp-bookings", docId: "b2", fields: { firstName: "Bob" } },
+    ]);
+    const report = await restore(db, {
       database: "development",
-      collections: {
-        "mc-bookings": { b1: { firstName: "Ada" } },
-        "itp-bookings": { b2: { firstName: "Bob" } },
-      },
-    };
-    const file = path.join(os.tmpdir(), `anon-restore-tenant-${process.pid}.json`);
-    fs.writeFileSync(file, JSON.stringify(backup));
-    try {
-      const report = await restore(stubDb, {
+      restore: "anon-development-x",
+      tenant: "mc",
+      dryRun: true,
+    });
+    expect(Object.keys(report.collections)).toEqual(["mc-bookings"]);
+    expect(report.skipped["itp-bookings"]).toMatchObject({ docs: 1 });
+    expect(report.totals.restoredDocs).toBe(1);
+  });
+
+  it("throws when the backup id does not exist", async () => {
+    const db = makeRestoreDb(null, []);
+    await expect(
+      restore(db, {
         database: "development",
-        restore: file,
-        tenant: "mc",
+        restore: "anon-development-missing",
         dryRun: true,
-      });
-      expect(Object.keys(report.collections)).toEqual(["mc-bookings"]);
-      expect(report.skipped["itp-bookings"]).toMatchObject({ docs: 1 });
-      expect(report.totals.restoredDocs).toBe(1);
-    } finally {
-      fs.unlinkSync(file);
-    }
+      }),
+    ).rejects.toThrow(/not found/);
+  });
+
+  it("refuses to restore a backup taken from another database", async () => {
+    const db = makeRestoreDb({ database: "staging" }, entries);
+    await expect(
+      restore(db, {
+        database: "production",
+        restore: "anon-staging-x",
+        dryRun: true,
+      }),
+    ).rejects.toThrow(/taken from "staging"/);
   });
 });

--- a/booking-app/tests/unit/anonymize-pii.unit.test.ts
+++ b/booking-app/tests/unit/anonymize-pii.unit.test.ts
@@ -8,14 +8,17 @@ import path from "path";
 const requireModule = createRequire(import.meta.url);
 const {
   ANON_PREFIX,
+  CACHE_COLLECTION,
   makeHasher,
   computeBookingUpdate,
   computePreBanUpdate,
   preBanLogDateMillis,
   parseArgs,
+  anonymize,
   restore,
 } = requireModule("../../scripts/anonymizePII.js") as {
   ANON_PREFIX: string;
+  CACHE_COLLECTION: string;
   makeHasher: (pepper: string) => (value: unknown) => unknown;
   computeBookingUpdate: (
     data: Record<string, any>,
@@ -27,6 +30,7 @@ const {
   ) => { patch: Record<string, any>; backup: Record<string, any> } | null;
   preBanLogDateMillis: (data: Record<string, any>) => number | null;
   parseArgs: (args: string[]) => any;
+  anonymize: (db: any, options: any) => Promise<any>;
   restore: (db: any, options: any) => Promise<any>;
 };
 
@@ -180,6 +184,62 @@ describe("scripts/anonymizePII parseArgs", () => {
     expect(() =>
       parseArgs(["--restore", "backup.json", "--database", "production"]),
     ).toThrow(/confirm-production/);
+  });
+});
+
+describe("scripts/anonymizePII anonymize cache scoping", () => {
+  // Minimal Firestore stub: listCollections + collection().where().get() /
+  // collection().get() returning the given docs. Dry-run only, so no batch
+  // commits or pepper are needed.
+  const fakeDb = (collections: Record<string, Record<string, any>>) => {
+    const docsOf = (name: string) =>
+      Object.entries(collections[name] || {}).map(([id, data]) => ({
+        id,
+        ref: `${name}/${id}`,
+        data: () => data,
+      }));
+    const snapOf = (name: string) => ({
+      size: docsOf(name).length,
+      docs: docsOf(name),
+    });
+    return {
+      listCollections: async () =>
+        Object.keys(collections).map((id) => ({ id })),
+      collection: (name: string) => ({
+        where: () => ({ get: async () => snapOf(name) }),
+        get: async () => snapOf(name),
+      }),
+    };
+  };
+
+  const collections = {
+    "mc-bookings": {},
+    "itp-bookings": {},
+    nyu_identity_cache: { al123: { university_id: "N1", name: "Ada" } },
+  };
+  const baseOpts = {
+    database: "development",
+    before: "2026-09-01",
+    dryRun: true,
+    cutoff: new Date("2026-09-01"),
+  };
+
+  it("clears the shared identity cache on a full (no --tenant) run", async () => {
+    const report = await anonymize(fakeDb(collections), { ...baseOpts });
+    expect(report.collections[CACHE_COLLECTION].docsDeleted).toBe(1);
+    expect(report.totals.docsDeleted).toBe(1);
+  });
+
+  it("leaves the shared identity cache untouched on a --tenant run", async () => {
+    const report = await anonymize(fakeDb(collections), {
+      ...baseOpts,
+      tenant: "mc",
+    });
+    expect(report.totals.docsDeleted).toBe(0);
+    expect(report.collections[CACHE_COLLECTION].docsDeleted).toBe(0);
+    expect(report.collections[CACHE_COLLECTION].skipped).toBeTruthy();
+    // The tenant filter also scopes the booking collections it touches.
+    expect(report.collections["itp-bookings"]).toBeUndefined();
   });
 });
 

--- a/booking-app/tests/unit/anonymize-pii.unit.test.ts
+++ b/booking-app/tests/unit/anonymize-pii.unit.test.ts
@@ -105,6 +105,45 @@ describe("scripts/anonymizePII computeBookingUpdate", () => {
     const data = { title: "meeting", firstName: `${ANON_PREFIX}x`, lastName: "" };
     expect(computeBookingUpdate(data, hash)).toBeNull();
   });
+
+  it("also hashes the duplicate PII nested in xstateData.snapshot.context.formData", () => {
+    const data = {
+      firstName: "Ada",
+      xstateData: {
+        snapshot: {
+          context: {
+            formData: {
+              firstName: "Ada",
+              netId: "al123",
+              phoneNumber: "212-555-0100",
+              department: "not-pii",
+            },
+          },
+        },
+      },
+    };
+    const result = computeBookingUpdate(data, hash)!;
+    const key = "xstateData.snapshot.context.formData";
+    expect(result.backup[`${key}.firstName`]).toBe("Ada");
+    expect(result.backup[`${key}.netId`]).toBe("al123");
+    expect(result.backup[`${key}.phoneNumber`]).toBe("212-555-0100");
+    // non-PII nested field is untouched
+    expect(`${key}.department` in result.patch).toBe(false);
+    for (const field of Object.keys(result.patch)) {
+      expect(String(result.patch[field]).startsWith(ANON_PREFIX)).toBe(true);
+    }
+  });
+
+  it("skips already-hashed nested formData values (idempotent re-run)", () => {
+    const data = {
+      xstateData: {
+        snapshot: {
+          context: { formData: { netId: `${ANON_PREFIX}deadbeef`, firstName: "" } },
+        },
+      },
+    };
+    expect(computeBookingUpdate(data, hash)).toBeNull();
+  });
 });
 
 describe("scripts/anonymizePII computePreBanUpdate", () => {
@@ -178,6 +217,12 @@ describe("scripts/anonymizePII parseArgs", () => {
   it("does not require --before in restore mode", () => {
     const opts = parseArgs(["--restore", "backup.json", "--database", "development"]);
     expect(opts.restore).toBe("backup.json");
+  });
+
+  it("rejects --backup-only combined with --restore (would bypass the prod gate)", () => {
+    expect(() =>
+      parseArgs(["--restore", "backup.json", "--backup-only", "--database", "production"]),
+    ).toThrow(/--backup-only cannot be combined with --restore/);
   });
 
   it("requires --confirm-production to restore to production", () => {

--- a/booking-app/tests/unit/anonymize-pii.unit.test.ts
+++ b/booking-app/tests/unit/anonymize-pii.unit.test.ts
@@ -1,6 +1,10 @@
 import { createRequire } from "module";
 import { describe, expect, it } from "vitest";
 
+import fs from "fs";
+import os from "os";
+import path from "path";
+
 const requireModule = createRequire(import.meta.url);
 const {
   ANON_PREFIX,
@@ -9,6 +13,7 @@ const {
   computePreBanUpdate,
   preBanLogDateMillis,
   parseArgs,
+  restore,
 } = requireModule("../../scripts/anonymizePII.js") as {
   ANON_PREFIX: string;
   makeHasher: (pepper: string) => (value: unknown) => unknown;
@@ -22,6 +27,7 @@ const {
   ) => { patch: Record<string, any>; backup: Record<string, any> } | null;
   preBanLogDateMillis: (data: Record<string, any>) => number | null;
   parseArgs: (args: string[]) => any;
+  restore: (db: any, options: any) => Promise<any>;
 };
 
 const ts = (ms: number) => ({ toMillis: () => ms });
@@ -174,5 +180,43 @@ describe("scripts/anonymizePII parseArgs", () => {
     expect(() =>
       parseArgs(["--restore", "backup.json", "--database", "production"]),
     ).toThrow(/confirm-production/);
+  });
+});
+
+describe("scripts/anonymizePII restore", () => {
+  const stubDb = {
+    collection: (name: string) => ({ doc: (id: string) => ({ ref: `${name}/${id}` }) }),
+  };
+
+  it("restores bookings/preBanLogs but skips the identity cache", async () => {
+    const backup = {
+      database: "development",
+      collections: {
+        "mc-bookings": { b1: { firstName: "Ada", netId: "al123" } },
+        "mc-preBanLogs": { p1: { netId: "al123" } },
+        nyu_identity_cache: {
+          al123: { data: {}, cachedAt: { _seconds: 1 }, expiresAt: { _seconds: 2 } },
+        },
+      },
+    };
+    const file = path.join(os.tmpdir(), `anon-restore-test-${process.pid}.json`);
+    fs.writeFileSync(file, JSON.stringify(backup));
+    try {
+      const report = await restore(stubDb, {
+        database: "development",
+        restore: file,
+        dryRun: true,
+      });
+      expect(Object.keys(report.collections).sort()).toEqual([
+        "mc-bookings",
+        "mc-preBanLogs",
+      ]);
+      expect(report.collections.nyu_identity_cache).toBeUndefined();
+      expect(report.skipped.nyu_identity_cache).toEqual({ docs: 1 });
+      expect(report.totals.restoredDocs).toBe(2);
+      expect(report.totals.restoredFields).toBe(3);
+    } finally {
+      fs.unlinkSync(file);
+    }
   });
 });

--- a/booking-app/tests/unit/anonymize-pii.unit.test.ts
+++ b/booking-app/tests/unit/anonymize-pii.unit.test.ts
@@ -1,0 +1,156 @@
+import { createRequire } from "module";
+import { describe, expect, it } from "vitest";
+
+const requireModule = createRequire(import.meta.url);
+const {
+  ANON_PREFIX,
+  makeHasher,
+  computeBookingUpdate,
+  computePreBanUpdate,
+  preBanLogDateMillis,
+  parseArgs,
+} = requireModule("../../scripts/anonymizePII.js") as {
+  ANON_PREFIX: string;
+  makeHasher: (pepper: string) => (value: unknown) => unknown;
+  computeBookingUpdate: (
+    data: Record<string, any>,
+    hash: (v: unknown) => unknown,
+  ) => { patch: Record<string, any>; backup: Record<string, any> } | null;
+  computePreBanUpdate: (
+    data: Record<string, any>,
+    hash: (v: unknown) => unknown,
+  ) => { patch: Record<string, any>; backup: Record<string, any> } | null;
+  preBanLogDateMillis: (data: Record<string, any>) => number | null;
+  parseArgs: (args: string[]) => any;
+};
+
+const ts = (ms: number) => ({ toMillis: () => ms });
+
+describe("scripts/anonymizePII makeHasher", () => {
+  const hash = makeHasher("pepper-value-1234567890");
+
+  it("is deterministic and marks output with the ANON prefix", () => {
+    const a = hash("abc123");
+    expect(a).toBe(hash("abc123"));
+    expect(String(a).startsWith(ANON_PREFIX)).toBe(true);
+    expect(a).not.toContain("abc123");
+  });
+
+  it("is idempotent — already-hashed values pass through", () => {
+    const once = hash("netid42") as string;
+    expect(hash(once)).toBe(once);
+  });
+
+  it("passes through empty and non-string values", () => {
+    expect(hash("")).toBe("");
+    expect(hash(undefined)).toBe(undefined);
+    expect(hash(null)).toBe(null);
+    expect(hash(42)).toBe(42);
+  });
+
+  it("changes output when the pepper changes", () => {
+    const other = makeHasher("a-different-pepper-000000");
+    expect(hash("same")).not.toBe(other("same"));
+  });
+});
+
+describe("scripts/anonymizePII computeBookingUpdate", () => {
+  const hash = makeHasher("pepper-value-1234567890");
+
+  it("hashes every present PII field and backs up the originals", () => {
+    const data = {
+      firstName: "Ada",
+      lastName: "Lovelace",
+      netId: "al123",
+      walkInNetId: "wk456",
+      nNumber: "N12345678",
+      phoneNumber: "212-555-0100",
+      sponsorFirstName: "Grace",
+      sponsorLastName: "Hopper",
+      title: "not-pii", // untouched
+    };
+    const result = computeBookingUpdate(data, hash)!;
+    expect(result).not.toBeNull();
+    expect(result.patch.title).toBeUndefined();
+    expect(result.backup.firstName).toBe("Ada");
+    expect(result.backup.phoneNumber).toBe("212-555-0100");
+    for (const field of Object.keys(result.patch)) {
+      expect(String(result.patch[field]).startsWith(ANON_PREFIX)).toBe(true);
+    }
+    // title must not be in the patch or backup
+    expect("title" in result.backup).toBe(false);
+  });
+
+  it("skips empty/missing fields and already-anonymized fields", () => {
+    const data = {
+      firstName: "",
+      lastName: `${ANON_PREFIX}deadbeef`,
+      netId: "keep-me",
+    };
+    const result = computeBookingUpdate(data, hash)!;
+    expect(Object.keys(result.patch)).toEqual(["netId"]);
+  });
+
+  it("returns null when there is nothing to anonymize", () => {
+    const data = { title: "meeting", firstName: `${ANON_PREFIX}x`, lastName: "" };
+    expect(computeBookingUpdate(data, hash)).toBeNull();
+  });
+});
+
+describe("scripts/anonymizePII computePreBanUpdate", () => {
+  const hash = makeHasher("pepper-value-1234567890");
+
+  it("hashes netId only", () => {
+    const result = computePreBanUpdate(
+      { netId: "al123", bookingId: "b1", excused: false },
+      hash,
+    )!;
+    expect(Object.keys(result.patch)).toEqual(["netId"]);
+    expect(result.backup.netId).toBe("al123");
+  });
+});
+
+describe("scripts/anonymizePII preBanLogDateMillis", () => {
+  it("returns the latest of the two dates", () => {
+    expect(preBanLogDateMillis({ lateCancelDate: ts(100), noShowDate: ts(200) })).toBe(200);
+    expect(preBanLogDateMillis({ noShowDate: ts(50) })).toBe(50);
+  });
+
+  it("returns null when no date is present", () => {
+    expect(preBanLogDateMillis({ netId: "x" })).toBeNull();
+  });
+});
+
+describe("scripts/anonymizePII parseArgs", () => {
+  it("requires --before", () => {
+    expect(() => parseArgs(["--database", "development"])).toThrow(/--before/);
+  });
+
+  it("rejects an unknown database", () => {
+    expect(() => parseArgs(["--before", "2026-09-01", "--database", "nope"])).toThrow(
+      /Invalid database/,
+    );
+  });
+
+  it("rejects an invalid --before date", () => {
+    expect(() => parseArgs(["--before", "not-a-date"])).toThrow(/Invalid --before/);
+  });
+
+  it("refuses to write to production without --confirm-production", () => {
+    expect(() =>
+      parseArgs(["--before", "2026-09-01", "--database", "production"]),
+    ).toThrow(/confirm-production/);
+  });
+
+  it("allows a production dry-run without confirmation", () => {
+    const opts = parseArgs([
+      "--before",
+      "2026-09-01",
+      "--database",
+      "production",
+      "--dry-run",
+    ]);
+    expect(opts.dryRun).toBe(true);
+    expect(opts.database).toBe("production");
+  });
+});

--- a/booking-app/tests/unit/anonymize-pii.unit.test.ts
+++ b/booking-app/tests/unit/anonymize-pii.unit.test.ts
@@ -153,4 +153,26 @@ describe("scripts/anonymizePII parseArgs", () => {
     expect(opts.dryRun).toBe(true);
     expect(opts.database).toBe("production");
   });
+
+  it("allows --backup-only on production without confirmation (no DB writes)", () => {
+    const opts = parseArgs([
+      "--before",
+      "2026-09-01",
+      "--database",
+      "production",
+      "--backup-only",
+    ]);
+    expect(opts.backupOnly).toBe(true);
+  });
+
+  it("does not require --before in restore mode", () => {
+    const opts = parseArgs(["--restore", "backup.json", "--database", "development"]);
+    expect(opts.restore).toBe("backup.json");
+  });
+
+  it("requires --confirm-production to restore to production", () => {
+    expect(() =>
+      parseArgs(["--restore", "backup.json", "--database", "production"]),
+    ).toThrow(/confirm-production/);
+  });
 });

--- a/booking-app/tests/unit/anonymize-pii.unit.test.ts
+++ b/booking-app/tests/unit/anonymize-pii.unit.test.ts
@@ -279,4 +279,29 @@ describe("scripts/anonymizePII restore", () => {
       fs.unlinkSync(file);
     }
   });
+
+  it("restores only the matching tenant's collections when --tenant is set", async () => {
+    const backup = {
+      database: "development",
+      collections: {
+        "mc-bookings": { b1: { firstName: "Ada" } },
+        "itp-bookings": { b2: { firstName: "Bob" } },
+      },
+    };
+    const file = path.join(os.tmpdir(), `anon-restore-tenant-${process.pid}.json`);
+    fs.writeFileSync(file, JSON.stringify(backup));
+    try {
+      const report = await restore(stubDb, {
+        database: "development",
+        restore: file,
+        tenant: "mc",
+        dryRun: true,
+      });
+      expect(Object.keys(report.collections)).toEqual(["mc-bookings"]);
+      expect(report.skipped["itp-bookings"]).toMatchObject({ docs: 1 });
+      expect(report.totals.restoredDocs).toBe(1);
+    } finally {
+      fs.unlinkSync(file);
+    }
+  });
 });


### PR DESCRIPTION
## Summary of Changes

Closes #1218. Adds an annual, human-triggered PII anonymization for the Firestore databases, backed by a script and a GitHub Actions reminder.

The PII fields from the ticket — **name, netId, n-number, phone** — are anonymized via an irreversible keyed hash (HMAC-SHA256 with an `ANONYMIZATION_PEPPER` secret). Same input + same pepper produces the same hash, so aggregate counts / de-duplication survive, but the original value cannot be recovered without the pepper.

**What it touches**

- `${tenant}-bookings` — `firstName`, `lastName`, `secondaryFirstName`, `secondaryLastName`, `secondaryName` (legacy), `sponsorFirstName`, `sponsorLastName`, `netId`, `walkInNetId`, `nNumber`, `phoneNumber`. Only for bookings whose `endDate` is **before the `--before` cutoff** — active/future bookings are never touched, so check-in, emails, and calendar are unaffected.
- `${tenant}-preBanLogs` — `netId`, only for logs whose latest date is before the cutoff.
- `nyu_identity_cache` — the doc id is a netId and the doc holds name + `university_id`; it is a 7-day TTL cache, so it is backed up and **deleted** (it regenerates on demand).

**Safety**

- Every original value is backed up **before** any mutation — into Firestore itself (collection `piiAnonymizationBackups`, same database as the data), so raw PII never leaves the access-controlled database. Nothing PII-bearing is written to CI logs or artifacts (this repo is public, and Actions artifacts are downloadable by anyone with read access; only a counts-only report is uploaded).
- Backup runs carry an `expiresAt` (default 30 days, `--backup-retention-days` to override) and expired runs are pruned automatically by the next real run. Roll back with `node scripts/anonymizePII.js --restore <backup-id> --database <env>`; restore refuses a backup taken from a different database.
- Hashing is **idempotent** (already-hashed `ANON:` values are skipped), so re-running is safe.
- Writing to production requires `--confirm-production` — including `--backup-only`, since the backup docs are themselves database writes. Only `--dry-run` is exempt.
- `--dry-run` reports the change set and writes nothing.

**How it runs**

- `.github/workflows/anonymize-pii-cron.yml` runs on **Sept 1** each year. The scheduled run is **dry-run only** (dev + production) and opens a **GitHub Issue** with the preview + instructions, so the yearly task cannot be silently forgotten.
- A human performs the real run via **Run workflow** (`dry_run=false`, plus `confirm_production=true` for production).
- Local: `node scripts/anonymizePII.js --database <env> --before <YYYY-MM-DD> [--dry-run]` (or `npm run anonymize:pii:dry-run -- --database ... --before ...`).

**Out of scope:** email. It is a document key / join key across the `users*` collections, so anonymizing it needs a separate design and is intentionally not included here.

**Deployment prerequisite:** an `ANONYMIZATION_PEPPER` secret (≥16 chars, stable over time) must be set on each environment that performs a real run. Dry-run does not need it.

Dry-run verified against the development database: 1,325 docs / 5,181 fields would be hashed and 4 cache docs deleted, with no writes.

## Schema Changes

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [ ] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

Tests: `tests/unit/anonymize-pii.unit.test.ts` (30 tests) covers the hasher (determinism, idempotency, pass-through), field selection + backup (including nested xstate formData), the preBanLog date filter, CLI arg validation, cache/tenant scoping, the backup-before-mutation ordering invariant, and Firestore-based restore (tenant scoping, missing backup, cross-database refusal). `tsc --noEmit` passes and the workflow YAML is valid.

## Screenshots / Video

No UI. This is a maintenance script plus a scheduled workflow, so there is nothing to show visually; the dry-run output and the reminder-issue body are described above.

