### PR TITLE
ci: remove claude-review bootstrap fallback, fail closed

### DIFF
--- a/.github/scripts/submit_review.py
+++ b/.github/scripts/submit_review.py
@@ -77,11 +77,16 @@ def parse_commentable_lines(diff: str) -> dict[str, set[int]]:
 
 
 def post(repo: str, pr: str, payload: dict) -> tuple[int, str]:
-    proc = subprocess.run(
-        ["gh", "api", "--method", "POST",
-         f"/repos/{repo}/pulls/{pr}/reviews", "--input", "-"],
-        input=json.dumps(payload), capture_output=True, text=True,
-    )
+    # Review posting is advisory and must never crash the job — surface a
+    # missing/broken gh binary as a failed attempt, not an unhandled exception.
+    try:
+        proc = subprocess.run(
+            ["gh", "api", "--method", "POST",
+             f"/repos/{repo}/pulls/{pr}/reviews", "--input", "-"],
+            input=json.dumps(payload), capture_output=True, text=True,
+        )
+    except OSError as exc:
+        return 1, f"could not invoke gh: {exc}"
     return proc.returncode, (proc.stdout + proc.stderr).strip()
 
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -142,22 +142,15 @@ jobs:
           # unscoped Write could poison $GITHUB_ENV/$GITHUB_PATH, and a
           # shadowed `gh` on PATH or an injected GH_HOST would otherwise
           # redirect the hardcoded API call (token included) elsewhere.
+          # Fail closed: if the script cannot be read from the base ref for
+          # ANY reason (unresolvable ref, deleted script, transient git
+          # error), skip the submit rather than ever executing the PR's copy.
           BASE_REF="origin/${{ github.event.pull_request.base.ref }}"
-          if ! /usr/bin/git rev-parse --verify --quiet "$BASE_REF^{commit}" > /dev/null; then
-            echo "error: cannot resolve $BASE_REF; refusing to fall back to the PR's copy of submit_review.py"
+          if ! /usr/bin/git show "$BASE_REF:.github/scripts/submit_review.py" > /tmp/submit_review.py 2>/dev/null; then
+            echo "error: could not read submit_review.py from $BASE_REF; refusing to run the PR's copy"
             exit 1
           fi
-          if /usr/bin/git cat-file -e "$BASE_REF:.github/scripts/submit_review.py" 2>/dev/null; then
-            /usr/bin/git show "$BASE_REF:.github/scripts/submit_review.py" > /tmp/submit_review.py
-            SCRIPT=/tmp/submit_review.py
-          else
-            # Bootstrap-only: the base branch resolves but doesn't have the
-            # script yet (the PR introducing it). Any other git failure exits
-            # above instead of silently trusting the PR copy.
-            echo "bootstrap: submit_review.py not on $BASE_REF yet; using the PR's committed copy"
-            /usr/bin/git checkout HEAD -- .github/scripts/submit_review.py
-            SCRIPT=.github/scripts/submit_review.py
-          fi
+          SCRIPT=/tmp/submit_review.py
           if [ ! -f /tmp/review.json ]; then
             echo "No /tmp/review.json produced; nothing to submit."
             exit 0


### PR DESCRIPTION
## Summary of Changes

Follow-up to #1521. Removes the bootstrap fallback from the Claude review workflow's submit step, which was only needed while `submit_review.py` did not yet exist on `main` (i.e. for #1521 itself).

- `.github/workflows/claude-review.yml` — the submit step now fails closed: if the script cannot be read from the base ref for any reason (unresolvable ref, deleted script, transient git error), the submit is skipped instead of ever executing the PR's own committed copy with the write-scoped token. This addresses the High finding from the Claude review on #1521 (the fallback was permanent code that reopened the trust hole it was built to close).
- `.github/scripts/submit_review.py` — wraps the `gh` invocation in try/except so a missing or broken `gh` binary surfaces as a failed attempt instead of an unhandled exception; review posting is advisory and must never crash the job (Medium finding from the same review).

This PR is itself reviewed by the merged workflow, so the new fail-closed base-ref path is exercised live: the base ref (`main`) now contains `submit_review.py`, and the review posted on this PR demonstrates it.

## Schema Changes

- [x] No tenant schema changes

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally (YAML/Python syntax validated; the workflow path can only run on GitHub Actions — the Claude review posted on this PR is the live test of the changed path)
- [x] I added or updated unit tests (or explained why not in the PR description) — CI workflow only; no application code
- [x] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description) — no UI changes; see the Claude review posted on this PR
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video

No UI changes — the Claude review posted on this PR demonstrates the workflow end-to-end.
