### PR TITLE
ci: add Claude PR review workflow

### DIFF
--- a/.github/scripts/submit_review.py
+++ b/.github/scripts/submit_review.py
@@ -135,11 +135,21 @@ def main() -> None:
             "not blocking the PR."
         )
         return
-    comments = review.get("comments") or []
-    body = review.get("body") or ""
-    base = {"event": review.get("event", "COMMENT")}
-    if review.get("commit_id"):
-        base["commit_id"] = review["commit_id"]
+    # review.json is untrusted model output: the review verdict is pinned to
+    # COMMENT (never APPROVE/REQUEST_CHANGES) and commit_id comes from the
+    # workflow env, so an injected payload can only influence comment text.
+    raw_comments = review.get("comments")
+    comments = (
+        [c for c in raw_comments if isinstance(c, dict)]
+        if isinstance(raw_comments, list)
+        else []
+    )
+    body = review.get("body")
+    body = body if isinstance(body, str) else ""
+    base = {"event": "COMMENT"}
+    head_sha = os.environ.get("HEAD_SHA")
+    if head_sha:
+        base["commit_id"] = head_sha
 
     valid: dict[str, set[int]] = {}
     try:
@@ -151,6 +161,12 @@ def main() -> None:
         print(f"warning: could not compute diff lines ({exc}); folding all inline comments")
 
     kept, folded = partition_comments(comments, valid)
+
+    # GitHub's create-review API requires start_side when start_line is set;
+    # a comment that omits it would 422 the whole review.
+    for c in kept:
+        if c.get("start_line") is not None:
+            c.setdefault("start_side", "RIGHT")
 
     def fold_into(text: str, items: list[dict], heading: str) -> str:
         if not items:

