### PR TITLE
Release: main → prod (2026-07-09)

### DIFF
--- a/.github/workflows/deploy_development_app_engine.yml
+++ b/.github/workflows/deploy_development_app_engine.yml
@@ -60,6 +60,9 @@ jobs:
           echo "NYU_API_USER_NAME=${{ secrets.NYU_API_USER_NAME }}" >> .env.production
           echo "NYU_API_PASSWORD=${{ secrets.NYU_API_PASSWORD }}" >> .env.production
           echo "NYU_API_ACCESS_ID=${{ secrets.NYU_API_ACCESS_ID }}" >> .env.production
+          echo "NYU_API_AUTH_PROVIDER=${{ vars.NYU_API_AUTH_PROVIDER }}" >> .env.production
+          echo "NYU_ENTRA_CLIENT_ID=${{ secrets.NYU_ENTRA_CLIENT_ID }}" >> .env.production
+          echo "NYU_ENTRA_CLIENT_SECRET=${{ secrets.NYU_ENTRA_CLIENT_SECRET }}" >> .env.production
           echo "OIDC_ISSUER=${{ vars.OIDC_ISSUER }}" >> .env.production
           echo "OIDC_CLIENT_ID=${{ vars.OIDC_CLIENT_ID }}" >> .env.production
           echo "OIDC_CLIENT_SECRET=${{ secrets.OIDC_CLIENT_SECRET }}" >> .env.production

--- a/.github/workflows/deploy_production_app_engine.yml
+++ b/.github/workflows/deploy_production_app_engine.yml
@@ -60,6 +60,9 @@ jobs:
           echo "NYU_API_USER_NAME=${{ secrets.NYU_API_USER_NAME }}" >> .env.production
           echo "NYU_API_PASSWORD=${{ secrets.NYU_API_PASSWORD }}" >> .env.production
           echo "NYU_API_ACCESS_ID=${{ secrets.NYU_API_ACCESS_ID }}" >> .env.production
+          echo "NYU_API_AUTH_PROVIDER=${{ vars.NYU_API_AUTH_PROVIDER }}" >> .env.production
+          echo "NYU_ENTRA_CLIENT_ID=${{ secrets.NYU_ENTRA_CLIENT_ID }}" >> .env.production
+          echo "NYU_ENTRA_CLIENT_SECRET=${{ secrets.NYU_ENTRA_CLIENT_SECRET }}" >> .env.production
           echo "OIDC_ISSUER=${{ vars.OIDC_ISSUER }}" >> .env.production
           echo "OIDC_CLIENT_ID=${{ vars.OIDC_CLIENT_ID }}" >> .env.production
           echo "OIDC_CLIENT_SECRET=${{ secrets.OIDC_CLIENT_SECRET }}" >> .env.production

--- a/.github/workflows/deploy_staging_app_engine.yml
+++ b/.github/workflows/deploy_staging_app_engine.yml
@@ -60,6 +60,9 @@ jobs:
           echo "NYU_API_USER_NAME=${{ secrets.NYU_API_USER_NAME }}" >> .env.production
           echo "NYU_API_PASSWORD=${{ secrets.NYU_API_PASSWORD }}" >> .env.production
           echo "NYU_API_ACCESS_ID=${{ secrets.NYU_API_ACCESS_ID }}" >> .env.production
+          echo "NYU_API_AUTH_PROVIDER=${{ vars.NYU_API_AUTH_PROVIDER }}" >> .env.production
+          echo "NYU_ENTRA_CLIENT_ID=${{ secrets.NYU_ENTRA_CLIENT_ID }}" >> .env.production
+          echo "NYU_ENTRA_CLIENT_SECRET=${{ secrets.NYU_ENTRA_CLIENT_SECRET }}" >> .env.production
           echo "OIDC_ISSUER=${{ vars.OIDC_ISSUER }}" >> .env.production
           echo "OIDC_CLIENT_ID=${{ vars.OIDC_CLIENT_ID }}" >> .env.production
           echo "OIDC_CLIENT_SECRET=${{ secrets.OIDC_CLIENT_SECRET }}" >> .env.production

