### PR TITLE
fix: show maintenance mode on blocked booking submit

### DIFF
--- a/booking-app/components/src/client/routes/booking/hooks/useSubmitBooking.tsx
+++ b/booking-app/components/src/client/routes/booking/hooks/useSubmitBooking.tsx
@@ -24,6 +24,7 @@ export default function useSubmitBooking(formContext: FormContextLevel) {
     reloadFutureBookings,
     pagePermission,
     roomSettings,
+    showMaintenanceMode,
   } = useContext(DatabaseContext);
   const {
     bookingCalendarInfo,
@@ -292,13 +293,24 @@ export default function useSubmitBooking(formContext: FormContextLevel) {
             // Handle other error status codes
             let errorMessage =
               "Sorry, an error occurred while submitting this request";
+            let maintenanceMode = false;
             try {
-              const errorData = await res.json();
-              if (errorData.error || errorData.message) {
-                errorMessage = errorData.error || errorData.message;
+              const errorData = (await res.json()) as {
+                error?: string;
+                message?: string;
+                maintenanceMode?: boolean;
+              };
+              const serverMessage = errorData.error ?? errorData.message;
+              if (serverMessage) {
+                errorMessage = serverMessage;
               }
+              maintenanceMode = errorData.maintenanceMode === true;
             } catch (e) {
               // If response is not JSON, use default message
+            }
+            if (maintenanceMode) {
+              showMaintenanceMode(errorMessage);
+              return;
             }
             setError(new Error(errorMessage));
             setSubmitting("error");
@@ -329,6 +341,7 @@ export default function useSubmitBooking(formContext: FormContextLevel) {
       userEmail,
       router,
       reloadFutureBookings,
+      showMaintenanceMode,
       department,
       role,
     ],

--- a/booking-app/components/src/client/routes/booking/hooks/useSubmitBooking.tsx
+++ b/booking-app/components/src/client/routes/booking/hooks/useSubmitBooking.tsx
@@ -293,7 +293,8 @@ export default function useSubmitBooking(formContext: FormContextLevel) {
             // Handle other error status codes
             let errorMessage =
               "Sorry, an error occurred while submitting this request";
-            let maintenanceMode = false;
+            let maintenanceMode = res.status === 503;
+            let maintenanceMessage = "";
             try {
               const errorData = (await res.json()) as {
                 error?: string;
@@ -303,13 +304,15 @@ export default function useSubmitBooking(formContext: FormContextLevel) {
               const serverMessage = errorData.error ?? errorData.message;
               if (serverMessage) {
                 errorMessage = serverMessage;
+                maintenanceMessage = serverMessage;
               }
-              maintenanceMode = errorData.maintenanceMode === true;
+              maintenanceMode =
+                maintenanceMode || errorData.maintenanceMode === true;
             } catch (e) {
               // If response is not JSON, use default message
             }
             if (maintenanceMode) {
-              showMaintenanceMode(errorMessage);
+              showMaintenanceMode(maintenanceMessage);
               return;
             }
             setError(new Error(errorMessage));

--- a/booking-app/components/src/client/routes/components/Provider.tsx
+++ b/booking-app/components/src/client/routes/components/Provider.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/lib/firebase/firebase";
 import {
   DEFAULT_MAINTENANCE_MODE_SETTINGS,
+  MAINTENANCE_MODE_MESSAGE_MAX_LEN,
   type MaintenanceModeSettings,
 } from "@/lib/utils/maintenanceMode";
 import { DEFAULT_SITE_BANNER_COLOR_HEX } from "@/lib/utils/siteBannerHex";
@@ -804,7 +805,8 @@ export const DatabaseProvider = ({
           setMaintenanceMode({
             enabled: true,
             message:
-              message.trim() || DEFAULT_MAINTENANCE_MODE_SETTINGS.message,
+              message.slice(0, MAINTENANCE_MODE_MESSAGE_MAX_LEN).trim() ||
+              DEFAULT_MAINTENANCE_MODE_SETTINGS.message,
           }),
         setUserEmail,
         fetchAllBookings: fetchBookings,

--- a/booking-app/components/src/client/routes/components/Provider.tsx
+++ b/booking-app/components/src/client/routes/components/Provider.tsx
@@ -90,6 +90,7 @@ export interface DatabaseContextType {
     rooms?: Array<{ roomId: string; trainingFormUrl?: string }>,
   ) => Promise<void>;
   reloadPolicySettings: () => Promise<void>;
+  showMaintenanceMode: (message: string) => void;
   setUserEmail: (x: string) => void;
   fetchAllBookings: (clicked: boolean) => Promise<void>;
   updateBookingInList: (
@@ -143,6 +144,7 @@ export const DatabaseContext = createContext<DatabaseContextType>({
   reloadBookingTypes: async () => {},
   reloadSafetyTrainedUsers: async () => {},
   reloadPolicySettings: async () => {},
+  showMaintenanceMode: () => {},
   setUserEmail: (x: string) => {},
   fetchAllBookings: async () => {},
   updateBookingInList: () => {},
@@ -798,6 +800,12 @@ export const DatabaseProvider = ({
         reloadBookingTypes: fetchBookingTypes,
         reloadSafetyTrainedUsers: fetchSafetyTrainedUsers,
         reloadPolicySettings: fetchPolicySettings,
+        showMaintenanceMode: (message: string) =>
+          setMaintenanceMode({
+            enabled: true,
+            message:
+              message.trim() || DEFAULT_MAINTENANCE_MODE_SETTINGS.message,
+          }),
         setUserEmail,
         fetchAllBookings: fetchBookings,
         updateBookingInList,


### PR DESCRIPTION
## Summary of Changes

<!-- Briefly describe what was changed and why -->

Instead of letting users go all the way to submitting the form and showing the generic submission error, the client recognizes the maintenance-specific 503, updates shared app state, and the global gate immediately replaces the form with the configured maintenance notice.

https://github.com/ITPNYU/booking-app/issues/1255

## Schema Changes

<!-- Required for every PR. Pick exactly one. -->

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

<!-- If schema changed, list affected tenants and what changed.
Example:
- mc: added `showCleaning` flag
- itp: added new resource (resourceId "999")
-->

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [x] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [x] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [x] I requested a code review from at least one other teammate

## Screenshots / Video

https://github.com/user-attachments/assets/c65c989a-630b-4fd2-b721-cd55a20f7bd0