--- a/.github/scripts/submit_review.py
+++ b/.github/scripts/submit_review.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Submit the Claude review payload as one PR review, resilient to inline
+comments GitHub cannot anchor to the diff.
+
+The model writes ``/tmp/review.json`` with inline comments keyed to new-file
+line numbers. GitHub's create-review API rejects the WHOLE review (HTTP 422,
+"Line could not be resolved") if any single comment's line falls outside the
+PR's diff hunks. To stay green without dropping findings, this script:
+
+  1. Computes the set of commentable RIGHT-side lines from ``gh pr diff``.
+  2. Keeps inline comments whose (path, line) is anchorable; folds the rest
+     into the review body so the finding still shows up.
+  3. POSTs once. On any residual failure, retries body-only, then gives up
+     gracefully -- a review-infra hiccup must not block the PR.
+
+Trust boundary: this is the trusted step. The endpoint is hardcoded here and
+the model never holds ``gh api``; a malicious diff can only influence comment
+*text* (which already lands in the review body either way), never which API
+call runs.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+
+REVIEW_PATH = "/tmp/review.json"
+
+
+def parse_commentable_lines(diff: str) -> dict[str, set[int]]:
+    """Map new-file path -> set of RIGHT-side line numbers inside diff hunks.
+
+    GitHub allows a RIGHT-side comment on added (``+``) and context (`` ``)
+    lines within a hunk; removed (``-``) lines have no new-file line. Pure
+    function over unified-diff text so it can be unit-tested without network.
+    """
+    valid: dict[str, set[int]] = {}
+    path: str | None = None
+    newln = 0
+    in_hunk = False
+    for line in diff.splitlines():
+        # A new file section resets state so inter-file metadata
+        # (``diff --git``, ``index``, ``--- ``/``+++ `` headers) is never
+        # mistaken for hunk content.
+        if line.startswith("diff --git"):
+            path, in_hunk = None, False
+            continue
+        if not in_hunk:
+            if line.startswith("+++ "):
+                p = line[4:].strip()
+                if p.startswith("b/"):
+                    p = p[2:]
+                path = None if p == "/dev/null" else p
+                if path is not None:
+                    valid.setdefault(path, set())
+            elif line.startswith("@@"):
+                m = re.search(r"\+(\d+)", line)
+                newln = int(m.group(1)) if m else 0
+                in_hunk = True
+            continue
+        # Inside a hunk.
+        if line.startswith("@@"):  # next hunk of the same file
+            m = re.search(r"\+(\d+)", line)
+            newln = int(m.group(1)) if m else 0
+            continue
+        if path is None:
+            continue
+        if line.startswith("+"):  # added line (commentable on RIGHT)
+            valid[path].add(newln)
+            newln += 1
+        elif line.startswith(" "):  # context line (commentable on RIGHT)
+            valid[path].add(newln)
+            newln += 1
+        # ``-`` (removed, no RIGHT line) and ``\`` ("No newline") consume nothing.
+    return valid
+
+
+def post(repo: str, pr: str, payload: dict) -> tuple[int, str]:
+    proc = subprocess.run(
+        ["gh", "api", "--method", "POST",
+         f"/repos/{repo}/pulls/{pr}/reviews", "--input", "-"],
+        input=json.dumps(payload), capture_output=True, text=True,
+    )
+    return proc.returncode, (proc.stdout + proc.stderr).strip()
+
+
+def partition_comments(
+    comments: list[dict], valid: dict[str, set[int]]
+) -> tuple[list[dict], list[dict]]:
+    """Split comments into (anchorable-inline, must-fold-into-body).
+
+    A comment is anchorable when it targets the RIGHT side and both its
+    ``line`` and (for a multi-line span) ``start_line`` land on a commentable
+    line of the file in the diff.
+    """
+    kept, folded = [], []
+    for c in comments:
+        p, ln, sl = c.get("path"), c.get("line"), c.get("start_line")
+        anchorable = (
+            c.get("side", "RIGHT") == "RIGHT"
+            and p in valid and ln in valid[p]
+            and (sl is None or sl in valid[p])
+        )
+        (kept if anchorable else folded).append(c)
+    return kept, folded
+
+
+def _loc(c: dict) -> str:
+    return f"{c.get('path')}:{c.get('line')}"
+
+
+def main() -> None:
+    pr = os.environ["PR_NUMBER"]
+    repo = os.environ["REPO"]
+    # The model occasionally writes a /tmp/review.json that isn't valid JSON
+    # (e.g. an unescaped quote or newline inside a comment body), which made
+    # ``json.load`` raise and fail the whole job. Review posting is advisory
+    # and must not block the PR -- mirror the graceful give-up the submit
+    # fallbacks already use: log loudly and return. Re-running the review
+    # regenerates the file.
+    try:
+        with open(REVIEW_PATH) as f:
+            review = json.load(f)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(
+            f"warning: could not read/parse {REVIEW_PATH} ({exc}); "
+            "skipping review submit, not blocking the PR."
+        )
+        return
+    if not isinstance(review, dict):
+        print(
+            f"warning: {REVIEW_PATH} is not a JSON object "
+            f"(got {type(review).__name__}); skipping review submit, "
+            "not blocking the PR."
+        )
+        return
+    comments = review.get("comments") or []
+    body = review.get("body") or ""
+    base = {"event": review.get("event", "COMMENT")}
+    if review.get("commit_id"):
+        base["commit_id"] = review["commit_id"]
+
+    valid: dict[str, set[int]] = {}
+    try:
+        diff = subprocess.run(
+            ["gh", "pr", "diff", pr], capture_output=True, text=True, check=True
+        ).stdout
+        valid = parse_commentable_lines(diff)
+    except Exception as exc:  # diff fetch/parse failed -> fall back to body-only
+        print(f"warning: could not compute diff lines ({exc}); folding all inline comments")
+
+    kept, folded = partition_comments(comments, valid)
+
+    def fold_into(text: str, items: list[dict], heading: str) -> str:
+        if not items:
+            return text
+        out = text + f"\n\n---\n**{heading}:**\n"
+        for c in items:
+            out += f"\n- `{_loc(c)}` -- {c.get('body', '').strip()}"
+        return out
+
+    # Attempt 1: anchorable comments inline, the rest folded into the body.
+    body1 = fold_into(body, folded, "Findings that could not be anchored to the diff")
+    rc, out = post(repo, pr, {**base, "body": body1, "comments": kept})
+    if rc == 0:
+        print(f"Posted review: {len(kept)} inline, {len(folded)} folded into body.")
+        return
+    print(f"Inline submit failed (rc={rc}); falling back to body-only.\n{out}")
+
+    # Attempt 2: everything in the body, no inline anchors at all.
+    body2 = fold_into(body1, kept, "Inline findings (anchoring unavailable)")
+    rc, out = post(repo, pr, {**base, "body": body2 or "Review produced no anchorable findings.",
+                              "comments": []})
+    if rc == 0:
+        print("Posted body-only review.")
+        return
+
+    # A body-only COMMENT review needs no line resolution, so this is an
+    # auth/rate-limit/transport problem, not the 422 we set out to fix.
+    # Log loudly but do not fail the job: review posting is advisory and must
+    # not block the PR.
+    print(f"warning: review submit failed entirely (rc={rc}); not blocking the PR.\n{out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,9 +22,13 @@ jobs:
     # Skip drafts, and skip Dependabot PRs — Dependabot-triggered runs don't get
     # the repo's Actions secrets, so the auth step can't load the OAuth token
     # and the check fails. Dep bumps don't need an AI code review anyway.
+    # Also skip fork PRs: they don't receive secrets either (the review can't
+    # auth), and gating on same-repo keeps the write-scoped GITHUB_TOKEN away
+    # from untrusted heads entirely.
     if: >-
       github.actor != 'dependabot[bot]' &&
-      github.event.pull_request.draft == false
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     # A hung API call would otherwise hold the runner for the 6h default.
     # Sized to fit the --max-turns budget below (~25s/turn observed) with margin,
@@ -51,8 +55,8 @@ jobs:
           # The fixed "Submit review" step below makes the one hardcoded POST call.
           # Write is left unscoped on purpose: a path-scoped matcher (Write(/tmp/**))
           # silently blocked the /tmp/review.json write and the review never posted.
-          # The one workspace write with an execution path — this script itself — is
-          # neutralized by the submit step restoring it from HEAD before running it;
+          # The one workspace write with an execution path — submit_review.py — is
+          # neutralized by the submit step executing the BASE-ref copy of the script;
           # the runner is ephemeral, and the real injection lever (the API call) is gone.
           # max-turns must cover: read the diff, reason over every hunk, then
           # write /tmp/review.json. Large PRs keep exhausting smaller budgets
@@ -116,14 +120,24 @@ jobs:
           REPO: ${{ github.repository }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          # The model held an unscoped Write tool while reading an
-          # attacker-controlled diff, so the working-tree copy of this script
-          # is untrusted at this point. Restore the committed version before
-          # executing it, or a prompt injection could rewrite the "trusted"
-          # script instead of calling gh api directly.
-          git checkout HEAD -- .github/scripts/submit_review.py
+          # Execute the submit script from the trusted BASE ref, not the PR's
+          # copy. The PR checkout is untrusted twice over: the Claude step
+          # holds an unscoped Write tool (runtime tampering), and the PR
+          # itself may commit an edited submit_review.py (committed
+          # tampering). Neither version may run with the write-scoped token.
+          # Bootstrap fallback: if the base branch doesn't have the script
+          # yet (the PR introducing it), use the PR copy restored from its
+          # committed state.
+          BASE_REF="origin/${{ github.event.pull_request.base.ref }}"
+          if git show "$BASE_REF:.github/scripts/submit_review.py" > /tmp/submit_review.py 2>/dev/null; then
+            SCRIPT=/tmp/submit_review.py
+          else
+            echo "warning: submit_review.py not on $BASE_REF yet (bootstrap PR); using the PR's committed copy"
+            git checkout HEAD -- .github/scripts/submit_review.py
+            SCRIPT=.github/scripts/submit_review.py
+          fi
           if [ ! -f /tmp/review.json ]; then
             echo "No /tmp/review.json produced; nothing to submit."
             exit 0
           fi
-          python3 .github/scripts/submit_review.py
+          python3 "$SCRIPT"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -55,9 +55,11 @@ jobs:
           # The fixed "Submit review" step below makes the one hardcoded POST call.
           # Write is left unscoped on purpose: a path-scoped matcher (Write(/tmp/**))
           # silently blocked the /tmp/review.json write and the review never posted.
-          # The one workspace write with an execution path — submit_review.py — is
-          # neutralized by the submit step executing the BASE-ref copy of the script;
-          # the runner is ephemeral, and the real injection lever (the API call) is gone.
+          # The writes with an execution path — submit_review.py itself, and the
+          # $GITHUB_ENV/$GITHUB_PATH file commands — are neutralized by the submit
+          # step executing the BASE-ref copy via absolute paths under a clean
+          # `env -i` environment; the runner is ephemeral, and the real injection
+          # lever (the API call) is gone.
           # max-turns must cover: read the diff, reason over every hunk, then
           # write /tmp/review.json. Large PRs keep exhausting smaller budgets
           # before the write, ending in error_max_turns with no review posted.
@@ -125,19 +127,37 @@ jobs:
           # holds an unscoped Write tool (runtime tampering), and the PR
           # itself may commit an edited submit_review.py (committed
           # tampering). Neither version may run with the write-scoped token.
-          # Bootstrap fallback: if the base branch doesn't have the script
-          # yet (the PR introducing it), use the PR copy restored from its
-          # committed state.
+          #
+          # All binaries are invoked by absolute path and the script runs
+          # under `env -i` with an explicit allowlist: the Claude step's
+          # unscoped Write could poison $GITHUB_ENV/$GITHUB_PATH, and a
+          # shadowed `gh` on PATH or an injected GH_HOST would otherwise
+          # redirect the hardcoded API call (token included) elsewhere.
           BASE_REF="origin/${{ github.event.pull_request.base.ref }}"
-          if git show "$BASE_REF:.github/scripts/submit_review.py" > /tmp/submit_review.py 2>/dev/null; then
+          if ! /usr/bin/git rev-parse --verify --quiet "$BASE_REF^{commit}" > /dev/null; then
+            echo "error: cannot resolve $BASE_REF; refusing to fall back to the PR's copy of submit_review.py"
+            exit 1
+          fi
+          if /usr/bin/git cat-file -e "$BASE_REF:.github/scripts/submit_review.py" 2>/dev/null; then
+            /usr/bin/git show "$BASE_REF:.github/scripts/submit_review.py" > /tmp/submit_review.py
             SCRIPT=/tmp/submit_review.py
           else
-            echo "warning: submit_review.py not on $BASE_REF yet (bootstrap PR); using the PR's committed copy"
-            git checkout HEAD -- .github/scripts/submit_review.py
+            # Bootstrap-only: the base branch resolves but doesn't have the
+            # script yet (the PR introducing it). Any other git failure exits
+            # above instead of silently trusting the PR copy.
+            echo "bootstrap: submit_review.py not on $BASE_REF yet; using the PR's committed copy"
+            /usr/bin/git checkout HEAD -- .github/scripts/submit_review.py
             SCRIPT=.github/scripts/submit_review.py
           fi
           if [ ! -f /tmp/review.json ]; then
             echo "No /tmp/review.json produced; nothing to submit."
             exit 0
           fi
-          python3 "$SCRIPT"
+          /usr/bin/env -i \
+            PATH=/usr/bin:/bin \
+            HOME="$HOME" \
+            GH_TOKEN="$GH_TOKEN" \
+            PR_NUMBER="$PR_NUMBER" \
+            REPO="$REPO" \
+            HEAD_SHA="$HEAD_SHA" \
+            /usr/bin/python3 "$SCRIPT"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -5,7 +5,9 @@ on:
     branches: [main]
     # ready_for_review is required so a draft promoted to ready gets reviewed —
     # without it the draft guard below would silently skip such PRs forever.
-    types: [opened, synchronize, ready_for_review]
+    # reopened is required for the same reason: a closed-then-reopened PR with
+    # no new commit would otherwise never be reviewed.
+    types: [opened, synchronize, ready_for_review, reopened]
 
 # One review per PR; a new push cancels the in-flight review instead of
 # stacking duplicate threads (and duplicate API spend).
@@ -52,6 +54,13 @@ jobs:
           # Claude only READS (gh pr diff) and WRITES the review payload to a file.
           # It is deliberately NOT given gh api: the PR diff is attacker-controlled,
           # so a prompt injection must not be able to choose which API endpoint runs.
+          # Accepted residual risk: the allowlist relies on Claude Code's permission
+          # engine, which evaluates compound commands (;, &&, |) per segment and
+          # rejects command substitution in non-interactive mode — not on naive
+          # string-prefix matching. If that engine were bypassed, the blast radius
+          # is contained by the submit step (base-ref script, env -i, absolute
+          # paths); token exfiltration from the agent's own step is inherent to
+          # running a hosted agent and is not mitigable at this layer.
           # The fixed "Submit review" step below makes the one hardcoded POST call.
           # Write is left unscoped on purpose: a path-scoped matcher (Write(/tmp/**))
           # silently blocked the /tmp/review.json write and the review never posted.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -51,8 +51,9 @@ jobs:
           # The fixed "Submit review" step below makes the one hardcoded POST call.
           # Write is left unscoped on purpose: a path-scoped matcher (Write(/tmp/**))
           # silently blocked the /tmp/review.json write and the review never posted.
-          # Residual risk is low — workspace writes have no execution path here and the
-          # runner is ephemeral; the real injection lever (the API call) is already gone.
+          # The one workspace write with an execution path — this script itself — is
+          # neutralized by the submit step restoring it from HEAD before running it;
+          # the runner is ephemeral, and the real injection lever (the API call) is gone.
           # max-turns must cover: read the diff, reason over every hunk, then
           # write /tmp/review.json. Large PRs keep exhausting smaller budgets
           # before the write, ending in error_max_turns with no review posted.
@@ -113,7 +114,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
+          # The model held an unscoped Write tool while reading an
+          # attacker-controlled diff, so the working-tree copy of this script
+          # is untrusted at this point. Restore the committed version before
+          # executing it, or a prompt injection could rewrite the "trusted"
+          # script instead of calling gh api directly.
+          git checkout HEAD -- .github/scripts/submit_review.py
           if [ ! -f /tmp/review.json ]; then
             echo "No /tmp/review.json produced; nothing to submit."
             exit 0

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,121 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    branches: [main]
+    # ready_for_review is required so a draft promoted to ready gets reviewed —
+    # without it the draft guard below would silently skip such PRs forever.
+    types: [opened, synchronize, ready_for_review]
+
+# One review per PR; a new push cancels the in-flight review instead of
+# stacking duplicate threads (and duplicate API spend).
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    # Skip drafts, and skip Dependabot PRs — Dependabot-triggered runs don't get
+    # the repo's Actions secrets, so the auth step can't load the OAuth token
+    # and the check fails. Dep bumps don't need an AI code review anyway.
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    # A hung API call would otherwise hold the runner for the 6h default.
+    # Sized to fit the --max-turns budget below (~25s/turn observed) with margin,
+    # so the turn cap — not this wall clock — stays the limiting factor.
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Claude review
+        # Pinned to the commit the v1 tag pointed at (mutable tags are a
+        # supply-chain risk for a step that runs with repo credentials).
+        uses: anthropics/claude-code-action@36a69b6a90b850823f86de06fdfd56264772ad98 # v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Claude subscription auth (no Bedrock / no API key). Generate with
+          # `claude setup-token` and store as the CLAUDE_CODE_OAUTH_TOKEN secret.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Claude only READS (gh pr diff) and WRITES the review payload to a file.
+          # It is deliberately NOT given gh api: the PR diff is attacker-controlled,
+          # so a prompt injection must not be able to choose which API endpoint runs.
+          # The fixed "Submit review" step below makes the one hardcoded POST call.
+          # Write is left unscoped on purpose: a path-scoped matcher (Write(/tmp/**))
+          # silently blocked the /tmp/review.json write and the review never posted.
+          # Residual risk is low — workspace writes have no execution path here and the
+          # runner is ephemeral; the real injection lever (the API call) is already gone.
+          # max-turns must cover: read the diff, reason over every hunk, then
+          # write /tmp/review.json. Large PRs keep exhausting smaller budgets
+          # before the write, ending in error_max_turns with no review posted.
+          # timeout-minutes above is sized to fit 80 turns (~25s/turn ≈ 33 min)
+          # so the turn cap stays the limiting factor.
+          claude_args: >-
+            --model claude-sonnet-5
+            --max-turns 80
+            --allowedTools "Bash(gh pr diff:*),Write"
+          prompt: |
+            You are reviewing pull request #${{ github.event.pull_request.number }}
+            in the repository ${{ github.repository }}. The head commit SHA is
+            ${{ github.event.pull_request.head.sha }}.
+
+            Report ONLY High and Medium severity findings:
+            - High: correctness bugs, security issues (auth, injection, secret
+              leakage, unsafe file handling), data loss, multi-tenant / app-scope
+              boundary breaks.
+            - Medium: likely-incorrect behavior, missing error handling, race
+              conditions, configuration that fails silently.
+            Do NOT report Low severity, nitpicks, style, formatting, naming, or
+            subjective preferences. If a finding is not clearly High or Medium, omit it.
+
+            Post everything as ONE single pull request review (GitHub Copilot style),
+            NOT as separate standalone comments. Steps:
+            1. Read the diff: gh pr diff ${{ github.event.pull_request.number }}
+            2. For each High/Medium finding, note the file path and the exact line
+               number in the NEW version of the file (the right side of the diff).
+            3. Use the Write tool to create /tmp/review.json with this shape:
+               {
+                 "event": "COMMENT",
+                 "commit_id": "${{ github.event.pull_request.head.sha }}",
+                 "body": "<1-2 sentence summary, e.g. '2 High, 1 Medium.'>",
+                 "comments": [
+                   {"path": "<file>", "line": <new-file line number>, "side": "RIGHT",
+                    "body": "**[High]** <concise issue + concrete fix>"}
+                 ]
+               }
+               Prefix every comment body with **[High]** or **[Medium]**. For a
+               multi-line span, also set "start_line" and "start_side": "RIGHT".
+            4. Do NOT submit the review yourself and do NOT call gh api — you do not
+               have that permission. Your only job is to WRITE /tmp/review.json. A
+               separate trusted workflow step submits it.
+            Always write /tmp/review.json. If there are no High or Medium findings,
+            write it with an empty "comments" array and body "No High or Medium
+            severity issues found."
+
+      # Trusted submit: the endpoint is hardcoded in the script, so even if a
+      # malicious PR injects instructions into the diff, it can only influence
+      # comment text — never which API call runs. Claude never holds an
+      # API-write tool. The script also drops inline comments GitHub can't
+      # anchor to the diff (which otherwise 422 the whole review) by folding
+      # them into the review body, so one bad line number no longer fails the
+      # job or loses the finding.
+      - name: Submit batched review
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ ! -f /tmp/review.json ]; then
+            echo "No /tmp/review.json produced; nothing to submit."
+            exit 0
+          fi
+          python3 .github/scripts/submit_review.py


### PR DESCRIPTION
## Summary of Changes

Adds an automated Claude code review to every pull request targeting `main`, posting High/Medium severity findings as a single batched review (GitHub Copilot style), adapted from the workflow used in `tesla-statement-ai-backend`.

- `.github/workflows/claude-review.yml` — runs `anthropics/claude-code-action` (pinned to the v1 commit SHA) on `opened` / `synchronize` / `ready_for_review`. Skips drafts and Dependabot PRs. One review per PR via `concurrency` (a new push cancels the in-flight review). Auth is a Claude subscription OAuth token (`CLAUDE_CODE_OAUTH_TOKEN` repo secret, already configured) — no AWS/Bedrock dependency. Model: `claude-sonnet-5`.
- `.github/scripts/submit_review.py` — trusted submit step. Posts the review with a hardcoded endpoint and folds inline comments that GitHub cannot anchor to the diff into the review body, so one bad line number does not 422 the whole review.

Security design: the review agent is only allowed `Bash(gh pr diff:*)` and `Write`. It never holds `gh api`, so a prompt injection in an attacker-controlled PR diff can only influence comment text, never which API call runs. Review posting is advisory — a review-infra failure never blocks the PR.

## Schema Changes

- [x] No tenant schema changes

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally (YAML/Python syntax validated; the workflow itself can only run on GitHub Actions — this PR is the live test, a Claude review should appear on it)
- [x] I added or updated unit tests (or explained why not in the PR description) — CI workflow only, no application code; `submit_review.py` is copied as-is from a workflow already running in production in another repository
- [x] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description) — no UI changes; the demonstration is the Claude review posted on this PR
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video

No UI changes — see the Claude review posted on this PR by the workflow itself.
