### PR TITLE
Add schema-driven auxiliary spaces for MC rooms (#1216)

### DIFF
--- a/booking-app/components/src/client/routes/admin/hooks/useExistingBooking.tsx
+++ b/booking-app/components/src/client/routes/admin/hooks/useExistingBooking.tsx
@@ -13,6 +13,7 @@ export default function useExistingBooking() {
     setSelectedRooms,
     setBookingCalendarInfo,
     setFormData,
+    setAnnexByRoom,
   } = useContext(BookingContext);
   const { allBookings, roomSettings } = useContext(DatabaseContext);
 
@@ -32,6 +33,7 @@ export default function useExistingBooking() {
       roomIds.includes(roomSetting.roomId),
     );
     setSelectedRooms(rooms);
+    setAnnexByRoom(booking.annexByRoom ?? {});
 
     const start = booking.startDate.toDate();
     const end = booking.endDate.toDate();
@@ -178,6 +180,7 @@ export default function useExistingBooking() {
         booking.equipmentServicesDetails,
         roomIdsForMaps.length === 1 ? roomIdsForMaps : [],
       ),
+      annexByRoom: booking.annexByRoom ?? {},
       webcheckoutCartNumber: booking.webcheckoutCartNumber,
       equipment: booking.equipment,
       staffing: booking.staffing,

--- a/booking-app/components/src/client/routes/booking/bookingProvider.tsx
+++ b/booking-app/components/src/client/routes/booking/bookingProvider.tsx
@@ -1,4 +1,5 @@
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
+import type React from "react";
 
 import { DateSelectArg } from "@fullcalendar/core";
 import dayjs from "dayjs";
@@ -31,12 +32,15 @@ export interface BookingContextType {
   reloadExistingCalendarEvents: () => void;
   role: Role | undefined;
   selectedRooms: RoomSetting[];
+  /** Selected auxiliary spaces keyed by parent room id. */
+  annexByRoom: Record<string, string[]>;
   setBookingCalendarInfo: (x: DateSelectArg) => void;
   setDepartment: (x: Department) => void;
   setFormData: (x: Inputs) => void;
   setHasShownMocapModal: (x: boolean) => void;
   setRole: (x: Role) => void;
   setSelectedRooms: (x: RoomSetting[]) => void;
+  setAnnexByRoom: React.Dispatch<React.SetStateAction<Record<string, string[]>>>;
   setSubmitting: (x: SubmitStatus) => void;
   submitting: SubmitStatus;
   fetchingStatus: "loading" | "loaded" | "error" | null;
@@ -57,12 +61,14 @@ export const BookingContext = createContext<BookingContextType>({
   reloadExistingCalendarEvents: () => {},
   role: undefined,
   selectedRooms: [],
+  annexByRoom: {},
   setBookingCalendarInfo: (x: DateSelectArg) => {},
   setDepartment: (x: Department) => {},
   setFormData: (x: Inputs) => {},
   setHasShownMocapModal: (x: boolean) => {},
   setRole: (x: Role) => {},
   setSelectedRooms: (x: RoomSetting[]) => {},
+  setAnnexByRoom: () => {},
   setSubmitting: (x: SubmitStatus) => {},
   submitting: "none",
   fetchingStatus: null,
@@ -90,6 +96,7 @@ export function BookingProvider({ children }) {
   const [hasShownMocapModal, setHasShownMocapModal] = useState(false);
   const [role, setRole] = useState<Role>();
   const [selectedRooms, setSelectedRooms] = useState<RoomSetting[]>([]);
+  const [annexByRoom, setAnnexByRoom] = useState<Record<string, string[]>>({});
   const [submitting, setSubmitting] = useState<SubmitStatus>("error");
   const {
     existingCalendarEvents,
@@ -191,12 +198,14 @@ export function BookingProvider({ children }) {
         isInBlackoutPeriod,
         role,
         selectedRooms,
+        annexByRoom,
         setBookingCalendarInfo,
         setDepartment,
         setFormData,
         setHasShownMocapModal,
         setRole,
         setSelectedRooms,
+        setAnnexByRoom,
         setSubmitting,
         submitting,
         fetchingStatus,

--- a/booking-app/components/src/client/routes/booking/components/FormInput.tsx
+++ b/booking-app/components/src/client/routes/booking/components/FormInput.tsx
@@ -100,6 +100,7 @@ export default function FormInput({
     isInBlackoutPeriod,
     formData,
     setFormData,
+    annexByRoom,
   } = useContext(BookingContext);
   const router = useRouter();
   const { tenant } = useParams();
@@ -288,10 +289,17 @@ export default function FormInput({
       // copy department + role from earlier in form
       department,
       role,
+      // Prefer live annex selections from room page over stale formData.
+      annexByRoom: annexByRoom ?? formData?.annexByRoom ?? {},
     },
     mode: "onBlur",
     resolver: undefined,
   });
+
+  // Keep form field in sync when user changes annex on the room selection page.
+  useEffect(() => {
+    setValue("annexByRoom", annexByRoom ?? {}, { shouldValidate: false });
+  }, [annexByRoom, setValue]);
 
   // different from other switches b/c services don't have yes/no columns in DB
   const [showEquipmentServices, setShowEquipmentServices] = useState(false);

--- a/booking-app/components/src/client/routes/booking/components/SelectRooms.tsx
+++ b/booking-app/components/src/client/routes/booking/components/SelectRooms.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, FormControlLabel, FormGroup, Tooltip } from "@mui/material";
+import { Box, Checkbox, FormControlLabel, FormGroup, Tooltip } from "@mui/material";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import RadioButtonUncheckedIcon from "@mui/icons-material/RadioButtonUnchecked";
 import dayjs from "dayjs";
@@ -7,6 +7,8 @@ import { FormContextLevel, RoomSetting } from "../../../../types";
 
 import { ConfirmDialogControlled } from "../../components/ConfirmDialog";
 import { useTenantSchema } from "../../components/SchemaProvider";
+import { getAnnexOptions } from "../../../../utils/resourceServicesUtils";
+import { canRequestAuxiliarySpaces } from "../../../../utils/roleUtils";
 import { BookingContext } from "../bookingProvider";
 import { useBookingDateRestrictions } from "../hooks/useBookingDateRestrictions";
 
@@ -29,6 +31,9 @@ export const SelectRooms = ({
     setHasShownMocapModal,
     bookingCalendarInfo,
     setBookingCalendarInfo,
+    role,
+    annexByRoom,
+    setAnnexByRoom,
   } = useContext(BookingContext);
   const { isBookingTimeInBlackout } = useBookingDateRestrictions();
   const { resources, calendarConfig } = useTenantSchema();
@@ -37,6 +42,7 @@ export const SelectRooms = ({
   // tenants that set the field explicitly are unaffected.
   const allowMultipleResourceSelect =
     calendarConfig?.multipleResourceSelect ?? false;
+  const showAnnex = canRequestAuxiliarySpaces(role);
 
   // Sort rooms by room number for consistent display order
   const sortedRooms = useMemo(
@@ -133,26 +139,48 @@ export const SelectRooms = ({
     return "Walk-in bookings are limited to 1 room or 2 connected ballroom bays";
   };
 
+  const clearAnnexForRoom = (roomId: string) => {
+    setAnnexByRoom((prev) => {
+      if (!(roomId in prev)) return prev;
+      const next = { ...prev };
+      delete next[roomId];
+      return next;
+    });
+  };
+
   const handleCheckChange = (e: any, room: RoomSetting) => {
     const newVal: boolean = e.target.checked;
     const normalizedRoom = { ...room, roomId: String(room.roomId) };
-    setSelected((prev: RoomSetting[]) => {
-      if (newVal) {
-        if (
-          !allowMultipleResourceSelect &&
-          prev.length > 0 &&
-          !prev.some((r) => String(r.roomId) === normalizedRoom.roomId)
-        ) {
+
+    if (newVal) {
+      if (
+        !allowMultipleResourceSelect &&
+        selected.length > 0 &&
+        !selected.some((r) => String(r.roomId) === normalizedRoom.roomId)
+      ) {
+        return;
+      }
+
+      if (!allowMultipleResourceSelect) {
+        // Replace selection: drop annex for any previously selected parents.
+        setAnnexByRoom({});
+      }
+
+      setSelected((prev: RoomSetting[]) => {
+        if (prev.some((r) => String(r.roomId) === normalizedRoom.roomId)) {
           return prev;
         }
-
-        const newSelection = [...prev, normalizedRoom].sort((a, b) =>
+        return [...prev, normalizedRoom].sort((a, b) =>
           String(a.roomId).localeCompare(String(b.roomId), undefined, {
             numeric: true,
           }),
         );
-        return newSelection;
-      }
+      });
+      return;
+    }
+
+    clearAnnexForRoom(normalizedRoom.roomId);
+    setSelected((prev: RoomSetting[]) => {
       const newSelection = prev.filter(
         (r) => String(r.roomId) !== normalizedRoom.roomId,
       );
@@ -163,18 +191,41 @@ export const SelectRooms = ({
     });
   };
 
+  const handleAnnexChange = (
+    parentRoomId: string,
+    optionValue: string,
+    checked: boolean,
+  ) => {
+    setAnnexByRoom((prev) => {
+      const current = prev[parentRoomId] ?? [];
+      const nextValues = checked
+        ? current.includes(optionValue)
+          ? current
+          : [...current, optionValue]
+        : current.filter((v) => v !== optionValue);
+      if (nextValues.length === 0) {
+        const next = { ...prev };
+        delete next[parentRoomId];
+        return next;
+      }
+      return { ...prev, [parentRoomId]: nextValues };
+    });
+  };
+
   return (
     <FormGroup>
       {sortedRooms.map((room: RoomSetting) => {
         const roomId = String(room.roomId);
         const disabled = isDisabled(roomId);
         const disabledReason = getDisabledReason(roomId);
+        const isSelected = selectedIds.includes(roomId);
+        const annexOptions = showAnnex && isSelected ? getAnnexOptions(room) : [];
 
         const checkbox = (
           <FormControlLabel
             control={
               <Checkbox
-                checked={selectedIds.includes(roomId)}
+                checked={isSelected}
                 onChange={(e) => handleCheckChange(e, room)}
                 icon={
                   allowMultipleResourceSelect ? undefined : (
@@ -202,12 +253,53 @@ export const SelectRooms = ({
           />
         );
 
-        return disabledReason ? (
-          <Tooltip title={disabledReason} key={room.name}>
-            <span>{checkbox}</span>
-          </Tooltip>
-        ) : (
-          checkbox
+        return (
+          <Box key={room.name}>
+            {disabledReason ? (
+              <Tooltip title={disabledReason}>
+                <span>{checkbox}</span>
+              </Tooltip>
+            ) : (
+              checkbox
+            )}
+            {annexOptions.length > 0 && (
+              <Box
+                sx={{ pl: 3, display: "flex", flexDirection: "column" }}
+                data-testid={`annex-options-${roomId}`}
+              >
+                {annexOptions.map((option) => (
+                  <FormControlLabel
+                    key={option.value}
+                    control={
+                      <Checkbox
+                        size="small"
+                        checked={(annexByRoom[roomId] ?? []).includes(
+                          option.value,
+                        )}
+                        onChange={(e) =>
+                          handleAnnexChange(
+                            roomId,
+                            option.value,
+                            e.target.checked,
+                          )
+                        }
+                        inputProps={{
+                          "aria-label": option.label,
+                        }}
+                        data-testid={`annex-option-${option.value}`}
+                      />
+                    }
+                    label={option.label}
+                    sx={{
+                      "& .MuiFormControlLabel-label": {
+                        fontSize: "0.9rem",
+                      },
+                    }}
+                  />
+                ))}
+              </Box>
+            )}
+          </Box>
         );
       })}
       <ConfirmDialogControlled

--- a/booking-app/components/src/client/routes/booking/hooks/useHandleStartBooking.tsx
+++ b/booking-app/components/src/client/routes/booking/hooks/useHandleStartBooking.tsx
@@ -12,6 +12,7 @@ export default function useHandleStartBooking() {
     setSelectedRooms,
     setBookingCalendarInfo,
     setFormData,
+    setAnnexByRoom,
   } = useContext(BookingContext);
 
   const handleStartBooking = () => {
@@ -22,6 +23,7 @@ export default function useHandleStartBooking() {
     setDepartment(undefined);
     setRole(undefined);
     setSelectedRooms([]);
+    setAnnexByRoom({});
     setBookingCalendarInfo(undefined);
     setFormData(undefined);
 

--- a/booking-app/components/src/client/routes/booking/hooks/useSubmitBooking.tsx
+++ b/booking-app/components/src/client/routes/booking/hooks/useSubmitBooking.tsx
@@ -40,6 +40,8 @@ export default function useSubmitBooking(formContext: FormContextLevel) {
     isBanned,
     needsSafetyTraining,
     isInBlackoutPeriod,
+    annexByRoom,
+    setAnnexByRoom,
   } = useContext(BookingContext);
 
   const isOverlap = useCalculateOverlap();
@@ -232,6 +234,7 @@ export default function useSubmitBooking(formContext: FormContextLevel) {
       // The form accepts NetID (e.g., "abc123") but the field should store email format
       const transformedData = {
         ...data,
+        annexByRoom: data.annexByRoom ?? annexByRoom ?? {},
         sponsorEmail: data.sponsorEmail && isValidNetIdFormat(data.sponsorEmail)
           ? `${data.sponsorEmail}@nyu.edu`
           : data.sponsorEmail,
@@ -308,6 +311,7 @@ export default function useSubmitBooking(formContext: FormContextLevel) {
           // clear stored booking data after submit confirmation
           setBookingCalendarInfo(undefined);
           setSelectedRooms([]);
+          setAnnexByRoom({});
           setFormData(undefined);
           setHasShownMocapModal(false);
 
@@ -325,6 +329,7 @@ export default function useSubmitBooking(formContext: FormContextLevel) {
     [
       bookingCalendarInfo,
       selectedRooms,
+      annexByRoom,
       liaisonUsers,
       userEmail,
       router,

--- a/booking-app/components/src/client/routes/components/bookingTable/MoreInfoModal.tsx
+++ b/booking-app/components/src/client/routes/components/bookingTable/MoreInfoModal.tsx
@@ -38,6 +38,7 @@ import { DatabaseContext } from "../Provider";
 import { default as CustomTable } from "../Table";
 import StackedTableCell from "./StackedTableCell";
 import { getStaffingServiceLabel } from "@/lib/tenant/mcResourceServices";
+import { formatAnnexByRoomForDisplay } from "@/components/src/utils/resourceServicesUtils";
 
 function formatStaffingServiceDisplay(value: string): string {
   const trimmed = value.trim();
@@ -46,6 +47,15 @@ function formatStaffingServiceDisplay(value: string): string {
     return StaffingServices[trimmed as keyof typeof StaffingServices];
   }
   return getStaffingServiceLabel(trimmed);
+}
+
+function hasAnnexSelections(
+  annexByRoom: Record<string, string[]> | undefined,
+): boolean {
+  if (!annexByRoom || typeof annexByRoom !== "object") return false;
+  return Object.values(annexByRoom).some(
+    (values) => Array.isArray(values) && values.length > 0,
+  );
 }
 
 interface Props {
@@ -126,7 +136,8 @@ export default function MoreInfoModal({
         Object.values(booking.furnishingsByRoom).some(
           (v) => typeof v === "string" && v.toLowerCase() === "yes",
         ),
-    );
+    ) ||
+    hasAnnexSelections(booking.annexByRoom);
 
   const [isEditingCart, setIsEditingCart] = useState(false);
   const [cartNumber, setCartNumber] = useState(
@@ -679,6 +690,17 @@ export default function MoreInfoModal({
                           />
                         </TableRow>
                       )}
+                    {hasAnnexSelections(booking.annexByRoom) && (
+                      <TableRow>
+                        <LabelCell>Auxiliary Spaces</LabelCell>
+                        <TableCell>
+                          {formatAnnexByRoomForDisplay(
+                            booking.annexByRoom,
+                            schema.resources,
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    )}
                     {booking.equipmentServices &&
                       booking.equipmentServices.length > 0 && (
                         <TableRow>

--- a/booking-app/components/src/client/routes/components/schemaTypes.ts
+++ b/booking-app/components/src/client/routes/components/schemaTypes.ts
@@ -39,6 +39,10 @@ export type ResourceFormOption = {
   required?: boolean;
   descriptionHtml?: string;
   chartField?: ResourceChartFieldConfig;
+  /** Optional Google Calendar ID for auxiliary spaces (filled when calendars exist). */
+  calendarId?: string;
+  /** Production calendar ID for auxiliary spaces. */
+  calendarIdProd?: string;
 };
 
 /** @deprecated Use ResourceFormOption */

--- a/booking-app/components/src/server/calendars.ts
+++ b/booking-app/components/src/server/calendars.ts
@@ -1,6 +1,6 @@
 import { bookingCalendarStrToDate } from "@/components/src/client/utils/date";
 import { getCalendarClient } from "@/lib/googleClient";
-import { getStaffingServiceLabel } from "@/lib/tenant/mcResourceServices";
+import { getMcResourceServices, getStaffingServiceLabel } from "@/lib/tenant/mcResourceServices";
 import { traceExternalCall } from "@/lib/newrelic-utils";
 import {
   BookingFormDetails,
@@ -8,6 +8,7 @@ import {
   StaffingServices,
 } from "../types";
 import { formatOrigin, getSecondaryContactName } from "../utils/formatters";
+import { formatAnnexByRoomForDisplay } from "../utils/resourceServicesUtils";
 
 import { serverGetRoomCalendarIds } from "./admin";
 
@@ -310,6 +311,18 @@ export const bookingContentsToDescription = async (
     );
     if (securityChartField) {
       description += listItem("Security Chart Field", securityChartField);
+    }
+  }
+
+  const annexByRoom = bookingContents.annexByRoom;
+  if (annexByRoom && typeof annexByRoom === "object") {
+    const annexRooms = Object.keys(annexByRoom).map((roomId) => ({
+      resourceId: roomId,
+      services: getMcResourceServices(roomId) ?? {},
+    }));
+    const annexDisplay = formatAnnexByRoomForDisplay(annexByRoom, annexRooms);
+    if (annexDisplay) {
+      description += listItem("Auxiliary Spaces", annexDisplay);
     }
   }
   description += "</ul>";

--- a/booking-app/components/src/types.ts
+++ b/booking-app/components/src/types.ts
@@ -197,6 +197,8 @@ export type Inputs = {
   furnishingsByRoom?: Record<string, string>;
   chartFieldForFurnishingsByRoom?: Record<string, string>;
   equipmentServicesDetailsByRoom?: Record<string, string>;
+  /** Selected auxiliary spaces keyed by parent room id → option values. */
+  annexByRoom?: Record<string, string[]>;
   webcheckoutCartNumber?: string;
   // Individual service fields for pregame parsing
   equipment?: string;

--- a/booking-app/components/src/utils/resourceServicesUtils.ts
+++ b/booking-app/components/src/utils/resourceServicesUtils.ts
@@ -144,7 +144,7 @@ export function getRoomsWithVisibleService(
   key: ResourceServiceKey,
   context: ServiceVisibilityContext,
 ): ServiceResourceLike[] {
-  // Annex / auxiliary space is schema-only for now — not rendered or requested.
+  // Annex / auxiliary space is rendered on the room selection page, not the services form.
   if (key === "annex" || key === "auxiliarySpace") {
     return [];
   }
@@ -158,6 +158,40 @@ export function getRoomsWithVisibleService(
     }
     return shouldShowServiceSection(section, context);
   });
+}
+
+/** Annex options for a parent room (used on the room selection page). */
+export function getAnnexOptions(
+  resource: ServiceResourceLike,
+): ResourceFormOption[] {
+  const section = getServiceSectionConfig(resource, "annex");
+  return section?.options ?? [];
+}
+
+/**
+ * Format selected auxiliary spaces for calendar descriptions / detail UI.
+ * Example: `1201: 1201 Foyer, 1201 Lounge; 103: Garage Green Room`
+ */
+export function formatAnnexByRoomForDisplay(
+  annexByRoom: Record<string, string[]> | undefined,
+  rooms: ServiceResourceLike[],
+): string {
+  if (!annexByRoom || typeof annexByRoom !== "object") return "";
+
+  const parts: string[] = [];
+  for (const [roomId, values] of Object.entries(annexByRoom)) {
+    if (!Array.isArray(values) || values.length === 0) continue;
+    const room = rooms.find(
+      (r) => getServiceResourceId(r) === String(roomId),
+    );
+    const options = room ? getAnnexOptions(room) : [];
+    const labels = values.map((value) => {
+      const opt = options.find((o) => o.value === value);
+      return opt?.label ?? value;
+    });
+    parts.push(`${roomId}: ${labels.join(", ")}`);
+  }
+  return parts.join("; ");
 }
 
 export function anyRoomHasVisibleService(

--- a/booking-app/components/src/utils/resourceServicesUtils.ts
+++ b/booking-app/components/src/utils/resourceServicesUtils.ts
@@ -170,7 +170,7 @@ export function getAnnexOptions(
 
 /**
  * Format selected auxiliary spaces for calendar descriptions / detail UI.
- * Example: `1201: 1201 Foyer, 1201 Lounge; 103: Garage Green Room`
+ * Example: `1201: 1200L-6 Seminar Foyer, 1204 Seminar Lounge; 103: Garage Green Room`
  */
 export function formatAnnexByRoomForDisplay(
   annexByRoom: Record<string, string[]> | undefined,

--- a/booking-app/components/src/utils/roleUtils.ts
+++ b/booking-app/components/src/utils/roleUtils.ts
@@ -41,3 +41,10 @@ export function getBaseRole(role: Role | string | undefined): BaseRole {
 
   return "student";
 }
+
+/** Auxiliary spaces are faculty/staff only — not students. */
+export function canRequestAuxiliarySpaces(
+  role: Role | string | undefined,
+): boolean {
+  return getBaseRole(role) !== "student";
+}

--- a/booking-app/lib/tenant/mcResourceServices.ts
+++ b/booking-app/lib/tenant/mcResourceServices.ts
@@ -12,6 +12,7 @@ const MC_SERVICES_BY_ROOM: Record<string, ResourceServicesConfig> = {
         walkIn: true,
         VIP: true,
       },
+      mode: "checkbox",
       options: [
         {
           value: "103GR",
@@ -202,6 +203,7 @@ const MC_SERVICES_BY_ROOM: Record<string, ResourceServicesConfig> = {
         walkIn: true,
         VIP: true,
       },
+      mode: "checkbox",
       options: [
         {
           value: "202GR",
@@ -1083,8 +1085,23 @@ const MC_SERVICES_BY_ROOM: Record<string, ResourceServicesConfig> = {
         walkIn: true,
         VIP: true,
       },
+      mode: "checkbox",
       label: "Request breakout space, lounge, or foyer",
       descriptionHtml: "<p>Check if your reservation requires use of breakout space, lounge, or foyer areas.</p>",
+      options: [
+        {
+          value: "1201-breakout",
+          label: "1201 Break-out Space",
+        },
+        {
+          value: "1201-foyer",
+          label: "1201 Foyer",
+        },
+        {
+          value: "1201-lounge",
+          label: "1201 Lounge",
+        },
+      ],
     },
   },
 };

--- a/booking-app/lib/tenant/mcResourceServices.ts
+++ b/booking-app/lib/tenant/mcResourceServices.ts
@@ -207,11 +207,11 @@ const MC_SERVICES_BY_ROOM: Record<string, ResourceServicesConfig> = {
       options: [
         {
           value: "202GR",
-          label: "Lecture Green Room",
+          label: "202GR Lecture Green Room",
         },
         {
           value: "205",
-          label: "Student Lounge",
+          label: "205 Student Lounge",
         }
       ],
     },
@@ -1090,16 +1090,16 @@ const MC_SERVICES_BY_ROOM: Record<string, ResourceServicesConfig> = {
       descriptionHtml: "<p>Check if your reservation requires use of breakout space, lounge, or foyer areas.</p>",
       options: [
         {
-          value: "1201-breakout",
-          label: "1201 Break-out Space",
+          value: "1200L-6",
+          label: "1200L-6 Seminar Foyer",
         },
         {
-          value: "1201-foyer",
-          label: "1201 Foyer",
+          value: "1202",
+          label: "1202 Seminar Breakout",
         },
         {
-          value: "1201-lounge",
-          label: "1201 Lounge",
+          value: "1204",
+          label: "1204 Seminar Lounge",
         },
       ],
     },

--- a/booking-app/tests/unit/SelectRooms.annex.unit.test.tsx
+++ b/booking-app/tests/unit/SelectRooms.annex.unit.test.tsx
@@ -1,0 +1,162 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it, vi } from "vitest";
+import {
+  FormContextLevel,
+  Role,
+  RoomSetting,
+} from "../../components/src/types";
+import {
+  SchemaContext,
+  generateDefaultSchema,
+} from "../../components/src/client/routes/components/SchemaProvider";
+import { BookingContext } from "../../components/src/client/routes/booking/bookingProvider";
+import { SelectRooms } from "../../components/src/client/routes/booking/components/SelectRooms";
+import { applyMcResourceServices } from "../../lib/tenant/mcResourceServices";
+
+vi.mock(
+  "../../components/src/client/routes/booking/hooks/useBookingDateRestrictions",
+  () => ({
+    useBookingDateRestrictions: () => ({
+      isBookingTimeInBlackout: () => ({ inBlackout: false, affectedPeriods: [] }),
+    }),
+  }),
+);
+
+const room1201 = applyMcResourceServices({
+  resourceId: "1201",
+  name: "Seminar Room",
+  capacity: 100,
+  calendarId: "cal-1201",
+  isEquipment: false,
+  isWalkIn: false,
+  isWalkInCanBookTwo: false,
+  services: [],
+}) as unknown as RoomSetting;
+
+const room103 = applyMcResourceServices({
+  resourceId: "103",
+  name: "The Garage",
+  capacity: 74,
+  calendarId: "cal-103",
+  isEquipment: false,
+  isWalkIn: true,
+  isWalkInCanBookTwo: false,
+  services: [],
+}) as unknown as RoomSetting;
+
+// RoomSetting uses roomId; applyMcResourceServices returns resourceId.
+(room1201 as any).roomId = "1201";
+(room103 as any).roomId = "103";
+
+function TestHarness({
+  role,
+  rooms = [room1201, room103],
+}: {
+  role?: Role;
+  rooms?: RoomSetting[];
+}) {
+  const [selected, setSelected] = useState<RoomSetting[]>([]);
+  const [annexByRoom, setAnnexByRoom] = useState<Record<string, string[]>>({});
+  const schema = {
+    ...generateDefaultSchema("mc"),
+    resources: rooms.map((r) => ({
+      resourceId: String(r.roomId),
+      name: r.name,
+      capacity: Number(r.capacity),
+      calendarId: r.calendarId,
+      isEquipment: false,
+      isWalkIn: false,
+      isWalkInCanBookTwo: false,
+      services: r.services,
+    })),
+    calendarConfig: {
+      ...generateDefaultSchema("mc").calendarConfig,
+      multipleResourceSelect: true,
+    },
+  };
+
+  return (
+    <SchemaContext.Provider value={schema as any}>
+      <BookingContext.Provider
+        value={{
+          hasShownMocapModal: false,
+          setHasShownMocapModal: () => {},
+          bookingCalendarInfo: undefined,
+          setBookingCalendarInfo: () => {},
+          role,
+          annexByRoom,
+          setAnnexByRoom,
+        } as any}
+      >
+        <SelectRooms
+          allRooms={rooms}
+          formContext={FormContextLevel.FULL_FORM}
+          selected={selected}
+          setSelected={setSelected}
+        />
+        <div data-testid="annex-state">{JSON.stringify(annexByRoom)}</div>
+      </BookingContext.Provider>
+    </SchemaContext.Provider>
+  );
+}
+
+describe("SelectRooms auxiliary spaces", () => {
+  it("shows indented annex options for faculty when parent is selected", () => {
+    render(<TestHarness role={Role.FACULTY} />);
+
+    expect(screen.queryByTestId("annex-options-1201")).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "1201 Seminar Room" }),
+    );
+
+    expect(screen.getByTestId("annex-options-1201")).toBeTruthy();
+    expect(
+      screen.getByRole("checkbox", { name: "1201 Break-out Space" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("checkbox", { name: "1201 Foyer" })).toBeTruthy();
+    expect(screen.getByRole("checkbox", { name: "1201 Lounge" })).toBeTruthy();
+  });
+
+  it("hides annex options for students even when parent is selected", () => {
+    render(<TestHarness role={Role.STUDENT} />);
+
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "1201 Seminar Room" }),
+    );
+
+    expect(screen.queryByTestId("annex-options-1201")).toBeNull();
+    expect(
+      screen.queryByRole("checkbox", { name: "1201 Foyer" }),
+    ).toBeNull();
+  });
+
+  it("clears annex selections when parent is deselected", () => {
+    render(<TestHarness role={Role.ADMIN_STAFF} />);
+
+    const parent = screen.getByRole("checkbox", {
+      name: "1201 Seminar Room",
+    });
+    fireEvent.click(parent);
+    fireEvent.click(screen.getByRole("checkbox", { name: "1201 Foyer" }));
+
+    expect(screen.getByTestId("annex-state").textContent).toContain(
+      "1201-foyer",
+    );
+
+    fireEvent.click(parent);
+    expect(screen.getByTestId("annex-state").textContent).toBe("{}");
+  });
+
+  it("shows schema-driven annex options for 103 green room", () => {
+    render(<TestHarness role={Role.FACULTY} />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "103 The Garage" }));
+
+    expect(screen.getByTestId("annex-options-103")).toBeTruthy();
+    expect(
+      screen.getByRole("checkbox", { name: "Garage Green Room" }),
+    ).toBeTruthy();
+  });
+});

--- a/booking-app/tests/unit/SelectRooms.annex.unit.test.tsx
+++ b/booking-app/tests/unit/SelectRooms.annex.unit.test.tsx
@@ -113,10 +113,14 @@ describe("SelectRooms auxiliary spaces", () => {
 
     expect(screen.getByTestId("annex-options-1201")).toBeTruthy();
     expect(
-      screen.getByRole("checkbox", { name: "1201 Break-out Space" }),
+      screen.getByRole("checkbox", { name: "1202 Seminar Breakout" }),
     ).toBeTruthy();
-    expect(screen.getByRole("checkbox", { name: "1201 Foyer" })).toBeTruthy();
-    expect(screen.getByRole("checkbox", { name: "1201 Lounge" })).toBeTruthy();
+    expect(
+      screen.getByRole("checkbox", { name: "1200L-6 Seminar Foyer" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("checkbox", { name: "1204 Seminar Lounge" }),
+    ).toBeTruthy();
   });
 
   it("hides annex options for students even when parent is selected", () => {
@@ -128,7 +132,7 @@ describe("SelectRooms auxiliary spaces", () => {
 
     expect(screen.queryByTestId("annex-options-1201")).toBeNull();
     expect(
-      screen.queryByRole("checkbox", { name: "1201 Foyer" }),
+      screen.queryByRole("checkbox", { name: "1200L-6 Seminar Foyer" }),
     ).toBeNull();
   });
 
@@ -139,11 +143,11 @@ describe("SelectRooms auxiliary spaces", () => {
       name: "1201 Seminar Room",
     });
     fireEvent.click(parent);
-    fireEvent.click(screen.getByRole("checkbox", { name: "1201 Foyer" }));
-
-    expect(screen.getByTestId("annex-state").textContent).toContain(
-      "1201-foyer",
+    fireEvent.click(
+      screen.getByRole("checkbox", { name: "1200L-6 Seminar Foyer" }),
     );
+
+    expect(screen.getByTestId("annex-state").textContent).toContain("1200L-6");
 
     fireEvent.click(parent);
     expect(screen.getByTestId("annex-state").textContent).toBe("{}");

--- a/booking-app/tests/unit/SelectRooms.multipleResourceSelect.unit.test.tsx
+++ b/booking-app/tests/unit/SelectRooms.multipleResourceSelect.unit.test.tsx
@@ -63,6 +63,9 @@ function TestHarness({ multipleResourceSelect }: { multipleResourceSelect: boole
           setHasShownMocapModal: () => {},
           bookingCalendarInfo: undefined,
           setBookingCalendarInfo: () => {},
+          role: undefined,
+          annexByRoom: {},
+          setAnnexByRoom: () => {},
         } as any}
       >
         <SelectRooms

--- a/booking-app/tests/unit/calendar-description.unit.test.ts
+++ b/booking-app/tests/unit/calendar-description.unit.test.ts
@@ -106,6 +106,23 @@ describe("Calendar Description Functions", () => {
   });
 
   describe("bookingContentsToDescription", () => {
+    it("should include auxiliary spaces in services section", async () => {
+      const withAnnex = {
+        ...mockBookingContents,
+        annexByRoom: {
+          "1201": ["1201-foyer", "1201-lounge"],
+          "103": ["103GR"],
+        },
+      };
+
+      const result = await bookingContentsToDescription(withAnnex);
+
+      expect(result).toContain("Auxiliary Spaces");
+      expect(result).toContain("1201 Foyer");
+      expect(result).toContain("1201 Lounge");
+      expect(result).toContain("Garage Green Room");
+    });
+
     it("should generate HTML description with all main sections", async () => {
       const result = await bookingContentsToDescription(mockBookingContents);
 

--- a/booking-app/tests/unit/calendar-description.unit.test.ts
+++ b/booking-app/tests/unit/calendar-description.unit.test.ts
@@ -110,7 +110,7 @@ describe("Calendar Description Functions", () => {
       const withAnnex = {
         ...mockBookingContents,
         annexByRoom: {
-          "1201": ["1201-foyer", "1201-lounge"],
+          "1201": ["1200L-6", "1204"],
           "103": ["103GR"],
         },
       };
@@ -118,8 +118,8 @@ describe("Calendar Description Functions", () => {
       const result = await bookingContentsToDescription(withAnnex);
 
       expect(result).toContain("Auxiliary Spaces");
-      expect(result).toContain("1201 Foyer");
-      expect(result).toContain("1201 Lounge");
+      expect(result).toContain("1200L-6 Seminar Foyer");
+      expect(result).toContain("1204 Seminar Lounge");
       expect(result).toContain("Garage Green Room");
     });
 

--- a/booking-app/tests/unit/coerce-tenant-schema.unit.test.ts
+++ b/booking-app/tests/unit/coerce-tenant-schema.unit.test.ts
@@ -75,7 +75,7 @@ describe("coerceTenantSchema — resources", () => {
     expect(coerced.resources[0].services?.catering?.chartField?.required).toBe(
       true,
     );
-    expect(coerced.resources[0].services?.annex?.mode).toBe("radio");
+    expect(coerced.resources[0].services?.annex?.mode).toBe("checkbox");
   });
 
   it("preserves Firestore object services config for mc tenant", () => {

--- a/booking-app/tests/unit/resource-services.unit.test.ts
+++ b/booking-app/tests/unit/resource-services.unit.test.ts
@@ -180,14 +180,14 @@ describe("applyMcResourceServices", () => {
     });
     expect(room.services?.annex?.mode).toBe("checkbox");
     expect(room.services?.annex?.options?.map((o) => o.value)).toEqual([
-      "1201-breakout",
-      "1201-foyer",
-      "1201-lounge",
+      "1200L-6",
+      "1202",
+      "1204",
     ]);
     expect(room.services?.annex?.options?.map((o) => o.label)).toEqual([
-      "1201 Break-out Space",
-      "1201 Foyer",
-      "1201 Lounge",
+      "1200L-6 Seminar Foyer",
+      "1202 Seminar Breakout",
+      "1204 Seminar Lounge",
     ]);
   });
 
@@ -414,9 +414,9 @@ describe("formatAnnexByRoomForDisplay", () => {
     expect(getAnnexOptions(room).length).toBe(3);
     expect(
       formatAnnexByRoomForDisplay(
-        { "1201": ["1201-foyer", "1201-lounge"] },
+        { "1201": ["1200L-6", "1204"] },
         [room],
       ),
-    ).toBe("1201: 1201 Foyer, 1201 Lounge");
+    ).toBe("1201: 1200L-6 Seminar Foyer, 1204 Seminar Lounge");
   });
 });

--- a/booking-app/tests/unit/resource-services.unit.test.ts
+++ b/booking-app/tests/unit/resource-services.unit.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import { getMediaCommonsServices } from "@/components/src/utils/tenantUtils";
 import {
   anyRoomHasVisibleService,
+  formatAnnexByRoomForDisplay,
+  getAnnexOptions,
   getRoomsWithVisibleService,
 } from "@/components/src/utils/resourceServicesUtils";
 import {
@@ -158,6 +160,7 @@ describe("applyMcResourceServices", () => {
     expect(missing.services?.setup?.mode).toBe("radio");
     expect(missing.services?.setup?.defaultValue).toBe("202_LAYOUT_0");
     expect(missing.services?.annex?.options?.length).toBe(2);
+    expect(missing.services?.annex?.mode).toBe("checkbox");
 
     const emptyArray = applyMcResourceServices({
       resourceId: "202",
@@ -166,6 +169,26 @@ describe("applyMcResourceServices", () => {
       services: [],
     });
     expect(emptyArray.services?.setup?.mode).toBe("radio");
+  });
+
+  it("includes 1201 breakout, foyer, and lounge annex options", () => {
+    const room = applyMcResourceServices({
+      resourceId: "1201",
+      name: "Seminar Room",
+      capacity: 100,
+      services: [],
+    });
+    expect(room.services?.annex?.mode).toBe("checkbox");
+    expect(room.services?.annex?.options?.map((o) => o.value)).toEqual([
+      "1201-breakout",
+      "1201-foyer",
+      "1201-lounge",
+    ]);
+    expect(room.services?.annex?.options?.map((o) => o.label)).toEqual([
+      "1201 Break-out Space",
+      "1201 Foyer",
+      "1201 Lounge",
+    ]);
   });
 
   it("replaces legacy services arrays with MC room defaults", () => {
@@ -377,5 +400,23 @@ describe("migrateResourceServices", () => {
       "Please describe the layout in detail.",
     );
     expect(result.setup?.options?.[0].required).toBe(false);
+  });
+});
+
+describe("formatAnnexByRoomForDisplay", () => {
+  it("resolves option labels from parent room annex config", () => {
+    const room = applyMcResourceServices({
+      resourceId: "1201",
+      name: "Seminar Room",
+      capacity: 100,
+      services: [],
+    });
+    expect(getAnnexOptions(room).length).toBe(3);
+    expect(
+      formatAnnexByRoomForDisplay(
+        { "1201": ["1201-foyer", "1201-lounge"] },
+        [room],
+      ),
+    ).toBe("1201: 1201 Foyer, 1201 Lounge");
   });
 });


### PR DESCRIPTION
## Summary
- Add schema-driven auxiliary spaces (defined on `services.annex`) and show them as indented children under selected parent rooms for faculty/staff only.
- Persist `annexByRoom` on bookings and surface selections in Google Calendar event descriptions and the More Info modal.
- Include 1201 break-out / foyer / lounge annex options; existing 103/202 green-room annex options use the same UI.

Closes #1216
Related to #1408

## Test plan
- [x] As faculty/staff, select 1201 and confirm break-out / foyer / lounge appear indented underneath
- [x] As a student, select 1201 and confirm auxiliary options are hidden
- [x] Select 103 / 202 and confirm Garage Green Room / Lecture Green Room / Student Lounge appear when eligible
- [x] Deselect a parent room and confirm its aux selections clear
- [x] Submit a booking with aux spaces and verify they appear in the calendar event description and More Info modal
- [x] Run unit tests: `npm run test:unit -- tests/unit/SelectRooms.annex.unit.test.tsx tests/unit/resource-services.unit.test.ts tests/unit/calendar-description.unit.test.ts`


Made with [Cursor](https://cursor.com)

<img width="1531" height="871" alt="image" src="https://github.com/user-attachments/assets/0fa3d2e0-02ae-48f8-bb29-8d02ab369c76" />

<img width="586" height="209" alt="image" src="https://github.com/user-attachments/assets/8ec024cf-a08f-4ee7-bdf5-02ecabb8a78f" />
