### PR TITLE
feat(schema): Zod tenant-schema as single source of truth (Phase 0, not wired)

### DIFF
--- a/booking-app/lib/tenant/tenantSchema.ts
+++ b/booking-app/lib/tenant/tenantSchema.ts
@@ -1,0 +1,326 @@
+// Single-source-of-truth tenant schema, expressed with Zod.
+//
+// The tenant schema's TYPE, DEFAULTS, and COERCION are currently maintained in
+// three separate hand-written places (`schemaTypes.ts`, `generateDefaultSchema`,
+// `coerceTenantSchema`) that drift. This module encodes all three once:
+//   - the type   → `z.infer<ReturnType<typeof makeTenantSchema>>`
+//   - defaults   → `makeTenantSchema(tenant).parse({})`
+//   - coercion   → `makeTenantSchema(tenant).parse(rawDoc)`
+//
+// Phase 0: this schema is introduced ALONGSIDE the existing code and asserted at
+// parity in tests. It is not yet wired into any read path.
+//
+// Zod 4 notes: `.default(v)` returns `v` without re-parsing, so nested objects
+// whose sub-defaults must cascade use `.prefault({})` (parse the empty object so
+// each field applies its own default). `z.looseObject` keeps unknown keys (the
+// DB may hold fields the code does not model yet), matching the `...raw` /
+// `...resource` passthrough in the current coerce.
+
+import { z } from "zod";
+
+import { defaultSafetyTrainingInfoUrl } from "@/components/src/constants/safetyTraining";
+
+// ── leaves ────────────────────────────────────────────────────────────────
+const HOUR_KEYS = [
+  "student",
+  "faculty",
+  "admin",
+  "studentWalkIn",
+  "facultyWalkIn",
+  "adminWalkIn",
+  "studentVIP",
+  "facultyVIP",
+  "adminVIP",
+] as const;
+
+const HourMap = z.object(
+  Object.fromEntries(HOUR_KEYS.map((k) => [k, z.number().default(-1)])),
+);
+
+const BaseRoleMap = z.object({
+  admin: z.number().default(-1),
+  faculty: z.number().default(-1),
+  student: z.number().default(-1),
+});
+
+const RequestLimits = z.object({
+  perDay: BaseRoleMap.prefault({}),
+  perWeek: BaseRoleMap.prefault({}),
+  perMonth: BaseRoleMap.prefault({}),
+  perSemester: BaseRoleMap.prefault({}),
+});
+
+const ResourceTraining = z.object({
+  required: z.boolean().default(false),
+  formId: z.string().default(""),
+  infoUrl: z.string().default(defaultSafetyTrainingInfoUrl),
+});
+
+const StaffingSection = z.object({
+  name: z.string().default(""),
+  indexes: z.array(z.number()).default([]),
+});
+
+const AutoApproval = z.object({
+  shouldAutoApprove: z.boolean().default(false),
+  minHour: BaseRoleMap.prefault({}),
+  maxHour: BaseRoleMap.prefault({}),
+  conditions: z
+    .object({
+      setup: z.boolean().default(false),
+      equipment: z.boolean().default(false),
+      staffing: z.boolean().default(false),
+      catering: z.boolean().default(false),
+      cleaning: z.boolean().default(false),
+      security: z.boolean().default(false),
+    })
+    .prefault({}),
+});
+
+// Legacy roomId→resourceId normalization + validation, matching coerceResource /
+// normalizeResourceId in lib/tenant/coerceTenantSchema.ts.
+function normalizeResourceId(value: unknown, field: string): string {
+  if (
+    (typeof value !== "string" && typeof value !== "number") ||
+    (typeof value === "number" && !Number.isFinite(value))
+  ) {
+    throw new Error(`${field} must be a string or finite number`);
+  }
+  const id = String(value);
+  if (!id.trim()) throw new Error(`${field} must be non-empty`);
+  if (id.includes(",")) throw new Error(`${field} must not contain commas`);
+  return id;
+}
+
+const Resource = z.preprocess((raw) => {
+  if (!raw || typeof raw !== "object") return raw;
+  const { roomId, resourceId, ...rest } = raw as Record<string, unknown>;
+  const canonical =
+    resourceId === undefined
+      ? normalizeResourceId(roomId, "resourceId")
+      : normalizeResourceId(resourceId, "resourceId");
+  if (
+    roomId !== undefined &&
+    normalizeResourceId(roomId, "roomId") !== canonical
+  ) {
+    throw new Error("resource has conflicting resourceId and roomId");
+  }
+  return { ...rest, resourceId: canonical };
+}, z.looseObject({
+  resourceId: z.string(),
+  capacity: z.number().default(0),
+  name: z.string().default(""),
+  isEquipment: z.boolean().default(false),
+  calendarId: z.string().default(""),
+  training: ResourceTraining.prefault({}),
+  isWalkIn: z.boolean().default(false),
+  isWalkInCanBookTwo: z.boolean().default(false),
+  services: z.array(z.string()).default([]),
+  requestLimits: RequestLimits.prefault({}),
+  autoApproval: AutoApproval.prefault({}),
+  maxHour: HourMap.prefault({}),
+  minHour: HourMap.prefault({}),
+  staffingServices: z.array(z.string()).default([]),
+  staffingSections: z.array(StaffingSection).default([]),
+  calendarIdProd: z.string().default(""),
+}));
+
+const Attestation = z.object({
+  id: z.string().default(""),
+  html: z.string().default(""),
+});
+
+const ContextLabels = z.object({
+  user: z.string().default("User"),
+  worker: z.string().default("PA"),
+  reviewer: z.string().default("Liaison"),
+  services: z.string().default("Services"),
+  admin: z.string().default("Admin"),
+});
+
+function contextLabelsFor(tenantId: string) {
+  return (tenantId || "").toLowerCase() === "itp"
+    ? {
+        user: "User",
+        worker: "ER",
+        reviewer: "1st Approver",
+        services: "Services",
+        admin: "Admin",
+      }
+    : {
+        user: "User",
+        worker: "PA",
+        reviewer: "Liaison",
+        services: "Services",
+        admin: "Admin",
+      };
+}
+
+const FormServices = z.object({
+  showCatering: z.boolean().default(true),
+  showEquipment: z.boolean().default(true),
+  showSecurity: z.boolean().default(true),
+  showSetup: z.boolean().default(true),
+  showStaffing: z.boolean().default(true),
+});
+
+const Form = z.object({
+  showBookingType: z.boolean().default(true),
+  showNNumber: z.boolean().default(true),
+  showSponsor: z.boolean().default(true),
+  services: FormServices.prefault({}),
+});
+
+const Mappings = z.object({
+  program: z.record(z.string(), z.array(z.string())).default({}),
+  role: z.record(z.string(), z.array(z.string())).default({}),
+  school: z.record(z.string(), z.array(z.string())).default({}),
+});
+
+const Origins = z.object({
+  VIP: z.boolean().default(false),
+  walkIn: z.boolean().default(false),
+});
+
+const EmailNotifications = z.object({
+  requestedUser: z.string().default(""),
+  requestedNeedsApproval: z.string().default(""),
+  reviewedNeedsApproval: z.string().default(""),
+  approvedWalkIn: z.string().default(""),
+  approvedVIP: z.string().default(""),
+  checkedOut: z.string().default(""),
+  checkedIn: z.string().default(""),
+  declined: z.string().default(""),
+  canceled: z.string().default(""),
+  canceledLate: z.string().default(""),
+  noShow: z.string().default(""),
+  closed: z.string().default(""),
+  approvedUser: z.string().default(""),
+});
+
+const TimeSensitiveRequestWarning = z.object({
+  hours: z.number().default(48),
+  isActive: z.boolean().default(false),
+  message: z.string().default(""),
+  policyLink: z.string().default(""),
+});
+
+const CalendarConfig = z.object({
+  startHour: z.record(z.string(), z.string()).default({
+    student: "09:00:00",
+    studentVIP: "06:00:00",
+    studentWalkIn: "09:00:00",
+    faculty: "09:00:00",
+    facultyVIP: "06:00:00",
+    facultyWalkIn: "09:00:00",
+    admin: "09:00:00",
+    adminVIP: "06:00:00",
+    adminWalkIn: "09:00:00",
+  }),
+  slotUnit: z.record(z.string(), z.number()).default({
+    student: 15,
+    studentVIP: 15,
+    studentWalkIn: 15,
+    faculty: 15,
+    facultyVIP: 15,
+    facultyWalkIn: 15,
+    admin: 15,
+    adminVIP: 15,
+    adminWalkIn: 15,
+  }),
+  multipleResourceSelect: z.boolean().default(false),
+  timeSensitiveRequestWarning: TimeSensitiveRequestWarning.prefault({}),
+});
+
+const CcEmailEnvs = z.object({
+  development: z.string().default(""),
+  staging: z.string().default(""),
+  production: z.string().default(""),
+});
+
+const AutoCancel = z.union([
+  z.literal(false),
+  z.object({
+    minutesPriorToStart: z.number(),
+    conditions: z.object({
+      requested: z.boolean(),
+      preApproved: z.boolean(),
+    }),
+  }),
+]);
+
+const Term = z.tuple([z.number(), z.number()]);
+
+/**
+ * Build the tenant-schema validator for a given tenant. The tenant id determines
+ * the per-tenant `contextLabels` default (itp uses ER / 1st Approver).
+ */
+export function makeTenantSchema(tenantId: string) {
+  const Tenant = z.object({
+    name: z.string().default(""),
+    logo: z.string().default(""),
+    nameForPolicy: z.string().default(""),
+    contextLabels: ContextLabels.prefault(contextLabelsFor(tenantId)),
+  });
+
+  const Doc = z.looseObject({
+    tenantId: z.string().default(tenantId),
+    tenant: Tenant.prefault({}),
+    policy: z.string().default(""),
+    mappings: Mappings.prefault({}),
+    roles: z.array(z.string()).default([]),
+    form: Form.prefault({}),
+    attestations: z.array(Attestation).default([]),
+    resources: z
+      .array(Resource)
+      .default([])
+      .superRefine((resources, ctx) => {
+        const seen = new Set<string>();
+        for (const r of resources as Array<{ resourceId: string }>) {
+          if (seen.has(r.resourceId)) {
+            ctx.addIssue({
+              code: "custom",
+              message: `resources has duplicate resourceId "${r.resourceId}"`,
+            });
+          }
+          seen.add(r.resourceId);
+        }
+      }),
+    origins: Origins.prefault({}),
+    training: z.object({ formId: z.string().default("") }).prefault({}),
+    supportPA: z.boolean().default(false),
+    supportLiaison: z.boolean().default(false),
+    resourceName: z.string().default(""),
+    declinedGracePeriod: z.number().default(24),
+    interimHighlightThresholdHours: z.number().default(18),
+    autoCancel: AutoCancel.default(false),
+    termConfig: z
+      .object({
+        fallTerm: Term.default([9, 12]),
+        springTerm: Term.default([1, 5]),
+        summerTerm: Term.default([6, 8]),
+      })
+      .prefault({}),
+    calendarConfig: CalendarConfig.prefault({}),
+    ccEmails: z
+      .object({
+        approved: CcEmailEnvs.prefault({}),
+        canceled: CcEmailEnvs.prefault({}),
+      })
+      .prefault({}),
+    emailNotifications: EmailNotifications.prefault({}),
+  });
+
+  // Override tenantId with the URL tenant (coerceTenantSchema does the same:
+  // `raw.tenantId || tenantSlug`, but we treat the URL as authoritative).
+  return z.preprocess((raw) => {
+    const r =
+      raw && typeof raw === "object"
+        ? { ...(raw as Record<string, unknown>) }
+        : {};
+    if (!r.tenantId) r.tenantId = tenantId;
+    return r;
+  }, Doc);
+}
+
+export type TenantSchema = z.infer<ReturnType<typeof makeTenantSchema>>;