--- a/booking-app/lib/server/nyuApiAuth.ts
+++ b/booking-app/lib/server/nyuApiAuth.ts
@@ -1,4 +1,21 @@
-const NYU_AUTH_URL = "https://auth.nyu.edu/oauth2/token";
+// NYU API OAuth token acquisition.
+//
+// NYU IT is migrating API auth from WSO2 to Microsoft Entra ID (WSO2 retires
+// July 31). Only the token endpoint changes; API base URLs stay the same.
+// Until our API's migration window, keep using WSO2. At cutover, set
+// NYU_API_AUTH_PROVIDER=entra (plus NYU_ENTRA_CLIENT_ID / NYU_ENTRA_CLIENT_SECRET)
+// and redeploy — no code change needed.
+
+const WSO2_AUTH_URL = "https://auth.nyu.edu/oauth2/token";
+// NYU's Entra tenant ID — constant. Verified against a live token request;
+// the value in the migration PDF (3eda674c-…) is a placeholder that returns
+// AADSTS700016. Overridable via env in case NYU IT publishes a different one.
+const ENTRA_TENANT_ID =
+  process.env.NYU_ENTRA_TENANT_ID || "665be5ef-3fc6-401b-b6c4-401a9d9c7b72";
+const ENTRA_AUTH_URL = `https://login.microsoftonline.com/${ENTRA_TENANT_ID}/oauth2/v2.0/token`;
+const ENTRA_SCOPE =
+  process.env.NYU_ENTRA_SCOPE || "https://graph.microsoft.com/.default";
+
 export const NYU_API_BASE = "https://api.nyu.edu/identity-v2-sys";
 
 // Cache the OAuth token in memory. Refresh 60s before actual expiry.
@@ -22,30 +39,56 @@ export async function getNYUToken(): Promise<string | null> {
   }
 }
 
