### PR TITLE
Fix deploy build type error on resource services reduce

### DIFF
--- a/booking-app/components/src/client/routes/admin/components/ResourceSpecific.tsx
+++ b/booking-app/components/src/client/routes/admin/components/ResourceSpecific.tsx
@@ -22,6 +22,7 @@ import ListTable from "../../components/ListTable";
 import { useTenantSchema } from "../../components/SchemaProvider";
 import { formatDate } from "../../../utils/date";
 import { TableNames } from "../../../../policy";
+import { isLegacyServicesArray } from "../../../../utils/resourceServicesUtils";
 
 type ResourceApproverRow = {
   id: string;
@@ -400,7 +401,13 @@ export const ResourceSpecific = () => {
     const result = new Map<string, Array<{ key: string; label: string }>>();
     resources.forEach((resource) => {
       const seen = new Set<string>();
-      const options = (resource.services ?? []).reduce<
+      // `services` may be a legacy string[] or the consolidated config object.
+      // Both describe the same set of services, so reduce over the service
+      // names (config keys) in either shape.
+      const serviceNames = isLegacyServicesArray(resource.services)
+        ? resource.services
+        : Object.keys(resource.services ?? {});
+      const options = serviceNames.reduce<
         Array<{ key: string; label: string }>
       >((acc, service) => {
         const key = normalizeServiceKey(service);


### PR DESCRIPTION
## Summary of Changes

The `Deploy DEVELOPMENT to App Engine` build was failing at the `tsc` step with:

```
components/src/client/routes/admin/components/ResourceSpecific.tsx:403
Type error: Property 'reduce' does not exist on type 'string[] | ResourceServicesConfig'.
```

`resource.services` is typed as `string[] | ResourceServicesConfig`. The service-approver options builder called `.reduce()` directly, which is only valid on the `string[]` arm — `ResourceServicesConfig` is an object and has no `reduce`, so the union call fails type-checking.

This is a latent incompatibility between two already-merged changes (the services config union type from the MC form services refactor, and the per-resource service approvers UI that reduces over `resource.services`). It was surfaced by the next deploy build, not caused by the PR that triggered that build.

Fix: normalize both shapes with the existing `isLegacyServicesArray` guard before reducing — use the array as-is, otherwise take the config object's keys as the service names. Both shapes describe the same set of services, and the downstream `SERVICE_LABELS` filter still drops non-approver services (`annex`, `furnishings`, `auxiliarySpace`).

## Schema Changes

- [x] No tenant schema changes
- [ ] Schema changed (describe below)

## Checklist

- [ ] I linked relevant issue(s) in the Development section
- [x] I checked for existing implementations and confirmed there is no duplication
- [x] I thoroughly tested this feature locally
- [ ] I added or updated unit tests (or explained why not in the PR description)
- [ ] I attached screenshots or a video demonstrating the feature (or explained why not in the PR description)
- [ ] I incorporated Copilot's feedback (or explained why not in the PR description), and marked conversations as resolved
- [x] I confirmed my PR passed all unit and end-to-end (E2E) tests
- [x] I confirmed there are no conflicts
- [ ] I requested a code review from at least one other teammate
