### PR TITLE
fix: persist final pre-approval history for services

### DIFF
--- a/booking-app/app/api/approve/route.ts
+++ b/booking-app/app/api/approve/route.ts
@@ -13,6 +13,7 @@ import { getMediaCommonsServices, isMediaCommons } from "@/components/src/utils/
 import { resolveCallerRole } from "@/lib/api/authz";
 import { requireSession } from "@/lib/api/requireSession";
 import {
+  logServerBookingChange,
   serverGetDataByCalendarEventId,
   serverGetFinalApproverEmail,
   serverListResourceApproversByEmail,
@@ -287,44 +288,24 @@ export async function POST(req: NextRequest) {
         }>(TableNames.BOOKING, id, tenant);
 
         if (doc) {
-          const logResponse = await fetch(
-            `${process.env.NEXT_PUBLIC_BASE_URL}/api/booking-logs`,
+          await logServerBookingChange({
+            bookingId: doc.id,
+            calendarEventId: id,
+            status: BookingStatusLabel.PRE_APPROVED,
+            changedBy: email,
+            requestNumber: doc.requestNumber,
+            tenant,
+          });
+
+          console.log(
+            `📋 XSTATE SERVICES REQUEST HISTORY LOGGED [${tenant?.toUpperCase()}]:`,
             {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                "x-tenant": tenant || DEFAULT_TENANT,
-              },
-              body: JSON.stringify({
-                bookingId: doc.id,
-                calendarEventId: id,
-                status: BookingStatusLabel.PRE_APPROVED, // Services Request is still PRE_APPROVED status
-                changedBy: email,
-                requestNumber: doc.requestNumber,
-                note: null,
-              }),
+              calendarEventId: id,
+              bookingId: doc.id,
+              requestNumber: doc.requestNumber,
+              status: BookingStatusLabel.PRE_APPROVED,
             },
           );
-
-          if (logResponse.ok) {
-            console.log(
-              `📋 XSTATE SERVICES REQUEST HISTORY LOGGED [${tenant?.toUpperCase()}]:`,
-              {
-                calendarEventId: id,
-                bookingId: doc.id,
-                requestNumber: doc.requestNumber,
-                status: BookingStatusLabel.PRE_APPROVED,
-              },
-            );
-          } else {
-            console.error(
-              `🚨 XSTATE SERVICES REQUEST HISTORY LOG FAILED [${tenant?.toUpperCase()}]:`,
-              {
-                calendarEventId: id,
-                status: logResponse.status,
-              },
-            );
-          }
 
           try {
             await notifyServiceApproversForRequestedServices(id, tenant);

--- a/booking-app/tests/unit/api-approve.unit.test.ts
+++ b/booking-app/tests/unit/api-approve.unit.test.ts
@@ -17,6 +17,7 @@ vi.mock("@/components/src/server/admin", () => ({
 }));
 
 vi.mock("@/lib/firebase/server/adminDb", () => ({
+  logServerBookingChange: vi.fn(),
   serverGetDataByCalendarEventId: vi.fn(),
   serverFetchAllDataFromCollection: vi.fn(),
   serverGetFinalApproverEmail: vi.fn(),
@@ -53,6 +54,7 @@ import {
 } from "@/components/src/server/admin";
 import { executeXStateTransition } from "@/lib/stateMachines/xstateUtilsV5";
 import {
+  logServerBookingChange,
   serverFetchAllDataFromCollection,
   serverGetFinalApproverEmail,
   serverGetDataByCalendarEventId,
@@ -86,6 +88,7 @@ const mockServerBookingContents = vi.mocked(serverBookingContents);
 const mockServerGetDataByCalendarEventId = vi.mocked(
   serverGetDataByCalendarEventId,
 );
+const mockLogServerBookingChange = vi.mocked(logServerBookingChange);
 const mockServerFetchAllDataFromCollection = vi.mocked(
   serverFetchAllDataFromCollection,
 );
@@ -518,9 +521,17 @@ describe("POST /api/approve", () => {
       ) as any,
     );
 
-    expect(mockFetch).toHaveBeenCalledWith(
+    expect(mockLogServerBookingChange).toHaveBeenCalledWith({
+      bookingId: "booking-db-id",
+      calendarEventId: bookingId,
+      status: "PRE-APPROVED",
+      changedBy: sessionEmail,
+      requestNumber: 42,
+      tenant: "itp",
+    });
+    expect(mockFetch).not.toHaveBeenCalledWith(
       "https://booking.test/api/booking-logs",
-      expect.objectContaining({ method: "POST" }),
+      expect.anything(),
     );
 
     await expect(parseJson(response)).resolves.toEqual({


### PR DESCRIPTION
## Summary of Changes

https://github.com/ITPNYU/booking-app/issues/1395

## Schema Changes

<!-- Required for every PR. Pick exactly one. -->

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

<!-- If schema changed, list affected tenants and what changed.
Example:
- mc: added `showCleaning` flag
- itp: added new resource (resourceId "999")
-->

## Checklist

- [x] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [x] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [x] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [x] I requested a code review from at least one other teammate

## Screenshots / Video

<img width="2528" height="77" alt="image" src="https://github.com/user-attachments/assets/87b75102-7d14-4595-8e00-b98f5b1bc309" />
<img width="533" height="373" alt="image" src="https://github.com/user-attachments/assets/7bed3424-8529-4d0f-8746-c79d2396bae8" />

Final pre-approval is logged with a note. 


