### PR TITLE
security(tenantSchema): session-based auth + validate on write

### DIFF
--- a/booking-app/app/api/tenantSchema/[tenant]/compare/route.ts
+++ b/booking-app/app/api/tenantSchema/[tenant]/compare/route.ts
@@ -1,12 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import {
-  serverFetchAllDataFromCollection,
-} from "@/lib/firebase/server/adminDb";
-import { TableNames } from "@/components/src/policy";
+import { isValidTenant } from "@/components/src/constants/tenants";
 import {
   getSchemaFromEnv,
   ENVIRONMENTS,
 } from "@/lib/firebase/server/multiDb";
+import { requireSuperAdmin } from "@/lib/api/requireSuperAdmin";
 
 export async function GET(
   request: NextRequest,
@@ -15,28 +13,16 @@ export async function GET(
   try {
     const { tenant } = await params;
 
-    // Verify super admin permission
-    const userEmail = request.headers.get("x-user-email");
-    if (!userEmail) {
+    if (!isValidTenant(tenant)) {
       return NextResponse.json(
-        { error: "Authentication required" },
-        { status: 401 },
+        { error: `Invalid tenant: ${tenant}` },
+        { status: 400 },
       );
     }
 
-    const superAdmins = await serverFetchAllDataFromCollection<{
-      id: string;
-      email: string;
-    }>(TableNames.SUPER_ADMINS);
-    const isSuperAdmin = superAdmins.some(
-      (sa) => sa.email.toLowerCase() === userEmail.toLowerCase(),
-    );
-    if (!isSuperAdmin) {
-      return NextResponse.json(
-        { error: "Super admin permission required" },
-        { status: 403 },
-      );
-    }
+    // Verify super admin permission from the NextAuth session.
+    const auth = await requireSuperAdmin(tenant);
+    if ("error" in auth) return auth.error;
 
     // Fetch schemas from all environments in parallel.
     // Catch per-env errors so one failing environment doesn't break the response.

--- a/booking-app/app/api/tenantSchema/[tenant]/route.ts
+++ b/booking-app/app/api/tenantSchema/[tenant]/route.ts
@@ -2,13 +2,14 @@ import { NextRequest, NextResponse } from "next/server";
 import {
   serverGetDocumentById,
   serverSaveDataToFirestoreWithId,
-  serverFetchAllDataFromCollection,
 } from "@/lib/firebase/server/adminDb";
 import { TableNames } from "@/components/src/policy";
 import { applyEnvironmentCalendarIds } from "@/lib/utils/calendarEnvironment";
 import { coerceTenantSchema } from "@/lib/tenant/coerceTenantSchema";
 import { isValidTenant } from "@/components/src/constants/tenants";
 import admin from "@/lib/firebase/server/firebaseAdmin";
+import { requireSession } from "@/lib/api/requireSession";
+import { requireSuperAdmin } from "@/lib/api/requireSuperAdmin";
 
 export async function GET(
   request: NextRequest,
@@ -16,6 +17,16 @@ export async function GET(
 ) {
   try {
     const { tenant } = await params;
+
+    // The schema exposes calendar IDs, email templates, and org mappings, so it
+    // requires an authenticated NYU session (the collection is `anyNYU`-read).
+    const session = await requireSession();
+    if (!session) {
+      return NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 },
+      );
+    }
 
     // Fetch the specific schema document using tenant as document ID
     const rawDoc = await serverGetDocumentById<Record<string, unknown>>(
@@ -71,33 +82,34 @@ export async function PUT(
       );
     }
 
-    // Verify super admin permission via email header
-    const userEmail = request.headers.get("x-user-email");
-    if (!userEmail) {
-      return NextResponse.json(
-        { error: "Authentication required" },
-        { status: 401 },
-      );
-    }
-
-    const superAdmins = await serverFetchAllDataFromCollection<{
-      id: string;
-      email: string;
-    }>(TableNames.SUPER_ADMINS);
-    const isSuperAdmin = superAdmins.some(
-      (sa) => sa.email.toLowerCase() === userEmail.toLowerCase(),
-    );
-    if (!isSuperAdmin) {
-      return NextResponse.json(
-        { error: "Super admin permission required" },
-        { status: 403 },
-      );
-    }
+    // Verify super admin permission from the NextAuth session (server-derived,
+    // not a client-supplied header).
+    const auth = await requireSuperAdmin(tenant);
+    if ("error" in auth) return auth.error;
 
     const newSchema = await request.json();
 
     // Enforce tenant id consistency with URL param
     newSchema.tenantId = tenant;
+
+    // Validate before writing. `set()` is a destructive full overwrite and the
+    // stored document is re-coerced on every read, so a document that cannot be
+    // coerced would 500 every subsequent read and lock the tenant out. Reject it
+    // here (400) instead of persisting a tenant-bricking payload.
+    try {
+      coerceTenantSchema(newSchema, tenant);
+    } catch (validationError) {
+      return NextResponse.json(
+        {
+          error: `Invalid schema: ${
+            validationError instanceof Error
+              ? validationError.message
+              : String(validationError)
+          }`,
+        },
+        { status: 400 },
+      );
+    }
 
     // Backup current schema before overwriting
     const existingSchema = await serverGetDocumentById(

--- a/booking-app/app/api/tenantSchema/[tenant]/sync/route.ts
+++ b/booking-app/app/api/tenantSchema/[tenant]/sync/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { serverFetchAllDataFromCollection } from "@/lib/firebase/server/adminDb";
 import { TableNames } from "@/components/src/policy";
 import { isValidTenant } from "@/components/src/constants/tenants";
 import { computeDiffSummary } from "@/lib/utils/schemaDiff";
 import { getFirestoreForEnv, ENVIRONMENTS, type Environment } from "@/lib/firebase/server/multiDb";
+import { requireSuperAdmin } from "@/lib/api/requireSuperAdmin";
 
 const BACKUP_COLLECTION = "tenantSchemaBackup";
 
@@ -47,28 +47,10 @@ export async function POST(
       );
     }
 
-    // Verify super admin permission
-    const userEmail = request.headers.get("x-user-email");
-    if (!userEmail) {
-      return NextResponse.json(
-        { error: "Authentication required" },
-        { status: 401 },
-      );
-    }
-
-    const superAdmins = await serverFetchAllDataFromCollection<{
-      id: string;
-      email: string;
-    }>(TableNames.SUPER_ADMINS);
-    const isSuperAdmin = superAdmins.some(
-      (sa) => sa.email.toLowerCase() === userEmail.toLowerCase(),
-    );
-    if (!isSuperAdmin) {
-      return NextResponse.json(
-        { error: "Super admin permission required" },
-        { status: 403 },
-      );
-    }
+    // Verify super admin permission from the NextAuth session.
+    const auth = await requireSuperAdmin(tenant);
+    if ("error" in auth) return auth.error;
+    const userEmail = auth.session.email;
 
     // Fetch source schema
     const sourceDb = getFirestoreForEnv(sourceEnv);
@@ -139,11 +121,14 @@ export async function POST(
         );
     }
 
-    // Write source schema to target, enforcing tenant consistency
+    // Write source schema to target, enforcing tenant consistency. Use the
+    // `tenantId` field the rest of the app reads (coerceTenantSchema reads
+    // `raw.tenantId`); writing a stray top-level `tenant` string would clobber
+    // the structured `tenant` branding object on the next read.
     await targetDb
       .collection(TableNames.TENANT_SCHEMA)
       .doc(tenant)
-      .set({ ...sourceSchema, tenant }, { merge: false });
+      .set({ ...sourceSchema, tenantId: tenant }, { merge: false });
 
     return NextResponse.json({
       success: true,

--- a/booking-app/components/src/client/routes/components/SchemaDriftBanner.tsx
+++ b/booking-app/components/src/client/routes/components/SchemaDriftBanner.tsx
@@ -20,9 +20,7 @@ export default function SchemaDriftBanner() {
     if (!userEmail || !tenant) return;
 
     try {
-      const res = await fetch(`/api/tenantSchema/${tenant}/compare`, {
-        headers: { "x-user-email": userEmail },
-      });
+      const res = await fetch(`/api/tenantSchema/${tenant}/compare`);
       if (!res.ok) {
         setChangedCount(0);
         return;

--- a/booking-app/components/src/client/routes/super/schemaCompare.tsx
+++ b/booking-app/components/src/client/routes/super/schemaCompare.tsx
@@ -212,9 +212,7 @@ export default function SchemaCompare() {
       if (!userEmail) return;
       setLoading(true);
       try {
-        const res = await fetch(`/api/tenantSchema/${tenantId}/compare`, {
-          headers: { "x-user-email": userEmail },
-        });
+        const res = await fetch(`/api/tenantSchema/${tenantId}/compare`);
         if (!res.ok) throw new Error(`Failed to fetch: ${res.status}`);
         const data = await res.json();
         setSchemas(data);
@@ -238,7 +236,6 @@ export default function SchemaCompare() {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            "x-user-email": userEmail,
           },
           body: JSON.stringify({
             sourceEnv: leftEnv,

--- a/booking-app/components/src/client/routes/super/schemaEditor.tsx
+++ b/booking-app/components/src/client/routes/super/schemaEditor.tsx
@@ -1248,7 +1248,6 @@ export default function SchemaEditor() {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
-          "x-user-email": userEmail,
         },
         body: JSON.stringify(schema),
       });

--- a/booking-app/lib/api/requireSuperAdmin.ts
+++ b/booking-app/lib/api/requireSuperAdmin.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+
+import { PagePermission } from "@/components/src/types";
+import { resolveCallerRole } from "@/lib/api/authz";
+import { requireSession, type SessionContext } from "@/lib/api/requireSession";
+
+/**
+ * Server-side super-admin gate for API routes. Derives the caller identity from
+ * the verified NextAuth session (never from a client-supplied header) and checks
+ * it against the SUPER_ADMINS collection via resolveCallerRole.
+ *
+ * On success returns `{ session }` (with the verified caller email); otherwise
+ * returns `{ error }` with the NextResponse (401/403) the route should return.
+ * Usage:
+ *   const auth = await requireSuperAdmin(tenant);
+ *   if ("error" in auth) return auth.error;
+ *   // auth.session.email is the verified caller
+ */
+export async function requireSuperAdmin(
+  tenant?: string,
+): Promise<{ session: SessionContext } | { error: NextResponse }> {
+  const session = await requireSession();
+  if (!session) {
+    return {
+      error: NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 },
+      ),
+    };
+  }
+  const role = await resolveCallerRole(session, tenant);
+  if (role !== PagePermission.SUPER_ADMIN) {
+    return {
+      error: NextResponse.json(
+        { error: "Super admin permission required" },
+        { status: 403 },
+      ),
+    };
+  }
+  return { session };
+}

--- a/booking-app/tests/unit/api-tenant-schema.unit.test.ts
+++ b/booking-app/tests/unit/api-tenant-schema.unit.test.ts
@@ -1,19 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
 
 const mockServerGetDocumentById = vi.fn();
 const mockServerSaveDataToFirestoreWithId = vi.fn();
-const mockServerFetchAllDataFromCollection = vi.fn();
 const mockFirestoreSet = vi.fn();
 const mockFirestoreDoc = vi.fn(() => ({ set: mockFirestoreSet }));
 const mockFirestoreCollection = vi.fn(() => ({ doc: mockFirestoreDoc }));
+const mockRequireSession = vi.fn();
+const mockRequireSuperAdmin = vi.fn();
 
 vi.mock("@/lib/firebase/server/adminDb", () => ({
-  serverGetDocumentById: (...args: any[]) =>
-    mockServerGetDocumentById(...args),
+  serverGetDocumentById: (...args: any[]) => mockServerGetDocumentById(...args),
   serverSaveDataToFirestoreWithId: (...args: any[]) =>
     mockServerSaveDataToFirestoreWithId(...args),
-  serverFetchAllDataFromCollection: (...args: any[]) =>
-    mockServerFetchAllDataFromCollection(...args),
 }));
 
 vi.mock("@/lib/firebase/server/firebaseAdmin", () => ({
@@ -29,31 +28,31 @@ vi.mock("@/lib/utils/calendarEnvironment", () => ({
 }));
 
 vi.mock("@/components/src/constants/tenants", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@/components/src/constants/tenants")>();
+  const actual =
+    await importOriginal<typeof import("@/components/src/constants/tenants")>();
   return {
     ...actual,
-    isValidTenant: (tenant: string) => ["mc", "itp", "mediaCommons"].includes(tenant),
+    isValidTenant: (tenant: string) =>
+      ["mc", "itp", "mediaCommons"].includes(tenant),
   };
 });
 
-import { GET, PUT } from "@/app/api/tenantSchema/[tenant]/route";
-import { NextRequest } from "next/server";
+// Auth is now session-derived, not a client header.
+vi.mock("@/lib/api/requireSession", () => ({
+  requireSession: (...args: any[]) => mockRequireSession(...args),
+}));
+vi.mock("@/lib/api/requireSuperAdmin", () => ({
+  requireSuperAdmin: (...args: any[]) => mockRequireSuperAdmin(...args),
+}));
 
-const createRequest = (
-  method: string,
-  body?: any,
-  headers: Record<string, string> = {},
-) => {
-  const req = new NextRequest("http://localhost:3000/api/tenantSchema/mc", {
+import { GET, PUT } from "@/app/api/tenantSchema/[tenant]/route";
+
+const createRequest = (method: string, body?: any) =>
+  new NextRequest("http://localhost:3000/api/tenantSchema/mc", {
     method,
-    headers: new Headers({
-      "Content-Type": "application/json",
-      ...headers,
-    }),
+    headers: new Headers({ "Content-Type": "application/json" }),
     ...(body ? { body: JSON.stringify(body) } : {}),
   });
-  return req;
-};
 
 const params = Promise.resolve({ tenant: "mc" });
 
@@ -69,9 +68,24 @@ const mockSchema = {
   resources: [{ name: "Room 1", resourceId: "1" }],
 };
 
+const SUPER = { email: "admin@nyu.edu", netId: "admin" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Defaults: authenticated NYU user, super admin. Individual tests override.
+  mockRequireSession.mockResolvedValue(SUPER);
+  mockRequireSuperAdmin.mockResolvedValue({ session: SUPER });
+});
+
 describe("GET /api/tenantSchema/[tenant]", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireSession.mockResolvedValue(null);
+
+    const response = await GET(createRequest("GET"), { params });
+    const { data, status } = await parseJson(response);
+
+    expect(status).toBe(401);
+    expect(data.error).toBe("Authentication required");
   });
 
   it("returns schema when found", async () => {
@@ -99,14 +113,15 @@ describe("GET /api/tenantSchema/[tenant]", () => {
 });
 
 describe("PUT /api/tenantSchema/[tenant]", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("returns 401 when no x-user-email header", async () => {
-    const response = await PUT(createRequest("PUT", mockSchema), {
-      params,
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireSuperAdmin.mockResolvedValue({
+      error: NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 },
+      ),
     });
+
+    const response = await PUT(createRequest("PUT", mockSchema), { params });
     const { data, status } = await parseJson(response);
 
     expect(status).toBe(401);
@@ -114,56 +129,52 @@ describe("PUT /api/tenantSchema/[tenant]", () => {
   });
 
   it("returns 403 when user is not a super admin", async () => {
-    mockServerFetchAllDataFromCollection.mockResolvedValue([
-      { id: "1", email: "admin@nyu.edu" },
-    ]);
+    mockRequireSuperAdmin.mockResolvedValue({
+      error: NextResponse.json(
+        { error: "Super admin permission required" },
+        { status: 403 },
+      ),
+    });
 
-    const response = await PUT(
-      createRequest("PUT", mockSchema, {
-        "x-user-email": "notadmin@nyu.edu",
-      }),
-      { params },
-    );
+    const response = await PUT(createRequest("PUT", mockSchema), { params });
     const { data, status } = await parseJson(response);
 
     expect(status).toBe(403);
     expect(data.error).toBe("Super admin permission required");
   });
 
+  it("returns 400 when the body cannot be coerced (poison-save guard)", async () => {
+    const poison = { resources: [{ resourceId: "a,b" }] };
+
+    const response = await PUT(createRequest("PUT", poison), { params });
+    const { data, status } = await parseJson(response);
+
+    expect(status).toBe(400);
+    expect(data.error).toContain("Invalid schema");
+    // Must not have written anything.
+    expect(mockServerSaveDataToFirestoreWithId).not.toHaveBeenCalled();
+  });
+
   it("saves schema and creates backup for super admin", async () => {
-    mockServerFetchAllDataFromCollection.mockResolvedValue([
-      { id: "1", email: "admin@nyu.edu" },
-    ]);
     mockServerGetDocumentById.mockResolvedValue(mockSchema);
     mockFirestoreSet.mockResolvedValue(undefined);
     mockServerSaveDataToFirestoreWithId.mockResolvedValue(undefined);
 
     const updatedSchema = { ...mockSchema, name: "Updated Name" };
 
-    const response = await PUT(
-      createRequest("PUT", updatedSchema, {
-        "x-user-email": "admin@nyu.edu",
-      }),
-      { params },
-    );
+    const response = await PUT(createRequest("PUT", updatedSchema), { params });
     const { data, status } = await parseJson(response);
 
     expect(status).toBe(200);
     expect(data.success).toBe(true);
     expect(data.backupCreated).toBe(true);
 
-    // Verify backup was created
-    expect(mockFirestoreCollection).toHaveBeenCalledWith(
-      "tenantSchemaBackup",
-    );
+    expect(mockFirestoreCollection).toHaveBeenCalledWith("tenantSchemaBackup");
     expect(mockFirestoreDoc).toHaveBeenCalledWith(
       expect.stringContaining("mc-backup-ui-edit-"),
     );
-    expect(mockFirestoreSet).toHaveBeenCalledWith(mockSchema, {
-      merge: false,
-    });
+    expect(mockFirestoreSet).toHaveBeenCalledWith(mockSchema, { merge: false });
 
-    // Verify schema was saved (PUT enforces tenantId from URL)
     expect(mockServerSaveDataToFirestoreWithId).toHaveBeenCalledWith(
       "tenantSchema",
       "mc",
@@ -172,87 +183,47 @@ describe("PUT /api/tenantSchema/[tenant]", () => {
   });
 
   it("skips backup when no existing schema", async () => {
-    mockServerFetchAllDataFromCollection.mockResolvedValue([
-      { id: "1", email: "admin@nyu.edu" },
-    ]);
     mockServerGetDocumentById.mockResolvedValue(null);
     mockServerSaveDataToFirestoreWithId.mockResolvedValue(undefined);
 
-    const response = await PUT(
-      createRequest("PUT", mockSchema, {
-        "x-user-email": "admin@nyu.edu",
-      }),
-      { params },
-    );
+    const response = await PUT(createRequest("PUT", mockSchema), { params });
     const { data, status } = await parseJson(response);
 
     expect(status).toBe(200);
     expect(data.success).toBe(true);
     expect(data.backupCreated).toBe(false);
-
-    // Backup should NOT have been created
     expect(mockFirestoreCollection).not.toHaveBeenCalled();
-
-    // Schema should still be saved
     expect(mockServerSaveDataToFirestoreWithId).toHaveBeenCalled();
   });
 
   it("returns 400 for invalid tenant", async () => {
     const invalidParams = Promise.resolve({ tenant: "invalid_tenant" });
 
-    const response = await PUT(
-      createRequest("PUT", mockSchema, {
-        "x-user-email": "admin@nyu.edu",
-      }),
-      { params: invalidParams },
-    );
+    const response = await PUT(createRequest("PUT", mockSchema), {
+      params: invalidParams,
+    });
     const { data, status } = await parseJson(response);
 
     expect(status).toBe(400);
     expect(data.error).toContain("Invalid tenant");
   });
 
-  it("enforces tenant field from URL param", async () => {
-    mockServerFetchAllDataFromCollection.mockResolvedValue([
-      { id: "1", email: "admin@nyu.edu" },
-    ]);
+  it("enforces tenantId from URL param", async () => {
     mockServerGetDocumentById.mockResolvedValue(null);
     mockServerSaveDataToFirestoreWithId.mockResolvedValue(undefined);
 
     const schemaWithWrongTenantId = { ...mockSchema, tenantId: "wrong" };
 
-    const response = await PUT(
-      createRequest("PUT", schemaWithWrongTenantId, {
-        "x-user-email": "admin@nyu.edu",
-      }),
-      { params },
-    );
+    const response = await PUT(createRequest("PUT", schemaWithWrongTenantId), {
+      params,
+    });
     const { status } = await parseJson(response);
 
     expect(status).toBe(200);
-    // Verify the saved schema has tenantId = "mc" (from URL), not "wrong"
     expect(mockServerSaveDataToFirestoreWithId).toHaveBeenCalledWith(
       "tenantSchema",
       "mc",
       expect.objectContaining({ tenantId: "mc" }),
     );
-  });
-
-  it("email comparison is case-insensitive", async () => {
-    mockServerFetchAllDataFromCollection.mockResolvedValue([
-      { id: "1", email: "Admin@NYU.edu" },
-    ]);
-    mockServerGetDocumentById.mockResolvedValue(null);
-    mockServerSaveDataToFirestoreWithId.mockResolvedValue(undefined);
-
-    const response = await PUT(
-      createRequest("PUT", mockSchema, {
-        "x-user-email": "admin@nyu.edu",
-      }),
-      { params },
-    );
-    const { status } = await parseJson(response);
-
-    expect(status).toBe(200);
   });
 });

--- a/booking-app/tests/unit/schema-sync.unit.test.ts
+++ b/booking-app/tests/unit/schema-sync.unit.test.ts
@@ -1,5 +1,6 @@
 import { computeDiffSummary } from "@/lib/utils/schemaDiff";
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
 
 // ---------------------------------------------------------------------------
 // computeDiffSummary — pure function tests
@@ -118,14 +119,10 @@ vi.mock("@/lib/firebase/server/multiDb", () => ({
   ENVIRONMENTS: ["development", "staging", "production"],
 }));
 
-const mockServerFetch = vi.fn();
-vi.mock("@/lib/firebase/server/adminDb", () => ({
-  serverFetchAllDataFromCollection: (...args: unknown[]) =>
-    mockServerFetch(...args),
-}));
-
-vi.mock("@/lib/firebase/server/firebaseAdmin", () => ({
-  default: {},
+// Auth is now session-derived; mock the super-admin gate directly.
+const mockRequireSuperAdmin = vi.fn();
+vi.mock("@/lib/api/requireSuperAdmin", () => ({
+  requireSuperAdmin: (...args: unknown[]) => mockRequireSuperAdmin(...args),
 }));
 
 import { POST } from "@/app/api/tenantSchema/[tenant]/sync/route";
@@ -148,12 +145,20 @@ async function parseResponse(response: Response) {
 describe("POST /api/tenantSchema/[tenant]/sync", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockServerFetch.mockResolvedValue([
-      { id: "1", email: "admin@nyu.edu" },
-    ]);
+    // Default: authenticated super admin.
+    mockRequireSuperAdmin.mockResolvedValue({
+      session: { email: "admin@nyu.edu", netId: "admin" },
+    });
   });
 
-  it("returns 401 when x-user-email header is missing", async () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockRequireSuperAdmin.mockResolvedValue({
+      error: NextResponse.json(
+        { error: "Authentication required" },
+        { status: 401 },
+      ),
+    });
+
     const res = await POST(
       createRequest({ sourceEnv: "development", targetEnv: "production" }),
       createParams("itp"),
@@ -163,7 +168,12 @@ describe("POST /api/tenantSchema/[tenant]/sync", () => {
   });
 
   it("returns 403 when user is not a super admin", async () => {
-    mockServerFetch.mockResolvedValue([{ id: "1", email: "other@nyu.edu" }]);
+    mockRequireSuperAdmin.mockResolvedValue({
+      error: NextResponse.json(
+        { error: "Super admin permission required" },
+        { status: 403 },
+      ),
+    });
 
     const res = await POST(
       createRequest(


### PR DESCRIPTION
## Summary of Changes

The tenant-schema API had two compounding security holes:

1. **Auth was a client-supplied header.** `PUT` / `sync` / `compare` on `/api/tenantSchema/[tenant]` verified super-admin by reading `x-user-email` from the request headers — which the browser sets from its own context. There is no `middleware.ts`, so nothing overwrites it with a verified value. Any caller could send `x-user-email: <a known super-admin>` and pass the check. `GET` had no auth at all and leaked the full schema (Google calendar IDs, email templates, org mappings).
2. **Writes were verbatim and destructive.** `PUT` wrote the request body straight to Firestore via `set()` (no `{merge}`, no validation). A malformed body could not only overwrite a tenant's schema, but would then throw in `coerceTenantSchema` on **every subsequent read** → `GET` 500 → the editor can no longer open the schema to fix it → `/[tenant]` layout calls `notFound()` → the whole tenant site 404s. A one-request tenant DoS.

This PR closes both using primitives already in the codebase (`requireSession` + `resolveCallerRole`, the same model `/api/firestore/*` uses).

- **New `lib/api/requireSuperAdmin`**: derives the caller from the verified NextAuth session and checks `SUPER_ADMINS` via `resolveCallerRole` — never a header. Returns `{ session }` on success or `{ error }` (401/403).
- **`GET`**: require an authenticated NYU session (`anyNYU`-read, matching the rest of the app).
- **`PUT` / `sync` / `compare`**: replace the `x-user-email` check with `requireSuperAdmin`.
- **`PUT` validation**: run the body through `coerceTenantSchema` before writing; reject an un-coercible schema with **400** instead of persisting a tenant-bricking document.
- **`sync` fixes**: write `tenantId` (the field the app reads) instead of a stray top-level `tenant` string that clobbered the nested `tenant` branding object; use the session email for `syncedBy`. Added the `isValidTenant` guard to `compare`.
- **Client cleanup**: removed the now-unused `x-user-email` sends from `schemaEditor`, `schemaCompare`, and `SchemaDriftBanner` — same-origin requests carry the session cookie automatically.

## Schema Changes

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [ ] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

Tests: `api-tenant-schema` and `schema-sync` unit tests updated to the session-based auth (mocking `requireSession`/`requireSuperAdmin`), plus a new poison-save test asserting an un-coercible body returns 400 and writes nothing. `tsc --noEmit` and `next build` pass; the unit suite is green (two `BookingBlackoutPeriods` timeouts observed only under full-suite parallelism pass in isolation — unrelated to this change).

**Note for reviewers:** the super-admin gate now requires the caller to be logged in via NYU SSO (session cookie), so exercising `PUT`/`sync`/`compare` requires an authenticated super-admin session — the header shortcut no longer works.

## Screenshots / Video

No UI change; this is an API auth/validation change. Behavior is covered by the unit tests described above.
