### PR TITLE
fix(schema): align supportPA/supportLiaison/multipleResourceSelect defaults to schema

### DIFF
--- a/booking-app/components/src/client/routes/booking/components/SelectRooms.tsx
+++ b/booking-app/components/src/client/routes/booking/components/SelectRooms.tsx
@@ -33,8 +33,10 @@ export const SelectRooms = ({
   const { isBookingTimeInBlackout } = useBookingDateRestrictions();
   const { resources, calendarConfig } = useTenantSchema();
   const selectedIds = selected.map((room) => String(room.roomId));
+  // Fall back to the schema default (false) to match generateDefaultSchema;
+  // tenants that set the field explicitly are unaffected.
   const allowMultipleResourceSelect =
-    calendarConfig?.multipleResourceSelect ?? true;
+    calendarConfig?.multipleResourceSelect ?? false;
 
   // Sort rooms by room number for consistent display order
   const sortedRooms = useMemo(

--- a/booking-app/components/src/client/routes/components/navBar.tsx
+++ b/booking-app/components/src/client/routes/components/navBar.tsx
@@ -86,8 +86,11 @@ export default function NavBar() {
     tenantSchema?.tenant?.contextLabels ?? defaultContextLabels;
   const supportVIP = tenantSchema?.origins?.VIP ?? false;
   const supportWalkIn = tenantSchema?.origins?.walkIn ?? false;
-  const supportPA = tenantSchema?.supportPA ?? true;
-  const supportLiaison = tenantSchema?.supportLiaison ?? true;
+  // Fall back to the schema default (false) so an omitted/uncoerced value
+  // matches generateDefaultSchema — a stored `false` already reads as false, so
+  // this is a no-op for tenants that set the field explicitly.
+  const supportPA = tenantSchema?.supportPA ?? false;
+  const supportLiaison = tenantSchema?.supportLiaison ?? false;
   const showSetup = tenantSchema?.form?.services?.showSetup ?? true;
   const showEquipment = tenantSchema?.form?.services?.showEquipment ?? true;
   const showStaffing = tenantSchema?.form?.services?.showStaffing ?? true;


### PR DESCRIPTION
## Summary of Changes

`navBar` and `SelectRooms` fell back to `?? true` for three toggles whose `generateDefaultSchema` default is `false`:

- `supportPA` — `navBar.tsx` (`?? true`)
- `supportLiaison` — `navBar.tsx` (`?? true`)
- `calendarConfig.multipleResourceSelect` — `SelectRooms.tsx` (`?? true`)

This is a split-brain: the schema says these features are off by default, but the UI turns them on when the value is missing. It stays hidden as long as a tenant sets the fields explicitly, but an omitted (or uncoerced) value silently enables a feature the schema says is off.

This PR changes the fallbacks to `?? false` so the code default matches the schema's single source of truth.

**Impact:** verified no-op for existing tenants — the production `mc` and `itp` schema documents both set all three fields explicitly (a stored `true`/`false` already reads as-is; `??` only fires on `undefined`). The change only affects a document that omits the field, which now consistently reads as `false` on every path (coerced or not), matching `generateDefaultSchema`.

## Schema Changes

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [ ] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [ ] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

Tests: no new test — this is a one-value default alignment. Confirmed the existing `SelectRooms.multipleResourceSelect` and `schema-completeness` unit tests stay green, and verified against production schema values that existing tenants are unaffected. `tsc --noEmit` and `next build` pass.

## Screenshots / Video

No visible change for the current tenants (mc/itp set these explicitly). The change only alters the default for a tenant document that omits the field, which is not the case in production today.
