### PR TITLE
feat: add per-resource service approvers UI

### DIFF
--- a/booking-app/components/src/client/routes/admin/components/ResourceSpecific.tsx
+++ b/booking-app/components/src/client/routes/admin/components/ResourceSpecific.tsx
@@ -1,74 +1,124 @@
 import { AddCircleOutline } from "@mui/icons-material";
-import { Box, IconButton, TextField, Typography } from "@mui/material";
+import {
+  Box,
+  IconButton,
+  MenuItem,
+  TextField,
+  Typography,
+} from "@mui/material";
 import Grid from "@mui/material/Unstable_Grid2/Grid2";
 import { Timestamp } from "firebase/firestore";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import {
   clientAddResourceApprover,
+  clientAddServiceApprover,
   clientListResourceApprovers,
+  clientListServiceApprovers,
   clientRemoveResourceApprover,
+  clientRemoveServiceApprover,
 } from "@/lib/firebase/firebase";
-import { useTenantSchema } from "../../components/SchemaProvider";
 import ListTable from "../../components/ListTable";
+import { useTenantSchema } from "../../components/SchemaProvider";
 import { formatDate } from "../../../utils/date";
 import { TableNames } from "../../../../policy";
 
-type ResourceApprover = {
+type ResourceApproverRow = {
   id: string;
-  resourceId: string;
   email: string;
   createdAt?: Timestamp;
 };
 
+type ResourceApprover = ResourceApproverRow & {
+  resourceId: string;
+};
+
+type ServiceApproverRow = {
+  id: string;
+  service: string;
+  email: string;
+  createdAt?: Timestamp;
+};
+
+type ServiceApprover = ServiceApproverRow & {
+  resourceId: string;
+};
+
+const SERVICE_LABELS: Record<string, string> = {
+  setup: "Setup",
+  equipment: "Equipment",
+  staff: "Staffing",
+  catering: "Catering",
+  cleaning: "Cleanup",
+  security: "Security",
+};
+
+const SERVICE_ALIASES: Record<string, string> = {
+  staffing: "staff",
+  cleanup: "cleaning",
+};
+
+const normalizeServiceKey = (service: string): string =>
+  SERVICE_ALIASES[service.trim().toLowerCase()] ?? service.trim().toLowerCase();
+
 const normalizeEmail = (email: string) => email.trim().toLowerCase();
 
-type ResourceApproverSectionProps = {
+const validateNyuEmail = async (
+  email: string,
+  tenantId: string,
+): Promise<boolean> => {
+  const match = email.match(/^([a-z0-9._-]+)@nyu\.edu$/i);
+  if (!match) return false;
+  const response = await fetch(
+    `/api/nyu/identity/${encodeURIComponent(match[1])}`,
+    { headers: { "x-tenant": tenantId } },
+  );
+  return response.ok;
+};
+
+type ResourceApproverTableProps = {
   resourceId: string;
-  approvers: ResourceApprover[];
+  rows: ResourceApproverRow[];
   rowsRefresh: () => Promise<void>;
 };
 
-const ResourceApproverSection = ({
+const ResourceApproverTable = ({
   resourceId,
-  approvers,
+  rows,
   rowsRefresh,
-}: ResourceApproverSectionProps) => {
+}: ResourceApproverTableProps) => {
   const { tenantId } = useTenantSchema();
+  const [loading, setLoading] = useState(false);
   const [valueToAdd, setValueToAdd] = useState("");
 
-  const addApprover = async () => {
+  const addResourceApprover = useCallback(async () => {
     const normalizedEmail = normalizeEmail(valueToAdd);
     if (!normalizedEmail) {
       return;
     }
 
-    if (approvers.some((approver) => approver.email === normalizedEmail)) {
+    const duplicate = rows.some(
+      (record) => normalizeEmail(record.email) === normalizedEmail,
+    );
+    if (duplicate) {
       alert("This user is already a resource approver.");
       return;
     }
 
+    setLoading(true);
     try {
       await clientAddResourceApprover(resourceId, normalizedEmail, tenantId);
       setValueToAdd("");
       await rowsRefresh();
-    } catch (addError) {
-      console.error("Failed to add resource approver:", addError);
+    } catch (error) {
+      console.error("Failed to add resource approver:", error);
       alert("Failed to add resource approver.");
+    } finally {
+      setLoading(false);
     }
-  };
+  }, [resourceId, rows, rowsRefresh, tenantId, valueToAdd]);
 
-  const rows = useMemo(
-    () =>
-      approvers.map(({ id, email, createdAt }) => ({
-        id,
-        email,
-        createdAt,
-      })),
-    [approvers],
-  );
-
-  const removeApprover = useCallback(
+  const removeResourceApprover = useCallback(
     async (row: { [key: string]: string }) => {
       await clientRemoveResourceApprover(resourceId, row.email, tenantId);
     },
@@ -97,7 +147,7 @@ const ResourceApproverSection = ({
             onKeyDown={(event) => {
               if (event.key === "Enter") {
                 event.preventDefault();
-                void addApprover();
+                void addResourceApprover();
               }
             }}
             value={valueToAdd}
@@ -106,10 +156,10 @@ const ResourceApproverSection = ({
           />
         </Grid>
         <IconButton
-          onClick={() => void addApprover()}
+          onClick={() => void addResourceApprover()}
           color="primary"
           sx={{ padding: 0 }}
-          disabled={!valueToAdd.trim()}
+          disabled={loading || !valueToAdd.trim()}
           aria-label={`Add resource approver for ${resourceId}`}
         >
           <AddCircleOutline />
@@ -125,7 +175,162 @@ const ResourceApproverSection = ({
       rows={rows as unknown as { [key: string]: string }[]}
       rowsRefresh={rowsRefresh}
       topRow={topRow}
-      onRemoveRow={removeApprover}
+      onRemoveRow={removeResourceApprover}
+      columnFormatters={{ createdAt: formatDate }}
+    />
+  );
+};
+
+type ServiceApproverTableProps = {
+  resourceId: string;
+  serviceOptions: Array<{ key: string; label: string }>;
+  rows: ServiceApproverRow[];
+  rowsRefresh: () => Promise<void>;
+};
+
+const ServiceApproverTable = ({
+  resourceId,
+  serviceOptions,
+  rows,
+  rowsRefresh,
+}: ServiceApproverTableProps) => {
+  const { tenantId } = useTenantSchema();
+  const [loading, setLoading] = useState(false);
+  const [serviceToAdd, setServiceToAdd] = useState<string>(
+    serviceOptions[0]?.key ?? "",
+  );
+  const [valueToAdd, setValueToAdd] = useState("");
+
+  useEffect(() => {
+    if (!serviceOptions.some((service) => service.key === serviceToAdd)) {
+      setServiceToAdd(serviceOptions[0]?.key ?? "");
+    }
+  }, [serviceOptions, serviceToAdd]);
+
+  const addServiceApprover = useCallback(async () => {
+    const normalizedEmail = normalizeEmail(valueToAdd);
+    if (!normalizedEmail || !serviceToAdd) {
+      return;
+    }
+
+    const duplicate = rows.some(
+      (record) =>
+        record.service === serviceToAdd &&
+        normalizeEmail(record.email) === normalizedEmail,
+    );
+    if (duplicate) {
+      alert("This user has already been added");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const isValidEmail = await validateNyuEmail(normalizedEmail, tenantId);
+      if (!isValidEmail) {
+        alert("Enter a valid NYU NetID email.");
+        return;
+      }
+      await clientAddServiceApprover(
+        resourceId,
+        serviceToAdd,
+        normalizedEmail,
+        tenantId,
+      );
+      setValueToAdd("");
+      await rowsRefresh();
+    } catch (error) {
+      console.error("Failed to add service approver:", error);
+      alert("Failed to add service approver.");
+    } finally {
+      setLoading(false);
+    }
+  }, [resourceId, rows, rowsRefresh, serviceToAdd, tenantId, valueToAdd]);
+
+  const removeServiceApprover = useCallback(
+    async (row: { [key: string]: string }) => {
+      await clientRemoveServiceApprover(
+        resourceId,
+        row.service,
+        row.email,
+        tenantId,
+      );
+    },
+    [resourceId, tenantId],
+  );
+
+  const topRow = (
+    <Grid
+      container
+      spacing={2}
+      display="flex"
+      justifyContent={"space-between"}
+      alignItems={"center"}
+    >
+      <Grid sx={{ paddingLeft: "16px", color: "rgba(0,0,0,0.6)" }}>
+        Service Approvers
+      </Grid>
+      <Grid paddingLeft={0} paddingRight={4} display="flex" alignItems="center">
+        <Grid container paddingRight={1} spacing={1}>
+          <Grid>
+            <TextField
+              select
+              id={`service-approver-service-${resourceId}`}
+              inputProps={{ "aria-label": `Service for ${resourceId}` }}
+              onChange={(event) => setServiceToAdd(event.target.value)}
+              value={serviceToAdd}
+              size="small"
+              disabled={serviceOptions.length === 0}
+            >
+              {serviceOptions.map((service) => (
+                <MenuItem key={service.key} value={service.key}>
+                  {service.label}
+                </MenuItem>
+              ))}
+            </TextField>
+          </Grid>
+          <Grid>
+            <TextField
+              id={`service-approver-email-${resourceId}`}
+              inputProps={{
+                "aria-label": `Service approver email for ${resourceId}`,
+              }}
+              onChange={(event) => setValueToAdd(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.preventDefault();
+                  void addServiceApprover();
+                }
+              }}
+              value={valueToAdd}
+              placeholder="Add email"
+              size="small"
+              disabled={serviceOptions.length === 0}
+            />
+          </Grid>
+        </Grid>
+        <IconButton
+          onClick={() => void addServiceApprover()}
+          color="primary"
+          sx={{ padding: 0 }}
+          disabled={
+            loading || !valueToAdd.trim() || serviceOptions.length === 0
+          }
+          aria-label={`Add service approver for ${resourceId}`}
+        >
+          <AddCircleOutline />
+        </IconButton>
+      </Grid>
+    </Grid>
+  );
+
+  return (
+    <ListTable
+      tableName={TableNames.SERVICE_APPROVERS}
+      columnNameToRemoveBy="email"
+      rows={rows as unknown as { [key: string]: string }[]}
+      rowsRefresh={rowsRefresh}
+      topRow={topRow}
+      onRemoveRow={removeServiceApprover}
       columnFormatters={{ createdAt: formatDate }}
     />
   );
@@ -134,6 +339,9 @@ const ResourceApproverSection = ({
 export const ResourceSpecific = () => {
   const { resources, tenantId } = useTenantSchema();
   const [approvers, setApprovers] = useState<ResourceApprover[]>([]);
+  const [serviceApprovers, setServiceApprovers] = useState<ServiceApprover[]>(
+    [],
+  );
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -141,17 +349,31 @@ export const ResourceSpecific = () => {
     setLoading(true);
     setLoadError(null);
     try {
-      const data = await clientListResourceApprovers(tenantId);
+      const [fetchedResourceApprovers, fetchedServiceApprovers] =
+        await Promise.all([
+          clientListResourceApprovers(tenantId),
+          clientListServiceApprovers(tenantId),
+        ]);
       setApprovers(
-        data.map((approver) => ({
-          ...approver,
-          email: normalizeEmail(approver.email),
-          resourceId: approver.resourceId.trim(),
+        fetchedResourceApprovers.map((item) => ({
+          id: item.id,
+          resourceId: item.resourceId.trim(),
+          email: normalizeEmail(item.email),
+          createdAt: item.createdAt,
+        })),
+      );
+      setServiceApprovers(
+        fetchedServiceApprovers.map((item) => ({
+          id: item.id,
+          resourceId: item.resourceId.trim(),
+          service: normalizeServiceKey(item.service),
+          email: normalizeEmail(item.email),
+          createdAt: item.createdAt,
         })),
       );
     } catch (error) {
-      console.error("Failed to load resource approvers:", error);
-      setLoadError("Failed to load resource approvers.");
+      console.error("Failed to load approvers:", error);
+      setLoadError("Failed to load approvers.");
     } finally {
       setLoading(false);
     }
@@ -162,24 +384,71 @@ export const ResourceSpecific = () => {
   }, [loadApprovers]);
 
   const approversByResource = useMemo(() => {
-    const result = new Map<string, ResourceApprover[]>();
-    approvers.forEach((approver) => {
-      const resourceApprovers = result.get(approver.resourceId) ?? [];
-      resourceApprovers.push(approver);
-      result.set(approver.resourceId, resourceApprovers);
+    const result = new Map<string, ResourceApproverRow[]>();
+    approvers.forEach(({ resourceId, ...row }) => {
+      const rows = result.get(resourceId) ?? [];
+      rows.push(row);
+      result.set(resourceId, rows);
     });
-    result.forEach((resourceApprovers) =>
-      resourceApprovers.sort((a, b) => a.email.localeCompare(b.email)),
+    result.forEach((rows) =>
+      rows.sort((a, b) => a.email.localeCompare(b.email)),
     );
     return result;
   }, [approvers]);
 
-  if (loading) {
-    return (
-      <Typography color="text.secondary">
-        Loading resource approvers...
-      </Typography>
+  const serviceOptionsByResource = useMemo(() => {
+    const result = new Map<string, Array<{ key: string; label: string }>>();
+    resources.forEach((resource) => {
+      const seen = new Set<string>();
+      const options = (resource.services ?? []).reduce<
+        Array<{ key: string; label: string }>
+      >((acc, service) => {
+        const key = normalizeServiceKey(service);
+        if (!SERVICE_LABELS[key] || seen.has(key)) return acc;
+        seen.add(key);
+        acc.push({ key, label: SERVICE_LABELS[key] });
+        return acc;
+      }, []);
+      result.set(resource.resourceId, options);
+    });
+    return result;
+  }, [resources]);
+
+  const serviceApproversByResource = useMemo(() => {
+    const result = new Map<string, ServiceApproverRow[]>();
+    serviceApprovers.forEach(({ resourceId, ...row }) => {
+      const allowedServices = new Set(
+        (serviceOptionsByResource.get(resourceId) ?? []).map(
+          (service) => service.key,
+        ),
+      );
+      if (!allowedServices.has(row.service)) return;
+      const rows = result.get(resourceId) ?? [];
+      rows.push(row);
+      result.set(resourceId, rows);
+    });
+    result.forEach((rows) =>
+      rows.sort((a, b) => {
+        const serviceCompare = a.service.localeCompare(b.service);
+        if (serviceCompare !== 0) return serviceCompare;
+        return a.email.localeCompare(b.email);
+      }),
     );
+    return result;
+  }, [serviceApprovers, serviceOptionsByResource]);
+
+  const sortedResources = useMemo(
+    () =>
+      [...resources].sort((a, b) =>
+        String(a.resourceId).localeCompare(String(b.resourceId), undefined, {
+          numeric: true,
+        }),
+      ),
+    [resources],
+  );
+
+  if (loading) {
+    return <Typography color="text.secondary">Loading approvers...</Typography>;
   }
 
   if (loadError) {
@@ -200,16 +469,26 @@ export const ResourceSpecific = () => {
 
   return (
     <Box mt={1}>
-      {resources.map((resource) => (
+      {sortedResources.map((resource) => (
         <Box key={resource.resourceId} mb={4}>
           <Typography variant="h6" style={{ marginBottom: 16 }}>
             {resource.resourceId} {resource.name}
           </Typography>
-          <ResourceApproverSection
+          <ResourceApproverTable
             resourceId={resource.resourceId}
-            approvers={approversByResource.get(resource.resourceId) ?? []}
+            rows={approversByResource.get(resource.resourceId) ?? []}
             rowsRefresh={loadApprovers}
           />
+          <Box mt={3}>
+            <ServiceApproverTable
+              resourceId={resource.resourceId}
+              serviceOptions={
+                serviceOptionsByResource.get(resource.resourceId) ?? []
+              }
+              rows={serviceApproversByResource.get(resource.resourceId) ?? []}
+              rowsRefresh={loadApprovers}
+            />
+          </Box>
         </Box>
       ))}
     </Box>

--- a/booking-app/components/src/client/routes/admin/components/ServiceApproverUsers.tsx
+++ b/booking-app/components/src/client/routes/admin/components/ServiceApproverUsers.tsx
@@ -114,6 +114,7 @@ export const ServiceApproverUsers = ({
         <Grid container paddingRight={1}>
           <TextField
             id={`service-approver-${flagField}`}
+            inputProps={{ "aria-label": `Approver email for ${title}` }}
             onChange={(e) => setValueToAdd(e.target.value)}
             value={valueToAdd}
             placeholder="Add email"
@@ -125,7 +126,7 @@ export const ServiceApproverUsers = ({
           color="primary"
           sx={{ padding: 0 }}
           disabled={loading}
-          aria-label="Add service approver"
+          aria-label={`Add approver for ${title}`}
         >
           <AddCircleOutline />
         </IconButton>

--- a/booking-app/components/src/policy.ts
+++ b/booking-app/components/src/policy.ts
@@ -22,6 +22,7 @@ export enum TableNames {
   BLACKOUT_PERIODS = "blackoutPeriods",
   TENANT_SCHEMA = "tenantSchema",
   USERS_RIGHTS = "usersRights",
+  SERVICE_APPROVERS = "usersServiceApprovers",
 }
 
 // Utility function to get tenant-specific collection names
@@ -47,6 +48,7 @@ export const getTenantCollectionName = (
     "usersApprovers",
     "usersResourceApprovers",
     "usersRights",
+    "usersServiceApprovers",
     "counters",
   ];
 
@@ -95,6 +97,26 @@ export const BOOKING_TABLE_HIDE_STATUS_TIME_ELAPSED = [
   BookingStatusLabel.CHECKED_OUT,
   BookingStatusLabel.CANCELED,
 ];
+
+export const normalizeApproverEmail = (email: string): string =>
+  email.trim().toLowerCase();
+
+const encodeApproverIdPart = (value: string): string =>
+  encodeURIComponent(value.trim());
+
+const encodeApproverIdSegment = (value: string): string => {
+  const encodedValue = encodeApproverIdPart(value);
+  return `${encodedValue.length}-${encodedValue}`;
+};
+
+export const getServiceApproverDocumentId = (
+  resourceId: string,
+  service: string,
+  email: string,
+): string =>
+  `${encodeApproverIdSegment(resourceId)}${encodeApproverIdSegment(
+    service,
+  )}${encodeApproverIdSegment(normalizeApproverEmail(email))}`;
 export enum ApproverLevel {
   FIRST = 1,
   FINAL = 2,
@@ -105,8 +127,8 @@ export const getResourceApproverDocumentId = (
   resourceId: string,
   email: string,
 ): string => {
-  const encodedResourceId = encodeURIComponent(resourceId.trim());
-  const encodedEmail = encodeURIComponent(email.trim().toLowerCase());
+  const encodedResourceId = encodeApproverIdPart(resourceId);
+  const encodedEmail = encodeApproverIdPart(normalizeApproverEmail(email));
   return `${encodedResourceId.length}-${encodedResourceId}${encodedEmail}`;
 };
 

--- a/booking-app/lib/api/authz.ts
+++ b/booking-app/lib/api/authz.ts
@@ -92,6 +92,7 @@ const POLICY: Record<string, Policy> = {
   [TableNames.USERS_RIGHTS]: { read: "anyNYU", write: "adminOrSuper" },
   [TableNames.APPROVERS]: { read: "anyNYU", write: "adminOrSuper" },
   [TableNames.RESOURCE_APPROVERS]: { read: "adminOrSuper", write: "adminOrSuper" },
+  [TableNames.SERVICE_APPROVERS]: { read: "adminOrSuper", write: "adminOrSuper" },
   [TableNames.ADMINS]: { read: "anyNYU", write: "adminOrSuper" },
   [TableNames.PAS]: { read: "anyNYU", write: "adminOrSuper" },
 

--- a/booking-app/lib/firebase/firebase.ts
+++ b/booking-app/lib/firebase/firebase.ts
@@ -2,6 +2,8 @@ import {
   ApproverLevel,
   TableNames,
   getResourceApproverDocumentId,
+  getServiceApproverDocumentId,
+  normalizeApproverEmail,
   getTenantCollectionName,
 } from "@/components/src/policy";
 import { Timestamp } from "firebase/firestore";
@@ -14,6 +16,7 @@ import {
   USER_RIGHT_FLAG_FIELDS,
   type UserRightFlagField,
 } from "@/lib/firebase/userRightsConstants";
+import { wrapTimestamp } from "@/lib/api/firestoreShared";
 import type {
   GetDocRequest,
   ListRequest,
@@ -48,6 +51,14 @@ export const getTenantCollection = (
 export type AdminUserData = {
   email: string;
   createdAt: Timestamp;
+};
+
+export type ServiceApproverData = {
+  id: string;
+  resourceId: string;
+  service: string;
+  email: string;
+  createdAt?: Timestamp;
 };
 
 export type ResourceApproverData = {
@@ -178,6 +189,69 @@ export const clientSaveDataToFirestore = async (
   } catch (error) {
     console.error("Error writing document: ", error);
   }
+};
+
+export const clientListServiceApprovers = async (
+  tenant?: string,
+): Promise<ServiceApproverData[]> => {
+  const docs = await clientFetchAllDataFromCollection<ServiceApproverData>(
+    TableNames.SERVICE_APPROVERS,
+    [],
+    tenant,
+  );
+  return docs.sort((a, b) => {
+    const resourceCompare = a.resourceId.localeCompare(b.resourceId);
+    if (resourceCompare !== 0) return resourceCompare;
+    const serviceCompare = a.service.localeCompare(b.service);
+    if (serviceCompare !== 0) return serviceCompare;
+    return a.email.localeCompare(b.email);
+  });
+};
+
+export const clientAddServiceApprover = async (
+  resourceId: string,
+  service: string,
+  email: string,
+  tenant?: string,
+) => {
+  const normalizedResourceId = resourceId.trim();
+  const normalizedService = service.trim();
+  const normalizedEmail = normalizeApproverEmail(email);
+  if (!normalizedResourceId || !normalizedService || !normalizedEmail) {
+    throw new Error("Resource, service, and email are required");
+  }
+  const docId = getServiceApproverDocumentId(
+    normalizedResourceId,
+    normalizedService,
+    normalizedEmail,
+  );
+  await postJson<MutateRequest>("/api/firestore/mutate", {
+    op: "set",
+    collection: TableNames.SERVICE_APPROVERS,
+    tenant: resolveTenantArg(tenant),
+    docId,
+    data: {
+      resourceId: normalizedResourceId,
+      service: normalizedService,
+      email: normalizedEmail,
+      createdAt: wrapTimestamp(Date.now()),
+    },
+  });
+};
+
+export const clientRemoveServiceApprover = async (
+  resourceId: string,
+  service: string,
+  email: string,
+  tenant?: string,
+) => {
+  const docId = getServiceApproverDocumentId(resourceId, service, email);
+  await postJson<MutateRequest>("/api/firestore/mutate", {
+    op: "delete",
+    collection: TableNames.SERVICE_APPROVERS,
+    tenant: resolveTenantArg(tenant),
+    docId,
+  });
 };
 
 export const clientSaveUserRightsData = async (

--- a/booking-app/tests/unit/firestoreAuthz.unit.test.ts
+++ b/booking-app/tests/unit/firestoreAuthz.unit.test.ts
@@ -70,6 +70,16 @@ describe("authorizeWrite", () => {
     expect(decision.ok).toBe(true);
   });
 
+  it("allows admin write to usersServiceApprovers", async () => {
+    usersRightsSnap.mockReturnValue([{ isAdmin: true }]);
+    const decision = await authorizeWrite(
+      session,
+      "mc",
+      "usersServiceApprovers",
+    );
+    expect(decision.ok).toBe(true);
+  });
+
   it("blocks admin from writing usersSuperAdmin (super-only)", async () => {
     usersRightsSnap.mockReturnValue([{ isAdmin: true }]);
     const decision = await authorizeWrite(session, "mc", "usersSuperAdmin");
@@ -159,12 +169,31 @@ describe("authorizeRead", () => {
     expect(decision.ok).toBe(false);
   });
 
+  it("blocks non-admin read of usersServiceApprovers", async () => {
+    const decision = await authorizeRead(
+      session,
+      "mc",
+      "usersServiceApprovers",
+    );
+    expect(decision.ok).toBe(false);
+  });
+
   it("allows admin read of usersResourceApprovers", async () => {
     usersRightsSnap.mockReturnValue([{ isAdmin: true }]);
     const decision = await authorizeRead(
       session,
       "mc",
       "usersResourceApprovers",
+    );
+    expect(decision.ok).toBe(true);
+  });
+
+  it("allows admin read of usersServiceApprovers", async () => {
+    usersRightsSnap.mockReturnValue([{ isAdmin: true }]);
+    const decision = await authorizeRead(
+      session,
+      "mc",
+      "usersServiceApprovers",
     );
     expect(decision.ok).toBe(true);
   });

--- a/booking-app/tests/unit/policy-approver-document-id.unit.test.ts
+++ b/booking-app/tests/unit/policy-approver-document-id.unit.test.ts
@@ -1,0 +1,31 @@
+import {
+  getResourceApproverDocumentId,
+  getServiceApproverDocumentId,
+} from "@/components/src/policy";
+import { describe, expect, it } from "vitest";
+
+describe("approver document IDs", () => {
+  it("normalizes resource approver resource IDs and emails", () => {
+    expect(
+      getResourceApproverDocumentId(" room/a ", " Person@NYU.EDU "),
+    ).toEqual(getResourceApproverDocumentId("room/a", "person@nyu.edu"));
+  });
+
+  it("normalizes service approver resources, services, and emails", () => {
+    expect(
+      getServiceApproverDocumentId(
+        " room/a ",
+        " equipment ",
+        " Person@NYU.EDU ",
+      ),
+    ).toEqual(
+      getServiceApproverDocumentId("room/a", "equipment", "person@nyu.edu"),
+    );
+  });
+
+  it("does not collide when service approver parts contain delimiter characters", () => {
+    expect(getServiceApproverDocumentId("a-", "b", "e@nyu.edu")).not.toEqual(
+      getServiceApproverDocumentId("a", "-b", "e@nyu.edu"),
+    );
+  });
+});

--- a/booking-app/tests/unit/resource-specific-approvers-ui.unit.test.tsx
+++ b/booking-app/tests/unit/resource-specific-approvers-ui.unit.test.tsx
@@ -10,23 +10,33 @@ import {
 } from "@/components/src/client/routes/components/SchemaProvider";
 import {
   clientAddResourceApprover,
+  clientAddServiceApprover,
   clientListResourceApprovers,
+  clientListServiceApprovers,
 } from "@/lib/firebase/firebase";
 
 vi.mock("@/lib/firebase/firebase", () => ({
   clientAddResourceApprover: vi.fn(),
+  clientAddServiceApprover: vi.fn(),
   clientListResourceApprovers: vi.fn(),
+  clientListServiceApprovers: vi.fn(),
   clientRemoveResourceApprover: vi.fn(),
+  clientRemoveServiceApprover: vi.fn(),
 }));
 
 const listApproversMock = vi.mocked(clientListResourceApprovers);
+const listServiceApproversMock = vi.mocked(clientListServiceApprovers);
 const addApproverMock = vi.mocked(clientAddResourceApprover);
+const addServiceApproverMock = vi.mocked(clientAddServiceApprover);
 
 describe("ResourceSpecific", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    global.fetch = vi.fn(async () => ({ ok: true })) as unknown as typeof fetch;
     listApproversMock.mockResolvedValue([]);
+    listServiceApproversMock.mockResolvedValue([]);
     addApproverMock.mockResolvedValue();
+    addServiceApproverMock.mockResolvedValue();
   });
 
   it("adds a normalized approver for an opaque resource ID", async () => {
@@ -37,6 +47,7 @@ describe("ResourceSpecific", () => {
         ...defaultResource,
         name: "Audio Studio",
         resourceId: "studio/a:floor-2",
+        services: ["equipment"],
       },
     ];
 
@@ -50,6 +61,7 @@ describe("ResourceSpecific", () => {
       await screen.findByText("studio/a:floor-2 Audio Studio"),
     ).toBeInTheDocument();
     expect(screen.getByText("Resource Approvers")).toBeInTheDocument();
+    expect(screen.getByText("Service Approvers")).toBeInTheDocument();
 
     const input = screen.getByLabelText(
       "Resource approver email for studio/a:floor-2",
@@ -68,6 +80,158 @@ describe("ResourceSpecific", () => {
         "tenant-one",
       ),
     );
-    expect(screen.queryByText("Service Approvers")).not.toBeInTheDocument();
+  });
+
+  it("adds a service approver for a resource and service", async () => {
+    const user = userEvent.setup();
+    const schema = generateDefaultSchema("tenant-one");
+    schema.resources = [
+      {
+        ...defaultResource,
+        name: "Audio Studio",
+        resourceId: "studio/a:floor-2",
+        services: ["equipment"],
+      },
+    ];
+
+    render(
+      <SchemaProvider value={schema}>
+        <ResourceSpecific />
+      </SchemaProvider>,
+    );
+
+    const input = await screen.findByLabelText(
+      "Service approver email for studio/a:floor-2",
+    );
+    await user.type(input, " Service@NYU.EDU ");
+    await user.click(
+      screen.getByRole("button", {
+        name: "Add service approver for studio/a:floor-2",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(addServiceApproverMock).toHaveBeenCalledWith(
+        "studio/a:floor-2",
+        "equipment",
+        "service@nyu.edu",
+        "tenant-one",
+      ),
+    );
+    expect(global.fetch).toHaveBeenCalledWith("/api/nyu/identity/service", {
+      headers: { "x-tenant": "tenant-one" },
+    });
+  });
+
+  it("does not add a service approver when NYU Identity validation fails", async () => {
+    global.fetch = vi.fn(async () => ({
+      ok: false,
+    })) as unknown as typeof fetch;
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    const user = userEvent.setup();
+    const schema = generateDefaultSchema("tenant-one");
+    schema.resources = [
+      {
+        ...defaultResource,
+        name: "Audio Studio",
+        resourceId: "studio/a:floor-2",
+        services: ["equipment"],
+      },
+    ];
+
+    render(
+      <SchemaProvider value={schema}>
+        <ResourceSpecific />
+      </SchemaProvider>,
+    );
+
+    const input = await screen.findByLabelText(
+      "Service approver email for studio/a:floor-2",
+    );
+    await user.type(input, " Missing@NYU.EDU ");
+    await user.click(
+      screen.getByRole("button", {
+        name: "Add service approver for studio/a:floor-2",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(alertSpy).toHaveBeenCalledWith("Enter a valid NYU NetID email."),
+    );
+    expect(addServiceApproverMock).not.toHaveBeenCalled();
+    alertSpy.mockRestore();
+  });
+
+  it("sorts resources by resource ID and limits services to each resource schema", async () => {
+    const schema = generateDefaultSchema("tenant-one");
+    schema.resources = [
+      {
+        ...defaultResource,
+        name: "Room 10",
+        resourceId: "10",
+        services: ["setup"],
+      },
+      {
+        ...defaultResource,
+        name: "Room 2",
+        resourceId: "2",
+        services: ["equipment"],
+      },
+    ];
+
+    render(
+      <SchemaProvider value={schema}>
+        <ResourceSpecific />
+      </SchemaProvider>,
+    );
+
+    const room2 = await screen.findByText("2 Room 2");
+    const room10 = await screen.findByText("10 Room 10");
+    expect(
+      room2.compareDocumentPosition(room10) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(screen.getByLabelText("Service for 2")).toHaveTextContent(
+      "Equipment",
+    );
+    expect(screen.getByLabelText("Service for 10")).toHaveTextContent("Setup");
+  });
+
+  it("hides persisted service approvers for services not configured on the resource", async () => {
+    listServiceApproversMock.mockResolvedValue([
+      {
+        id: "garage-equipment",
+        resourceId: "garage",
+        service: "equipment",
+        email: "equipment@nyu.edu",
+      },
+      {
+        id: "garage-catering",
+        resourceId: "garage",
+        service: "catering",
+        email: "catering@nyu.edu",
+      },
+    ]);
+
+    const schema = generateDefaultSchema("tenant-one");
+    schema.resources = [
+      {
+        ...defaultResource,
+        name: "Garage",
+        resourceId: "garage",
+        services: ["equipment"],
+      },
+    ];
+
+    render(
+      <SchemaProvider value={schema}>
+        <ResourceSpecific />
+      </SchemaProvider>,
+    );
+
+    expect(await screen.findByText("equipment@nyu.edu")).toBeInTheDocument();
+    expect(screen.queryByText("catering@nyu.edu")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Service for garage")).toHaveTextContent(
+      "Equipment",
+    );
   });
 });


### PR DESCRIPTION
## Summary of Changes

Extracted the UI part from the service approvers branch. 

https://github.com/ITPNYU/booking-app/issues/908

## Schema Changes

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

<!-- If schema changed, list affected tenants and what changed.
Example:
- mc: added `showCleaning` flag
- itp: added new resource (resourceId "999")
-->

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [x] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [x] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [x] I requested a code review from at least one other teammate

## Screenshots / Video

<img width="2108" height="851" alt="image" src="https://github.com/user-attachments/assets/abacdd3a-a6aa-4203-a45e-e2cc88f7d988" />
<img width="334" height="368" alt="image" src="https://github.com/user-attachments/assets/34b96dd9-6327-4c1d-a6db-661cfc453fbb" />
