### PR TITLE
Fix booking submissions failing after drag-adjusting the time selection

### DIFF
--- a/booking-app/app/api/bookings/route.ts
+++ b/booking-app/app/api/bookings/route.ts
@@ -519,7 +519,27 @@ export async function POST(request: NextRequest) {
     },
   });
 
-  const hasOverlap = await checkOverlap(selectedRooms, bookingCalendarInfo);
+  let hasOverlap: boolean;
+  try {
+    hasOverlap = await checkOverlap(selectedRooms, bookingCalendarInfo);
+  } catch (err: any) {
+    console.error(
+      `🚨 OVERLAP CHECK FAILED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+      {
+        googleStatus: err?.response?.status ?? err?.code,
+        googleError: JSON.stringify(
+          err?.response?.data ?? err?.errors ?? err?.message,
+        ),
+        roomIds: selectedRooms?.map((r: any) => r.roomId),
+        startStr: bookingCalendarInfo?.startStr,
+        endStr: bookingCalendarInfo?.endStr,
+      },
+    );
+    return NextResponse.json(
+      { error: "Unable to verify room availability. Please try again." },
+      { status: 500 },
+    );
+  }
   if (hasOverlap) {
     return NextResponse.json(
       { error: "Time slot no longer available" },
@@ -820,10 +840,29 @@ export async function POST(request: NextRequest) {
       bookingCalendarInfo,
       description,
     );
-  } catch (err) {
+  } catch (err: any) {
+    console.error(
+      `🚨 CALENDAR EVENT CREATION FAILED [${tenant?.toUpperCase() || "UNKNOWN"}]:`,
+      {
+        googleStatus: err?.response?.status ?? err?.code,
+        googleError: JSON.stringify(
+          err?.response?.data ?? err?.errors ?? err?.message,
+        ),
+        roomIds: selectedRoomIds,
+        startStr: bookingCalendarInfo?.startStr,
+        endStr: bookingCalendarInfo?.endStr,
+        descriptionLength: description.length,
+      },
+    );
     console.error(err);
+    const googleMessage = err?.errors?.[0]?.message ?? err?.message;
     return NextResponse.json(
-      { result: "error", message: "ROOM CALENDAR ID NOT FOUND" },
+      {
+        result: "error",
+        message: googleMessage
+          ? `Failed to create calendar event: ${googleMessage}`
+          : "Failed to create calendar event",
+      },
       { status: 500 },
     );
   }

--- a/booking-app/app/api/bookings/route.ts
+++ b/booking-app/app/api/bookings/route.ts
@@ -1,3 +1,4 @@
+import { bookingCalendarStrToDate } from "@/components/src/client/utils/date";
 import { toFirebaseTimestampFromString } from "@/components/src/client/utils/serverDate";
 import {
   firstApproverEmails,
@@ -426,12 +427,22 @@ async function checkOverlap(
 ) {
   const calendar = await getCalendarClient();
 
+  // Google requires RFC3339 with mandatory offset for timeMin/timeMax;
+  // bookingCalendarStrToDate also absorbs offset-less strings from stale
+  // client bundles.
+  const timeMin = bookingCalendarStrToDate(
+    bookingCalendarInfo.startStr,
+  ).toISOString();
+  const timeMax = bookingCalendarStrToDate(
+    bookingCalendarInfo.endStr,
+  ).toISOString();
+
   // Check each selected room for overlaps
   for (const room of selectedRooms) {
     const events = await calendar.events.list({
       calendarId: room.calendarId,
-      timeMin: bookingCalendarInfo.startStr,
-      timeMax: bookingCalendarInfo.endStr,
+      timeMin,
+      timeMax,
       singleEvents: true,
     });
 
@@ -455,8 +466,8 @@ async function checkOverlap(
 
       const eventStart = new Date(event.start.dateTime || event.start.date);
       const eventEnd = new Date(event.end.dateTime || event.end.date);
-      const requestStart = new Date(bookingCalendarInfo.startStr);
-      const requestEnd = new Date(bookingCalendarInfo.endStr);
+      const requestStart = new Date(timeMin);
+      const requestEnd = new Date(timeMax);
       // log the event that overlaps and then return
       if (
         (eventStart >= requestStart && eventStart < requestEnd) ||

--- a/booking-app/app/api/bookings/route.ts
+++ b/booking-app/app/api/bookings/route.ts
@@ -271,8 +271,8 @@ async function handleBookingApprovalEmails(
     );
 
     // Format dates and times properly
-    const startDate = new Date(bookingCalendarInfo?.startStr);
-    const endDate = new Date(bookingCalendarInfo?.endStr);
+    const startDate = bookingCalendarStrToDate(bookingCalendarInfo?.startStr);
+    const endDate = bookingCalendarStrToDate(bookingCalendarInfo?.endStr);
 
     const emailPromises = recipients.map(recipient => {
       console.log(
@@ -815,8 +815,8 @@ export async function POST(request: NextRequest) {
   const selectedRoomIds = selectedRoomIdsArray.join(", ");
 
   // Build booking contents for description
-  const startDateObj = new Date(bookingCalendarInfo.startStr);
-  const endDateObj = new Date(bookingCalendarInfo.endStr);
+  const startDateObj = bookingCalendarStrToDate(bookingCalendarInfo.startStr);
+  const endDateObj = bookingCalendarStrToDate(bookingCalendarInfo.endStr);
 
   // Use display values for calendar description
   const dataWithDisplayValues = {

--- a/booking-app/components/src/client/utils/date.tsx
+++ b/booking-app/components/src/client/utils/date.tsx
@@ -1,14 +1,34 @@
 import { Timestamp } from "firebase/firestore";
 import { format } from "date-fns";
-import { formatInTimeZone, toZonedTime } from "date-fns-tz";
+import { formatInTimeZone, fromZonedTime, toZonedTime } from "date-fns-tz";
 import { DEFAULT_SLOT_UNIT } from "../routes/booking/utils/getSlotUnit";
 
 // All times in the booking app are displayed in Eastern Time
 export const TIMEZONE = "America/New_York";
 
-/** FullCalendar `startStr` / `endStr` format: Eastern local time without offset. */
+/**
+ * FullCalendar `startStr` / `endStr` format: Eastern local time WITH offset
+ * (e.g. "2026-07-15T10:00:00-04:00"). The offset is required — the server
+ * passes these strings to Google Calendar `events.list` (timeMin/timeMax must
+ * be RFC3339 with mandatory offset) and parses them with `new Date()` on a
+ * UTC host, so an offset-less string 400s the overlap check and shifts stored
+ * times by 4-5 hours.
+ */
 export const toBookingCalendarStr = (date: Date): string =>
-  formatInTimeZone(date, TIMEZONE, "yyyy-MM-dd'T'HH:mm:ss");
+  formatInTimeZone(date, TIMEZONE, "yyyy-MM-dd'T'HH:mm:ssXXX");
+
+const RFC3339_OFFSET_RE = /(Z|[+-]\d{2}:?\d{2})$/;
+
+/**
+ * Parse a booking calendar string to the instant it represents. Strings from
+ * clients running bundles older than this fix lack a timezone offset; those
+ * are Eastern wall times, so interpret them in TIMEZONE instead of letting
+ * `new Date()` read them in the host timezone (UTC on the server).
+ */
+export const bookingCalendarStrToDate = (dateStr: string): Date =>
+  RFC3339_OFFSET_RE.test(dateStr)
+    ? new Date(dateStr)
+    : fromZonedTime(dateStr, TIMEZONE);
 
 export const formatDate = (
   oldDate:

--- a/booking-app/components/src/client/utils/serverDate.ts
+++ b/booking-app/components/src/client/utils/serverDate.ts
@@ -1,7 +1,7 @@
 import { format, toZonedTime } from "date-fns-tz";
 import { Timestamp } from "firebase-admin/firestore";
 import { extractSecondsNanos } from "@/lib/utils/timestampWire";
-import { TIMEZONE } from "./date";
+import { bookingCalendarStrToDate, TIMEZONE } from "./date";
 
 type DateInput = Date | Timestamp | { [key: string]: any } | number | string;
 
@@ -65,7 +65,9 @@ export const toFirebaseTimestampFromString = (
   dateString: string,
 ): Timestamp => {
   try {
-    const date = new Date(dateString);
+    // Offset-less strings are Eastern wall times (stale booking clients);
+    // parsing them with `new Date()` on a UTC host would shift them 4-5h.
+    const date = bookingCalendarStrToDate(dateString);
     if (isNaN(date.getTime())) {
       throw new Error("Invalid date string");
     }

--- a/booking-app/components/src/server/calendars.ts
+++ b/booking-app/components/src/server/calendars.ts
@@ -1,3 +1,4 @@
+import { bookingCalendarStrToDate } from "@/components/src/client/utils/date";
 import { getCalendarClient } from "@/lib/googleClient";
 import { traceExternalCall } from "@/lib/newrelic-utils";
 import { BookingFormDetails, BookingStatusLabel } from "../types";
@@ -277,6 +278,12 @@ type InsertEventType = {
   endTime: string | number | Date;
   roomEmails: string[];
 };
+
+// Booking times arrive as client strings; offset-less ones are Eastern wall
+// times from stale bundles and must not be parsed in the host timezone.
+const toEventInstant = (time: string | number | Date): Date =>
+  typeof time === "string" ? bookingCalendarStrToDate(time) : new Date(time);
+
 export const insertEvent = async ({
   calendarId,
   title,
@@ -298,10 +305,10 @@ export const insertEvent = async ({
             summary: title,
             description,
             start: {
-              dateTime: new Date(startTime).toISOString(),
+              dateTime: toEventInstant(startTime).toISOString(),
             },
             end: {
-              dateTime: new Date(endTime).toISOString(),
+              dateTime: toEventInstant(endTime).toISOString(),
             },
             attendees: roomEmails.map((email: string) => ({ email })),
           },

--- a/booking-app/components/src/server/calendars.ts
+++ b/booking-app/components/src/server/calendars.ts
@@ -286,27 +286,45 @@ export const insertEvent = async ({
   roomEmails,
 }: InsertEventType) => {
   const calendar = await getCalendarClient();
-  const event = await traceExternalCall(
-    "GoogleCalendar",
-    "events.insert",
-    () =>
-      calendar.events.insert({
-        calendarId,
-        sendUpdates: "all", // Send notifications to all attendees when calendar event is created
-        requestBody: {
-          summary: title,
-          description,
-          start: {
-            dateTime: new Date(startTime).toISOString(),
+  try {
+    const event = await traceExternalCall(
+      "GoogleCalendar",
+      "events.insert",
+      () =>
+        calendar.events.insert({
+          calendarId,
+          sendUpdates: "all", // Send notifications to all attendees when calendar event is created
+          requestBody: {
+            summary: title,
+            description,
+            start: {
+              dateTime: new Date(startTime).toISOString(),
+            },
+            end: {
+              dateTime: new Date(endTime).toISOString(),
+            },
+            attendees: roomEmails.map((email: string) => ({ email })),
           },
-          end: {
-            dateTime: new Date(endTime).toISOString(),
-          },
-          attendees: roomEmails.map((email: string) => ({ email })),
-        },
-      }),
-  );
-  return event.data;
+        }),
+    );
+    return event.data;
+  } catch (error: any) {
+    // Log the raw inputs and the Google error body; the generic gaxios
+    // "Bad Request" message alone is not actionable when this fails in prod
+    console.error("🚨 GOOGLE CALENDAR EVENT INSERT FAILED:", {
+      calendarId,
+      rawStartTime: String(startTime),
+      rawEndTime: String(endTime),
+      roomEmails,
+      titleLength: title?.length ?? 0,
+      descriptionLength: description?.length ?? 0,
+      googleStatus: error?.response?.status ?? error?.code,
+      googleError: JSON.stringify(
+        error?.response?.data ?? error?.errors ?? error?.message,
+      ),
+    });
+    throw error;
+  }
 };
 
 export const updateCalendarEvent = async (

--- a/booking-app/tests/unit/date-utils.unit.test.tsx
+++ b/booking-app/tests/unit/date-utils.unit.test.tsx
@@ -1,21 +1,28 @@
 import { describe, expect, it } from "vitest";
 import {
+  bookingCalendarStrToDate,
   formatTimeAmPm,
   toBookingCalendarStr,
 } from "@/components/src/client/utils/date";
 
 describe("Date Utils", () => {
   describe("toBookingCalendarStr", () => {
-    it("formats 9:00 AM Eastern as local calendar string without UTC suffix", () => {
+    it("formats 9:00 AM Eastern as local calendar string with offset", () => {
       // 9:00 AM EDT on 2026-04-07 = 13:00 UTC
       const start = new Date("2026-04-07T13:00:00.000Z");
-      expect(toBookingCalendarStr(start)).toBe("2026-04-07T09:00:00");
+      expect(toBookingCalendarStr(start)).toBe("2026-04-07T09:00:00-04:00");
     });
 
-    it("formats 9:00 PM Eastern as local calendar string", () => {
+    it("formats 9:00 PM Eastern as local calendar string with offset", () => {
       // 9:00 PM EDT on 2026-04-07 = 01:00 UTC next day
       const end = new Date("2026-04-08T01:00:00.000Z");
-      expect(toBookingCalendarStr(end)).toBe("2026-04-07T21:00:00");
+      expect(toBookingCalendarStr(end)).toBe("2026-04-07T21:00:00-04:00");
+    });
+
+    it("uses the EST offset outside daylight saving time", () => {
+      // 9:00 AM EST on 2026-01-15 = 14:00 UTC
+      const start = new Date("2026-01-15T14:00:00.000Z");
+      expect(toBookingCalendarStr(start)).toBe("2026-01-15T09:00:00-05:00");
     });
 
     it("does not produce UTC ISO strings that shift start time on resize", () => {
@@ -29,6 +36,46 @@ describe("Date Utils", () => {
       expect(endStr).not.toContain("Z");
       expect(formatTimeAmPm(start)).toBe("9:00 AM");
       expect(formatTimeAmPm(end)).toBe("9:00 PM");
+    });
+
+    it("produces RFC3339 strings Google Calendar timeMin/timeMax accepts", () => {
+      const start = new Date("2026-04-07T13:00:00.000Z");
+      // RFC3339 requires a mandatory offset; offset-less strings 400 on
+      // events.list, which broke checkOverlap for drag-adjusted selections
+      expect(toBookingCalendarStr(start)).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/,
+      );
+    });
+  });
+
+  describe("bookingCalendarStrToDate", () => {
+    it("round-trips with toBookingCalendarStr", () => {
+      const start = new Date("2026-04-07T13:00:00.000Z");
+      const parsed = bookingCalendarStrToDate(toBookingCalendarStr(start));
+      expect(parsed.getTime()).toBe(start.getTime());
+    });
+
+    it("parses offset strings as the instant they denote", () => {
+      expect(
+        bookingCalendarStrToDate("2026-04-07T09:00:00-04:00").toISOString(),
+      ).toBe("2026-04-07T13:00:00.000Z");
+    });
+
+    it("parses UTC (Z) strings as-is", () => {
+      expect(
+        bookingCalendarStrToDate("2026-04-07T13:00:00.000Z").toISOString(),
+      ).toBe("2026-04-07T13:00:00.000Z");
+    });
+
+    it("interprets offset-less strings from stale clients as Eastern time", () => {
+      // Regardless of the host timezone (UTC in prod), a bare local string
+      // must be read as Eastern wall time
+      expect(
+        bookingCalendarStrToDate("2026-04-07T09:00:00").toISOString(),
+      ).toBe("2026-04-07T13:00:00.000Z");
+      expect(
+        bookingCalendarStrToDate("2026-01-15T09:00:00").toISOString(),
+      ).toBe("2026-01-15T14:00:00.000Z");
     });
   });
 

--- a/booking-app/tests/unit/server-calendars.unit.test.ts
+++ b/booking-app/tests/unit/server-calendars.unit.test.ts
@@ -109,6 +109,55 @@ describe("server/calendars", () => {
     });
   });
 
+  it("insertEvent logs the Google error body and rethrows on failure", async () => {
+    const googleError = Object.assign(new Error("Bad Request"), {
+      code: 400,
+      response: {
+        status: 400,
+        data: {
+          error: {
+            errors: [{ reason: "invalid", message: "Invalid attendee email." }],
+          },
+        },
+      },
+    });
+    const insertMock = vi.fn().mockRejectedValue(googleError);
+    mockGetCalendarClient.mockResolvedValue({
+      events: {
+        insert: insertMock,
+      },
+    });
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const { insertEvent } = await import("@/components/src/server/calendars");
+
+    await expect(
+      insertEvent({
+        calendarId: "cal-1",
+        title: "[REQUESTED] 222 Demo",
+        description: "<p>demo</p>",
+        startTime: "2026-07-16T12:00:00-04:00",
+        endTime: "2026-07-16T16:00:00-04:00",
+        roomEmails: ["room-cal-2"],
+      }),
+    ).rejects.toThrow("Bad Request");
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "🚨 GOOGLE CALENDAR EVENT INSERT FAILED:",
+      expect.objectContaining({
+        calendarId: "cal-1",
+        rawStartTime: "2026-07-16T12:00:00-04:00",
+        rawEndTime: "2026-07-16T16:00:00-04:00",
+        roomEmails: ["room-cal-2"],
+        googleStatus: 400,
+        googleError: expect.stringContaining("Invalid attendee email."),
+      }),
+    );
+    consoleErrorSpy.mockRestore();
+  });
+
   it("bookingContentsToDescription formats booking details", async () => {
     const bookingContents = {
       requestNumber: "42",


### PR DESCRIPTION
## Summary of Changes

Booking submissions have been failing intermittently in production since the 7/8 deploy with a 500 and the client message "Sorry, an error occurred while submitting this request" (Beth Rosenberg's failed 1201 requests, Noah's replication, Mimi's failed re-booking, and several ITP submissions — 20 occurrences in the logs between 7/8 and 7/14, zero in the 30 days before).

**Root cause:** `toBookingCalendarStr` (introduced in #1511) formats booking start/end times as Eastern local strings **without a timezone offset** (`2026-07-15T10:00:00`). These strings are produced only when a user drag-adjusts (resizes/moves) their selected time block (`handleEventEdit`) or loads an existing booking for editing (`useExistingBooking`) — which is why the failures looked intermittent and user/room-independent. `POST /api/bookings` passes the strings straight to Google Calendar `events.list` as `timeMin`/`timeMax`, which require RFC3339 with a mandatory offset, so Google rejects the availability check with a generic `400 Bad Request` and the route 500s before anything is saved. Verified directly against the Calendar API: an offset-less `timeMin` reproduces the exact production error signature (`errors: [{reason: "badRequest"}]`), while offset'd strings return 200.

**Fixes:**

- `toBookingCalendarStr` now emits the RFC3339 offset (`2026-07-15T10:00:00-04:00`), preserving #1511's intent (Eastern wall time on resize/drag) while producing a format Google accepts.
- New `bookingCalendarStrToDate` parses booking time strings back to instants, interpreting offset-less strings (from stale client bundles cached before this deploy) as Eastern time instead of host-local/UTC. Applied in `checkOverlap` (`timeMin`/`timeMax`), `insertEvent`, and `toFirebaseTimestampFromString` — the latter two also protect the modification/edit/bookingsDirect routes, which skip `checkOverlap` and would otherwise silently store times shifted by 4–5 hours when given an offset-less string.
- Error visibility: `checkOverlap` failures now return a clear 500 with the Google error body logged instead of an unhandled error, and calendar-creation failures no longer return the misleading `ROOM CALENDAR ID NOT FOUND` message.

**Testing:**

- Unit: updated/added tests for `toBookingCalendarStr` (offset present, EDT/EST) and `bookingCalendarStrToDate` (round-trip, offset/Z passthrough, offset-less → Eastern). Full unit suite passes; the one failure (`server-admin` date formatting) is a pre-existing host-timezone-dependent failure that also fails on this branch's base without these changes.
- Manual (local dev, MC tenant): selected a time block for 1201 Seminar Room, drag-resized it, and submitted → `POST /api/bookings` returned 200 and the booking was created. The server log confirms the drag-adjusted selection now sends `start: '2026-07-15T14:00:00-04:00'` and the overlap check passes. Before this fix, the same flow fails at the overlap check with the production 400 signature.
- `tsc --noEmit` and `next build` pass.

## Schema Changes

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [x] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description) — no UI changes; behavior is verified via the API responses and server logs described above
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [ ] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [x] I requested a code review from at least one other teammate

## Screenshots / Video
<img width="1568" height="758" alt="booking-drag-resize-tz-fix-demo" src="https://github.com/user-attachments/assets/ea70c70a-e58f-4807-a523-c8912d58befb" />