--- a/booking-app/package-lock.json
+++ b/booking-app/package-lock.json
@@ -47,7 +47,8 @@
         "react-hook-form": "^7.52.0",
         "styled-components": "^6.1.12",
         "tailwind-datepicker-react": "^1.4.3",
-        "xstate": "^5.20.2"
+        "xstate": "^5.20.2",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.0",
@@ -16019,6 +16020,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/booking-app/package.json
+++ b/booking-app/package.json
@@ -63,7 +63,8 @@
     "react-hook-form": "^7.52.0",
     "styled-components": "^6.1.12",
     "tailwind-datepicker-react": "^1.4.3",
-    "xstate": "^5.20.2"
+    "xstate": "^5.20.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.0",

--- a/booking-app/tests/unit/tenantSchema.parity.unit.test.ts
+++ b/booking-app/tests/unit/tenantSchema.parity.unit.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { makeTenantSchema } from "@/lib/tenant/tenantSchema";
+import { generateDefaultSchema } from "@/components/src/client/routes/components/schemaTypes";
+import { coerceTenantSchema } from "@/lib/tenant/coerceTenantSchema";
+
+// JSON round-trip drops `undefined` and non-index array props (the legacy
+// `__defaults__` marker), normalizing both sides to what Firestore actually
+// stores / the app actually consumes.
+const norm = (v: unknown) => JSON.parse(JSON.stringify(v));
+
+describe("tenantSchema Zod parity — defaults", () => {
+  for (const tenant of ["mc", "itp"]) {
+    it(`parse({}) reproduces generateDefaultSchema(${tenant})`, () => {
+      expect(norm(makeTenantSchema(tenant).parse({}))).toEqual(
+        norm(generateDefaultSchema(tenant)),
+      );
+    });
+  }
+});
+
+describe("tenantSchema Zod parity — coercion", () => {
+  it("normalizes legacy roomId → resourceId like coerce", () => {
+    const raw = { resources: [{ roomId: 101, name: "One" }] };
+    const zod = norm(makeTenantSchema("mc").parse(raw));
+    const legacy = norm(coerceTenantSchema(raw, "mc"));
+    expect(zod.resources[0].resourceId).toBe("101");
+    expect(zod.resources[0]).not.toHaveProperty("roomId");
+    expect(legacy.resources[0].resourceId).toBe("101");
+  });
+
+  it("keeps unknown top-level keys (DB-ahead passthrough), like coerce", () => {
+    const raw = { futureField: "x" };
+    expect((makeTenantSchema("mc").parse(raw) as any).futureField).toBe("x");
+    expect((coerceTenantSchema(raw, "mc") as any).futureField).toBe("x");
+  });
+
+  it("fills omitted top-level objects the same way coerce does", () => {
+    const raw = { policy: "p" };
+    const zod = norm(makeTenantSchema("mc").parse(raw));
+    const legacy = norm(coerceTenantSchema(raw, "mc"));
+    expect(zod.emailNotifications).toEqual(legacy.emailNotifications);
+    expect(zod.origins).toEqual(legacy.origins);
+    expect(zod.form).toEqual(legacy.form);
+    expect(zod.calendarConfig).toEqual(legacy.calendarConfig);
+  });
+
+  it("defaults tenantId to the tenant arg when omitted, keeps it otherwise — like coerce", () => {
+    // Omitted → defaults to the tenant argument.
+    expect((makeTenantSchema("mc").parse({}) as any).tenantId).toBe("mc");
+    expect((coerceTenantSchema({}, "mc") as any).tenantId).toBe("mc");
+    // Present → both keep the stored value (URL override happens in the PUT
+    // route, not in coercion).
+    const raw = { tenantId: "wrong" };
+    expect((makeTenantSchema("mc").parse(raw) as any).tenantId).toBe("wrong");
+    expect((coerceTenantSchema(raw, "mc") as any).tenantId).toBe("wrong");
+  });
+});
+
+describe("tenantSchema Zod — validation matches coerce", () => {
+  const bad: Record<string, unknown>[] = [
+    { resources: [{ resourceId: "a,b" }] }, // comma
+    { resources: [{ resourceId: "" }] }, // empty
+    { resources: [{ resourceId: "a" }, { resourceId: "a" }] }, // duplicate
+    { resources: [{ resourceId: "a", roomId: "b" }] }, // conflict
+  ];
+  for (const raw of bad) {
+    it(`rejects ${JSON.stringify(raw.resources)}`, () => {
+      expect(() => makeTenantSchema("mc").parse(raw)).toThrow();
+      expect(() => coerceTenantSchema(raw, "mc")).toThrow();
+    });
+  }
+});
+
+describe("tenantSchema Zod — intended improvement over coerce", () => {
+  it("fills resource-level defaults that coerce leaves undefined", () => {
+    const raw = { resources: [{ resourceId: "a", name: "A" }] };
+    const zodR = (makeTenantSchema("mc").parse(raw) as any).resources[0];
+    const legacyR = (coerceTenantSchema(raw, "mc") as any).resources[0];
+
+    // Zod fills these from the schema defaults...
+    expect(zodR.isWalkIn).toBe(false);
+    expect(zodR.maxHour.student).toBe(-1);
+    expect(zodR.requestLimits.perDay.admin).toBe(-1);
+
+    // ...while today's coerce leaves them undefined (the drift this fixes).
+    expect(legacyR.isWalkIn).toBeUndefined();
+    expect(legacyR.maxHour).toBeUndefined();
+    expect(legacyR.requestLimits).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary of Changes

The tenant schema's **type**, **defaults**, and **coercion** are maintained in three separate hand-written places — `schemaTypes.ts` (`SchemaContextType`), `generateDefaultSchema`, and `lib/tenant/coerceTenantSchema.ts` — that have to agree but drift. A concrete example: `coerceResource` returns `{ ...resource, resourceId }` and never merges `defaultResource`, so a resource document that omits `maxHour` / `requestLimits` / `autoApproval` reads as `undefined` at runtime and every consumer null-guards.

This PR introduces **one Zod schema** (`lib/tenant/tenantSchema.ts`) that encodes all three at once:

- the **type** → `z.infer<ReturnType<typeof makeTenantSchema>>`
- the **defaults** → `makeTenantSchema(tenant).parse({})`
- the **coercion + validation** → `makeTenantSchema(tenant).parse(rawDoc)`

It is added **alongside** the existing code and is **not wired into any read path** — this change touches no runtime behavior. It is the foundation (and the safety net) for later routing schema reads through it.

A parity test (`tests/unit/tenantSchema.parity.unit.test.ts`) proves the Zod schema is equivalent to the current code:

- reproduces `generateDefaultSchema` **exactly** for `mc` and `itp`;
- matches `coerce`'s legacy `roomId → resourceId` normalization, DB-ahead passthrough of unknown keys, omitted-field defaulting, and `tenantId` handling;
- throws on the same invalid resources `coerce` rejects (comma / empty / duplicate / `roomId`-conflict);
- and additionally fills the resource-level defaults today's `coerce` leaves undefined — the drift this is meant to remove — asserted explicitly so the one intentional difference is documented.

Adds `zod ^4` (zero runtime dependencies).

## Schema Changes

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [ ] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

Tests: new parity suite (11 cases) plus the existing `coerce-tenant-schema` and `schema-completeness` unit tests, all green. `tsc --noEmit` and `next build` pass.

## Screenshots / Video

No UI or runtime change — this adds a validator module and its parity test; nothing calls it yet.