-async function refreshNYUToken(): Promise<string | null> {
+function buildEntraTokenRequest(): { url: string; init: RequestInit } {
+  const clientId = process.env.NYU_ENTRA_CLIENT_ID;
+  const clientSecret = process.env.NYU_ENTRA_CLIENT_SECRET;
 
-  try {
-    const clientId = process.env.NYU_API_CLIENT_ID;
-    const clientSecret = process.env.NYU_API_CLIENT_SECRET;
-    const username = process.env.NYU_API_USER_NAME;
-    const password = process.env.NYU_API_PASSWORD;
+  if (!clientId || !clientSecret) {
+    throw new Error("NYU Entra ID credentials not configured");
+  }
 
-    if (!clientId || !clientSecret || !username || !password) {
-      throw new Error("NYU credentials not configured");
-    }
+  const params = new URLSearchParams({
+    grant_type: "client_credentials",
+    client_id: clientId,
+    client_secret: clientSecret,
+    scope: ENTRA_SCOPE,
+  });
 
-    const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
-      "base64",
-    );
+  return {
+    url: ENTRA_AUTH_URL,
+    init: {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      cache: "no-store",
+      body: params.toString(),
+    },
+  };
+}
 
-    const params = new URLSearchParams({
-      grant_type: "password",
-      username,
-      password,
-      scope: "openid",
-    });
+function buildWso2TokenRequest(): { url: string; init: RequestInit } {
+  const clientId = process.env.NYU_API_CLIENT_ID;
+  const clientSecret = process.env.NYU_API_CLIENT_SECRET;
+  const username = process.env.NYU_API_USER_NAME;
+  const password = process.env.NYU_API_PASSWORD;
 
-    const response = await fetch(NYU_AUTH_URL, {
+  if (!clientId || !clientSecret || !username || !password) {
+    throw new Error("NYU credentials not configured");
+  }
+
+  const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString(
+    "base64",
+  );
+
+  const params = new URLSearchParams({
+    grant_type: "password",
+    username,
+    password,
+    scope: "openid",
+  });
+
+  return {
+    url: WSO2_AUTH_URL,
+    init: {
       method: "POST",
       headers: {
         Authorization: `Basic ${basicAuth}`,
@@ -53,7 +96,18 @@ async function refreshNYUToken(): Promise<string | null> {
       },
       cache: "no-store",
       body: params.toString(),
-    });
+    },
+  };
+}
+
+async function refreshNYUToken(): Promise<string | null> {
+  try {
+    const { url, init } =
+      process.env.NYU_API_AUTH_PROVIDER === "entra"
+        ? buildEntraTokenRequest()
+        : buildWso2TokenRequest();
+
+    const response = await fetch(url, init);
 
     if (!response.ok) {
       console.log("Error response", response);

--- a/booking-app/tests/unit/nyuApiAuth.unit.test.ts
+++ b/booking-app/tests/unit/nyuApiAuth.unit.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const originalFetch = globalThis.fetch;
+const mockFetch = vi.fn();
+
+function tokenResponse(token = "test-token", expiresIn = 3600) {
+  return {
+    ok: true,
+    json: async () => ({ access_token: token, expires_in: expiresIn }),
+  };
+}
+
+// nyuApiAuth caches the token and reads env at module scope, so each test
+// re-imports a fresh module instance.
+async function importFreshModule() {
+  vi.resetModules();
+  return import("@/lib/server/nyuApiAuth");
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+  vi.stubEnv("NYU_API_CLIENT_ID", "wso2-client");
+  vi.stubEnv("NYU_API_CLIENT_SECRET", "wso2-secret");
+  vi.stubEnv("NYU_API_USER_NAME", "wso2-user");
+  vi.stubEnv("NYU_API_PASSWORD", "wso2-pass");
+  vi.stubEnv("NYU_API_AUTH_PROVIDER", "");
+  vi.stubEnv("NYU_ENTRA_CLIENT_ID", "");
+  vi.stubEnv("NYU_ENTRA_CLIENT_SECRET", "");
+  vi.stubEnv("NYU_ENTRA_TENANT_ID", "");
+  vi.stubEnv("NYU_ENTRA_SCOPE", "");
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.unstubAllEnvs();
+});
+
+describe("getNYUToken — WSO2 (default provider)", () => {
+  it("posts a password grant with Basic auth to auth.nyu.edu", async () => {
+    mockFetch.mockResolvedValueOnce(tokenResponse("wso2-token"));
+    const { getNYUToken } = await importFreshModule();
+
+    const token = await getNYUToken();
+
+    expect(token).toBe("wso2-token");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://auth.nyu.edu/oauth2/token");
+    expect(init.headers.Authorization).toBe(
+      `Basic ${Buffer.from("wso2-client:wso2-secret").toString("base64")}`,
+    );
+    const body = new URLSearchParams(init.body);
+    expect(body.get("grant_type")).toBe("password");
+    expect(body.get("username")).toBe("wso2-user");
+    expect(body.get("password")).toBe("wso2-pass");
+    expect(body.get("scope")).toBe("openid");
+  });
+
+  it("returns null when WSO2 credentials are missing", async () => {
+    vi.stubEnv("NYU_API_PASSWORD", "");
+    const { getNYUToken } = await importFreshModule();
+
+    expect(await getNYUToken()).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("getNYUToken — Entra ID provider", () => {
+  beforeEach(() => {
+    vi.stubEnv("NYU_API_AUTH_PROVIDER", "entra");
+    vi.stubEnv("NYU_ENTRA_CLIENT_ID", "entra-client");
+    vi.stubEnv("NYU_ENTRA_CLIENT_SECRET", "entra-secret");
+  });
+
+  it("posts a client_credentials grant to the Entra token endpoint", async () => {
+    mockFetch.mockResolvedValueOnce(tokenResponse("entra-token"));
+    const { getNYUToken } = await importFreshModule();
+
+    const token = await getNYUToken();
+
+    expect(token).toBe("entra-token");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe(
+      "https://login.microsoftonline.com/665be5ef-3fc6-401b-b6c4-401a9d9c7b72/oauth2/v2.0/token",
+    );
+    // Entra uses credentials in the body, not Basic auth
+    expect(init.headers.Authorization).toBeUndefined();
+    const body = new URLSearchParams(init.body);
+    expect(body.get("grant_type")).toBe("client_credentials");
+    expect(body.get("client_id")).toBe("entra-client");
+    expect(body.get("client_secret")).toBe("entra-secret");
+    expect(body.get("scope")).toBe("https://graph.microsoft.com/.default");
+    expect(body.get("username")).toBeNull();
+    expect(body.get("password")).toBeNull();
+  });
+
+  it("honors NYU_ENTRA_TENANT_ID and NYU_ENTRA_SCOPE overrides", async () => {
+    vi.stubEnv("NYU_ENTRA_TENANT_ID", "custom-tenant");
+    vi.stubEnv("NYU_ENTRA_SCOPE", "api://custom/.default");
+    mockFetch.mockResolvedValueOnce(tokenResponse());
+    const { getNYUToken } = await importFreshModule();
+
+    await getNYUToken();
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe(
+      "https://login.microsoftonline.com/custom-tenant/oauth2/v2.0/token",
+    );
+    expect(new URLSearchParams(init.body).get("scope")).toBe(
+      "api://custom/.default",
+    );
+  });
+
+  it("returns null when Entra credentials are missing", async () => {
+    vi.stubEnv("NYU_ENTRA_CLIENT_SECRET", "");
+    const { getNYUToken } = await importFreshModule();
+
+    expect(await getNYUToken()).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null on a non-OK token response", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+    const { getNYUToken } = await importFreshModule();
+
+    expect(await getNYUToken()).toBeNull();
+  });
+});
+
+describe("getNYUToken — caching", () => {
+  it("reuses the cached token until expiry", async () => {
+    mockFetch.mockResolvedValue(tokenResponse("cached-token"));
+    const { getNYUToken } = await importFreshModule();
+
+    expect(await getNYUToken()).toBe("cached-token");
+    expect(await getNYUToken()).toBe("cached-token");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("deduplicates concurrent refreshes", async () => {
+    mockFetch.mockResolvedValue(tokenResponse());
+    const { getNYUToken } = await importFreshModule();
+
+    await Promise.all([getNYUToken(), getNYUToken(), getNYUToken()]);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary of Changes

Ships #1502 (Entra ID `client_credentials` token mode for the NYU API) to production. This is the only change between `prod` and `main`.

**Why now:** NYU IT migrated `identity-v2-sys` to Entra ID during the July 8 migration window (3–5pm EDT). The API gateway now rejects WSO2 tokens with `400 "Token format is not valid."`, so production identity fetches have been failing on cache misses since 4:33pm EDT on July 8 (first affected users: efh257, jyl9645, nw2289). The 7-day Firestore identity cache is absorbing most of the impact, but coverage shrinks daily as entries expire.

**Configuration is already in place** (verified against the live API):

- Repo secrets `NYU_ENTRA_CLIENT_ID` / `NYU_ENTRA_CLIENT_SECRET` are set.
- Repo variable `NYU_API_AUTH_PROVIDER=entra` is set, so this deploy switches token acquisition to Entra.
- NYU granted our Entra client (`MuleSoft_Booking App_EID`) access to `identity-v2-sys` on July 8: a live Entra token now returns `200` with real identity data (`401`/`403` before the grant). The `api_access_id` query parameter is still required post-migration and the code already sends it.
- The WSO2 path remains the code default when `NYU_API_AUTH_PROVIDER` is unset, but WSO2 tokens are permanently rejected by the API, so the flag flip is what restores service.

## Schema Changes

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [x] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate

## Screenshots / Video

Backend-only change (NYU token endpoint); no UI. Verification against the live NYU API is described above; unit tests for both provider paths are in `tests/unit/nyuApiAuth.unit.test.ts` (see #1502).
