### PR TITLE
Fix approved status for service bookings

### DIFF
--- a/booking-app/components/src/utils/statusFromXState.ts
+++ b/booking-app/components/src/utils/statusFromXState.ts
@@ -30,6 +30,21 @@ type BookingLike = {
   setupService?: string;
 };
 
+function areAllServiceRequestStatesApproved(serviceRequestState: any): boolean {
+  if (!serviceRequestState || typeof serviceRequestState !== "object") {
+    return false;
+  }
+
+  const substates = Object.values(serviceRequestState);
+  return (
+    substates.length > 0 &&
+    substates.every(
+      (substate) =>
+        typeof substate === "string" && substate.endsWith(" Approved"),
+    )
+  );
+}
+
 export function getStatusFromXState(
   booking: BookingLike,
   tenant?: string,
@@ -62,11 +77,12 @@ export function getStatusFromXState(
           return BookingStatusLabel.CHECKED_OUT;
         }
         if (xvalue["Services Request"]) {
-          // A final-approval timestamp is the durable booking-level signal. In
-          // practice the client can briefly retain a stale parallel-state
-          // snapshot after the final service decision has completed the
-          // machine, so do not let that snapshot regress the displayed status.
-          if (booking?.finalApprovedAt) {
+          // Some bookings retain this parallel-state snapshot momentarily after
+          // its final region completes. Only treat that stale snapshot as
+          // approved when every service region is actually approved; the final
+          // approval field may be a legacy/zero timestamp or may predate
+          // completion of the service workflow.
+          if (areAllServiceRequestStatesApproved(xvalue["Services Request"])) {
             return BookingStatusLabel.APPROVED;
           }
           return BookingStatusLabel.PRE_APPROVED;

--- a/booking-app/components/src/utils/statusFromXState.ts
+++ b/booking-app/components/src/utils/statusFromXState.ts
@@ -62,6 +62,13 @@ export function getStatusFromXState(
           return BookingStatusLabel.CHECKED_OUT;
         }
         if (xvalue["Services Request"]) {
+          // A final-approval timestamp is the durable booking-level signal. In
+          // practice the client can briefly retain a stale parallel-state
+          // snapshot after the final service decision has completed the
+          // machine, so do not let that snapshot regress the displayed status.
+          if (booking?.finalApprovedAt) {
+            return BookingStatusLabel.APPROVED;
+          }
           return BookingStatusLabel.PRE_APPROVED;
         }
       }

--- a/booking-app/tests/unit/status-from-xstate.unit.test.ts
+++ b/booking-app/tests/unit/status-from-xstate.unit.test.ts
@@ -1,0 +1,42 @@
+import { BookingStatusLabel } from "@/components/src/types";
+import { getStatusFromXState } from "@/components/src/utils/statusFromXState";
+import { describe, expect, it } from "vitest";
+
+const servicesRequestState = {
+  "Services Request": {
+    "Staff Request": "Staff Approved",
+    "Equipment Request": "Equipment Approved",
+  },
+};
+
+describe("getStatusFromXState", () => {
+  it("shows final-approved service bookings as approved when the snapshot is stale", () => {
+    const booking = {
+      finalApprovedAt: { seconds: 1_722_744_000 },
+      xstateData: {
+        snapshot: {
+          value: servicesRequestState,
+        },
+      },
+    };
+
+    expect(getStatusFromXState(booking)).toBe(BookingStatusLabel.APPROVED);
+  });
+
+  it("keeps an unfinished services request pre-approved", () => {
+    const booking = {
+      xstateData: {
+        snapshot: {
+          value: {
+            "Services Request": {
+              "Staff Request": "Staff Approved",
+              "Equipment Request": "Equipment Requested",
+            },
+          },
+        },
+      },
+    };
+
+    expect(getStatusFromXState(booking)).toBe(BookingStatusLabel.PRE_APPROVED);
+  });
+});

--- a/booking-app/tests/unit/status-from-xstate.unit.test.ts
+++ b/booking-app/tests/unit/status-from-xstate.unit.test.ts
@@ -6,13 +6,16 @@ const servicesRequestState = {
   "Services Request": {
     "Staff Request": "Staff Approved",
     "Equipment Request": "Equipment Approved",
+    "Catering Request": "Catering Approved",
+    "Cleaning Request": "Cleaning Approved",
+    "Security Request": "Security Approved",
+    "Setup Request": "Setup Approved",
   },
 };
 
 describe("getStatusFromXState", () => {
-  it("shows final-approved service bookings as approved when the snapshot is stale", () => {
+  it("shows completed service bookings as approved when the snapshot is stale", () => {
     const booking = {
-      finalApprovedAt: { seconds: 1_722_744_000 },
       xstateData: {
         snapshot: {
           value: servicesRequestState,
@@ -23,8 +26,9 @@ describe("getStatusFromXState", () => {
     expect(getStatusFromXState(booking)).toBe(BookingStatusLabel.APPROVED);
   });
 
-  it("keeps an unfinished services request pre-approved", () => {
+  it("keeps an unfinished services request pre-approved despite a final approval timestamp", () => {
     const booking = {
+      finalApprovedAt: { seconds: 0 },
       xstateData: {
         snapshot: {
           value: {


### PR DESCRIPTION
## Summary of Changes

#1202 


## Schema Changes

<!-- Required for every PR. Pick exactly one. -->

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

<!-- If schema changed, list affected tenants and what changed.
Example:
- mc: added `showCleaning` flag
- itp: added new resource (resourceId "999")
-->

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [x] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [x] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [x] I requested a code review from at least one other teammate

## Screenshots / Video

<img width="2528" height="77" alt="image" src="https://github.com/user-attachments/assets/87b75102-7d14-4595-8e00-b98f5b1bc309" />
<img width="2526" height="64" alt="image" src="https://github.com/user-attachments/assets/3c3b6425-568f-4479-ad0d-866aad98134d" />
<img width="552" height="371" alt="image" src="https://github.com/user-attachments/assets/48d8e7b4-04d1-4d1a-85cc-4443a8d03f73" />
Dashboard status is consistent with history tab. Showing approved status for service bookings.